### PR TITLE
chore: switch to Swatinem/rust-cache for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
@@ -26,23 +26,8 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
 
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
 
       - name: Run tests
         run: cargo test --workspace --all-features


### PR DESCRIPTION
## Changes
Replaced manual cargo cache steps with `Swatinem/rust-cache@v2`.

## Benefits
- **Simpler Configuration**: Single step instead of three separate cache steps
- **Automatic Cache Key Management**: Handles cache keys intelligently based on Cargo.lock and toolchain
- **Better Cache Hit Rates**: Optimized for Rust/Cargo workflows
- **Intelligent Cleanup**: Automatically removes old cache entries to stay within GitHub's cache limits
- **Reduced Maintenance**: Action handles caching best practices automatically

## What Changed
- Removed manual `actions/cache@v4` steps for cargo registry, index, and build target
- Added single `Swatinem/rust-cache@v2` step that handles all Rust caching

This is a standard improvement recommended in the Rust ecosystem for GitHub Actions workflows.