### PR TITLE
feat: update meta-crate with all resilience patterns

### DIFF
--- a/crates/tower-resilience/Cargo.toml
+++ b/crates/tower-resilience/Cargo.toml
@@ -17,14 +17,20 @@ tower-resilience-core = { version = "0.1.0", path = "../tower-resilience-core" }
 # Optional pattern dependencies
 tower-circuitbreaker = { version = "0.1.0", path = "../tower-circuitbreaker", optional = true }
 tower-bulkhead = { version = "0.1.0", path = "../tower-bulkhead", optional = true }
+tower-timelimiter = { version = "0.1.0", path = "../tower-timelimiter", optional = true }
+tower-cache = { version = "0.1.0", path = "../tower-cache", optional = true }
+tower-retry-plus = { version = "0.1.0", path = "../tower-retry-plus", optional = true }
 
 [features]
 default = []
 # Individual patterns
 circuitbreaker = ["dep:tower-circuitbreaker"]
 bulkhead = ["dep:tower-bulkhead"]
+timelimiter = ["dep:tower-timelimiter"]
+cache = ["dep:tower-cache"]
+retry = ["dep:tower-retry-plus"]
 # Enable all patterns
-full = ["circuitbreaker", "bulkhead"]
+full = ["circuitbreaker", "bulkhead", "timelimiter", "cache", "retry"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
@@ -33,3 +39,7 @@ tower = { version = "0.5", features = ["util"] }
 [[example]]
 name = "combined"
 required-features = ["circuitbreaker", "bulkhead"]
+
+[[example]]
+name = "full_stack"
+required-features = ["full"]

--- a/crates/tower-resilience/examples/full_stack.rs
+++ b/crates/tower-resilience/examples/full_stack.rs
@@ -1,0 +1,244 @@
+//! Example demonstrating multiple resilience patterns.
+//!
+//! This example shows each resilience patternspattern withworking separate servicesindependently:
+//! - Circuit breaker + Bulkhead (from existing example)
+//! - Retry with exponential backoff
+//! - Timeout for slow calls
+//! - Response caching
+//!
+//! Note: Composing all patterns in a single stack requires unified error handling.
+//! See the individual pattern examples for detailed usage.
+
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+use std::time::Duration;
+use tokio::time::sleep;
+use tower::{Layer, Service, ServiceBuilder};
+use tower_resilience::{
+    bulkhead::BulkheadConfig,
+    cache::CacheConfig,
+    circuitbreaker::CircuitBreakerConfig,
+    retry::{ExponentialBackoff, RetryConfig},
+    timelimiter::TimeLimiterConfig,
+};
+
+#[derive(Debug, Clone)]
+struct ServiceError;
+
+impl std::fmt::Display for ServiceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Service error")
+    }
+}
+
+impl std::error::Error for ServiceError {}
+
+impl From<tower_resilience::bulkhead::BulkheadError> for ServiceError {
+    fn from(_: tower_resilience::bulkhead::BulkheadError) -> Self {
+        ServiceError
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    println!("Tower Resilience - Pattern Showcase");
+    println!("====================================\n");
+
+    // Demo 1: Circuit Breaker + Bulkhead
+    demo_circuit_breaker_and_bulkhead().await;
+
+    // Demo 2: Retry with Exponential Backoff
+    demo_retry().await;
+
+    // Demo 3: Timeout
+    demo_timeout().await;
+
+    // Demo 4: Cache
+    demo_cache().await;
+
+    println!("\n=== All Patterns Demonstrated ===");
+}
+
+async fn demo_circuit_breaker_and_bulkhead() {
+    println!("--- Demo 1: Circuit Breaker + Bulkhead ---");
+
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let cc = Arc::clone(&call_count);
+
+    let service = tower::service_fn(move |_req: ()| {
+        let cc = Arc::clone(&cc);
+        async move {
+            let count = cc.fetch_add(1, Ordering::SeqCst) + 1;
+            if count % 3 == 0 {
+                Ok(())
+            } else {
+                Err(ServiceError)
+            }
+        }
+    });
+
+    let bulkhead = BulkheadConfig::builder().max_concurrent_calls(5).build();
+
+    let service = ServiceBuilder::new().layer(bulkhead).service(service);
+
+    let cb_config = CircuitBreakerConfig::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(10)
+        .build();
+
+    let mut service = cb_config.layer(service);
+
+    for i in 1..=15 {
+        match tower::ServiceExt::ready(&mut service)
+            .await
+            .unwrap()
+            .call(())
+            .await
+        {
+            Ok(()) => println!("  Request {}: Success", i),
+            Err(_) => println!("  Request {}: Failed", i),
+        }
+    }
+
+    println!(
+        "  Total service calls: {}\n",
+        call_count.load(Ordering::SeqCst)
+    );
+}
+
+async fn demo_retry() {
+    println!("--- Demo 2: Retry with Exponential Backoff ---");
+
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let cc = Arc::clone(&call_count);
+
+    let service = tower::service_fn(move |req: String| {
+        let cc = Arc::clone(&cc);
+        async move {
+            let count = cc.fetch_add(1, Ordering::SeqCst) + 1;
+            println!("  [Service] Attempt {}", count);
+            if count < 3 {
+                Err(ServiceError)
+            } else {
+                Ok(format!("Success after {} attempts: {}", count, req))
+            }
+        }
+    });
+
+    let retry_config: RetryConfig<ServiceError> = RetryConfig::builder()
+        .max_attempts(5)
+        .backoff(ExponentialBackoff::new(Duration::from_millis(50)))
+        .on_retry(|attempt, delay| {
+            println!("  [Retry] Attempt {} after {:?}", attempt, delay);
+        })
+        .build();
+
+    let retry_layer = retry_config.layer();
+    let mut service = retry_layer.layer(service);
+
+    match tower::ServiceExt::ready(&mut service)
+        .await
+        .unwrap()
+        .call("test".to_string())
+        .await
+    {
+        Ok(resp) => println!("  Result: {}\n", resp),
+        Err(_) => println!("  Result: Failed after retries\n"),
+    }
+}
+
+async fn demo_timeout() {
+    println!("--- Demo 3: Timeout ---");
+
+    let service = tower::service_fn(|duration: Duration| async move {
+        println!("  [Service] Sleeping for {:?}", duration);
+        sleep(duration).await;
+        Ok::<_, ServiceError>("Completed")
+    });
+
+    let timeout_config = TimeLimiterConfig::builder()
+        .timeout_duration(Duration::from_millis(100))
+        .on_timeout(|| println!("  [Timeout] Request timed out!"))
+        .on_success(|duration| println!("  [Success] Completed in {:?}", duration))
+        .build();
+
+    let timeout_layer = timeout_config.layer();
+    let mut service = timeout_layer.layer(service);
+
+    // Fast request
+    println!("  Fast request (50ms):");
+    let _ = tower::ServiceExt::ready(&mut service)
+        .await
+        .unwrap()
+        .call(Duration::from_millis(50))
+        .await;
+
+    // Slow request
+    println!("  Slow request (200ms):");
+    let _ = tower::ServiceExt::ready(&mut service)
+        .await
+        .unwrap()
+        .call(Duration::from_millis(200))
+        .await;
+
+    println!();
+}
+
+async fn demo_cache() {
+    println!("--- Demo 4: Cache ---");
+
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let cc = Arc::clone(&call_count);
+
+    let service = tower::service_fn(move |req: String| {
+        let cc = Arc::clone(&cc);
+        async move {
+            let count = cc.fetch_add(1, Ordering::SeqCst) + 1;
+            println!("  [Service] Processing '{}' (call #{})", req, count);
+            sleep(Duration::from_millis(100)).await;
+            Ok::<_, ServiceError>(format!("Response to {}", req))
+        }
+    });
+
+    let cache_config: CacheConfig<String, String> = CacheConfig::builder()
+        .max_size(10)
+        .ttl(Duration::from_secs(5))
+        .key_extractor(|req: &String| req.clone())
+        .on_hit(|| println!("  [Cache] Hit!"))
+        .on_miss(|| println!("  [Cache] Miss"))
+        .build();
+
+    let cache_layer = cache_config.layer();
+    let mut service = cache_layer.layer(service);
+
+    // First request - cache miss
+    println!("  Request 'test1' (first time):");
+    let _ = tower::ServiceExt::ready(&mut service)
+        .await
+        .unwrap()
+        .call("test1".to_string())
+        .await;
+
+    // Second request - cache hit
+    println!("  Request 'test1' (cached):");
+    let _ = tower::ServiceExt::ready(&mut service)
+        .await
+        .unwrap()
+        .call("test1".to_string())
+        .await;
+
+    // Different request
+    println!("  Request 'test2' (first time):");
+    let _ = tower::ServiceExt::ready(&mut service)
+        .await
+        .unwrap()
+        .call("test2".to_string())
+        .await;
+
+    println!(
+        "  Total service calls: {}\n",
+        call_count.load(Ordering::SeqCst)
+    );
+}

--- a/crates/tower-resilience/src/lib.rs
+++ b/crates/tower-resilience/src/lib.rs
@@ -9,6 +9,9 @@
 //! - **Circuit Breaker** (`circuitbreaker` feature): Prevents cascading failures by
 //!   temporarily blocking calls to failing services
 //! - **Bulkhead** (`bulkhead` feature): Isolates resources by limiting concurrent calls
+//! - **Time Limiter** (`timelimiter` feature): Advanced timeout handling with event system
+//! - **Cache** (`cache` feature): Response memoization with LRU eviction and TTL
+//! - **Retry** (`retry` feature): Enhanced retry with flexible backoff strategies
 //!
 //! # Usage
 //!
@@ -62,6 +65,9 @@
 //!
 //! - `tower-circuitbreaker`
 //! - `tower-bulkhead`
+//! - `tower-timelimiter`
+//! - `tower-cache`
+//! - `tower-retry-plus`
 //! - `tower-resilience-core` (shared infrastructure)
 
 // Re-export core (always available)
@@ -73,3 +79,12 @@ pub use tower_circuitbreaker as circuitbreaker;
 
 #[cfg(feature = "bulkhead")]
 pub use tower_bulkhead as bulkhead;
+
+#[cfg(feature = "timelimiter")]
+pub use tower_timelimiter as timelimiter;
+
+#[cfg(feature = "cache")]
+pub use tower_cache as cache;
+
+#[cfg(feature = "retry")]
+pub use tower_retry_plus as retry;


### PR DESCRIPTION
Updates the  meta-crate to include all implemented resilience patterns (#10).

## Changes

### Dependencies & Features
- Added , , and  as optional dependencies
- Added individual features: , , 
- Updated  feature to include all patterns

### Documentation
- Updated lib.rs documentation to list all 5 patterns
- Added all standalone crates to the documentation

### Re-exports
- Re-export , , and  modules based on features
- Maintains backward compatibility with existing  and  features

### Examples
- Added  example demonstrating all patterns:
  - Circuit breaker + Bulkhead composition
  - Retry with exponential backoff
  - Timeout handling
  - Response caching
- Requires  to run

## Usage

Users can now enable specific patterns:
```toml
[dependencies]
tower-resilience = { version = "0.1", features = ["retry", "cache"] }
```

Or enable everything:
```toml
[dependencies]
tower-resilience = { version = "0.1", features = ["full"] }
```

## Testing
- `cargo build -p tower-resilience --all-features` - builds successfully
- `cargo test -p tower-resilience --all-features` - all tests pass
- `cargo run --example full_stack -p tower-resilience --all-features` - example works

Closes #10