### PR TITLE
chore: update metrics-util to v0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ futures = { workspace = true }
 
 [dev-dependencies]
 metrics = { workspace = true }
-metrics-util = { version = "0.18", default-features = false, features = ["debugging"] }
+metrics-util = { version = "0.20", default-features = false, features = ["debugging"] }
 
 [workspace]
 resolver = "2"

--- a/crates/tower-circuitbreaker/Cargo.toml
+++ b/crates/tower-circuitbreaker/Cargo.toml
@@ -20,7 +20,7 @@ tower-resilience-core.workspace = true
 
 tracing = { workspace = true, optional = true }
 metrics = { workspace = true, optional = true }
-metrics-util = { version = "0.19", optional = true }
+metrics-util = { version = "0.20", optional = true }
 
 [features]
 default = []


### PR DESCRIPTION
## Changes
Update `metrics-util` dependency to the latest version v0.20.

## Updated Files
- Root `Cargo.toml`: v0.18 → v0.20
- `tower-circuitbreaker/Cargo.toml`: v0.19 → v0.20

## Testing
- All tests pass
- Clippy passes with `-D warnings`