### PR TITLE
chore: enable semver_check in release-plz config

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -3,6 +3,8 @@
 changelog_update = true
 git_release_enable = true
 git_tag_enable = true
+# Validate semantic versioning
+semver_check = true
 
 # Generate separate changelogs for each crate
 [[package]]


### PR DESCRIPTION
Add `semver_check = true` to release-plz configuration.

This enables semantic versioning validation to automatically catch breaking changes and ensure proper version bumps according to semver rules.