### PR TITLE
test: add P1 and P2 comprehensive circuit breaker tests

### DIFF
--- a/tests/circuitbreaker_combinations.rs
+++ b/tests/circuitbreaker_combinations.rs
@@ -1,0 +1,360 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+use std::time::Duration;
+use tokio::time::sleep;
+use tower::Service;
+use tower_circuitbreaker::{CircuitBreakerConfig, CircuitState, SlidingWindowType};
+
+/// Test time-based window + slow call detection + failure classification
+#[tokio::test]
+async fn time_based_slow_call_failure_classification() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&call_count);
+
+    // Mix of fast failures, slow failures, fast successes, slow successes
+    let service = tower::service_fn(move |_req: ()| {
+        let count = c.fetch_add(1, Ordering::Relaxed);
+        async move {
+            match count {
+                0..=2 => {
+                    // Fast failures (30%)
+                    sleep(Duration::from_millis(50)).await;
+                    Err::<(), _>("fast_error")
+                }
+                3..=5 => {
+                    // Slow failures (30%)
+                    sleep(Duration::from_millis(150)).await;
+                    Err("slow_error")
+                }
+                6..=7 => {
+                    // Fast successes (20%)
+                    sleep(Duration::from_millis(50)).await;
+                    Ok(())
+                }
+                _ => {
+                    // Slow successes (20%)
+                    sleep(Duration::from_millis(150)).await;
+                    Ok(())
+                }
+            }
+        }
+    });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .sliding_window_type(SlidingWindowType::TimeBased)
+        .sliding_window_duration(Duration::from_secs(5))
+        .failure_rate_threshold(0.7) // 60% failure rate < 70%
+        .slow_call_duration_threshold(Duration::from_millis(100))
+        .slow_call_rate_threshold(0.6) // 50% slow rate < 60%
+        .minimum_number_of_calls(10)
+        .wait_duration_in_open(Duration::from_millis(100))
+        .name("combination-test")
+        .build();
+
+    let mut cb = layer.layer(service);
+
+    for _ in 0..10 {
+        let _ = cb.call(()).await;
+    }
+
+    // 6 failures (60%) < 70%, 5 slow (50%) < 60%
+    // Both below thresholds, should stay closed
+    assert_eq!(cb.state().await, CircuitState::Closed);
+}
+
+/// Test count-based + slow call rate + failure rate (both thresholds)
+#[tokio::test]
+async fn count_based_dual_thresholds() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&call_count);
+
+    // All slow, half fail
+    let service = tower::service_fn(move |_req: ()| {
+        let count = c.fetch_add(1, Ordering::Relaxed);
+        async move {
+            sleep(Duration::from_millis(150)).await;
+            if count < 5 {
+                Err::<(), _>("error")
+            } else {
+                Ok(())
+            }
+        }
+    });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .sliding_window_type(SlidingWindowType::CountBased)
+        .sliding_window_size(10)
+        .failure_rate_threshold(0.6) // 50% < 60%, won't trip
+        .slow_call_duration_threshold(Duration::from_millis(100))
+        .slow_call_rate_threshold(0.9) // 100% >= 90%, will trip
+        .minimum_number_of_calls(10)
+        .wait_duration_in_open(Duration::from_millis(100))
+        .name("dual-threshold")
+        .build();
+
+    let mut cb = layer.layer(service);
+
+    for _ in 0..10 {
+        let _ = cb.call(()).await;
+    }
+
+    // Slow call rate trips it
+    assert_eq!(cb.state().await, CircuitState::Open);
+}
+
+/// Test custom failure classifier + slow call detection
+#[tokio::test]
+async fn custom_classifier_with_slow_calls() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&call_count);
+
+    let service = tower::service_fn(move |_req: ()| {
+        let count = c.fetch_add(1, Ordering::Relaxed);
+        async move {
+            sleep(Duration::from_millis(if count < 5 { 150 } else { 50 })).await;
+
+            if count < 3 {
+                Err::<(), _>("retryable_error")
+            } else if count < 6 {
+                Err("fatal_error")
+            } else {
+                Ok(())
+            }
+        }
+    });
+
+    // Only count "fatal_error" as failures
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .sliding_window_size(10)
+        .failure_rate_threshold(0.5)
+        .slow_call_duration_threshold(Duration::from_millis(100))
+        .slow_call_rate_threshold(0.6)
+        .minimum_number_of_calls(10)
+        .wait_duration_in_open(Duration::from_millis(100))
+        .failure_classifier(|result: &Result<(), &str>| {
+            result
+                .as_ref()
+                .err()
+                .map(|e| *e == "fatal_error")
+                .unwrap_or(false)
+        })
+        .name("custom-classifier")
+        .build();
+
+    let mut cb = layer.layer(service);
+
+    for _ in 0..10 {
+        let _ = cb.call(()).await;
+    }
+
+    // Only 3 "fatal" failures (30%) < 50%
+    // But 5 slow calls (50%) < 60%
+    // Should stay closed
+    assert_eq!(cb.state().await, CircuitState::Closed);
+}
+
+/// Test event listeners + all configuration permutations
+#[tokio::test]
+async fn event_listeners_with_complex_config() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let permitted = Arc::new(AtomicUsize::new(0));
+    let rejected = Arc::new(AtomicUsize::new(0));
+    let transitions = Arc::new(AtomicUsize::new(0));
+    let slow_calls = Arc::new(AtomicUsize::new(0));
+
+    let c = Arc::clone(&call_count);
+    let p = Arc::clone(&permitted);
+    let r = Arc::clone(&rejected);
+    let t = Arc::clone(&transitions);
+    let s = Arc::clone(&slow_calls);
+
+    let service = tower::service_fn(move |_req: ()| {
+        let count = c.fetch_add(1, Ordering::Relaxed);
+        async move {
+            sleep(Duration::from_millis(if count < 5 { 150 } else { 50 })).await;
+            if count < 5 {
+                Err::<(), _>("error")
+            } else {
+                Ok(())
+            }
+        }
+    });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .sliding_window_type(SlidingWindowType::TimeBased)
+        .sliding_window_duration(Duration::from_secs(10))
+        .failure_rate_threshold(0.5)
+        .slow_call_duration_threshold(Duration::from_millis(100))
+        .slow_call_rate_threshold(0.5)
+        .minimum_number_of_calls(5)
+        .wait_duration_in_open(Duration::from_millis(50))
+        .permitted_calls_in_half_open(2)
+        .name("event-test")
+        .on_call_permitted(move |_state| {
+            p.fetch_add(1, Ordering::Relaxed);
+        })
+        .on_call_rejected(move || {
+            r.fetch_add(1, Ordering::Relaxed);
+        })
+        .on_state_transition(move |_from, _to| {
+            t.fetch_add(1, Ordering::Relaxed);
+        })
+        .on_slow_call(move |_duration| {
+            s.fetch_add(1, Ordering::Relaxed);
+        })
+        .build();
+
+    let mut cb = layer.layer(service);
+
+    // Make calls that will trip circuit
+    for _ in 0..10 {
+        let _ = cb.call(()).await;
+    }
+
+    // Verify events were emitted
+    assert!(
+        permitted.load(Ordering::Relaxed) > 0,
+        "Should have permitted calls"
+    );
+    assert!(
+        slow_calls.load(Ordering::Relaxed) > 0,
+        "Should have detected slow calls"
+    );
+    assert!(
+        transitions.load(Ordering::Relaxed) > 0,
+        "Should have state transitions"
+    );
+}
+
+/// Test manual state control during active failure scenarios
+#[tokio::test]
+async fn manual_override_during_failures() {
+    let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(10)
+        .minimum_number_of_calls(5)
+        .wait_duration_in_open(Duration::from_millis(100))
+        .name("manual-override")
+        .build();
+
+    let mut cb = layer.layer(service);
+
+    // Cause failures
+    for _ in 0..10 {
+        let _ = cb.call(()).await;
+    }
+    assert_eq!(cb.state().await, CircuitState::Open);
+
+    // Force closed despite failures
+    cb.force_closed().await;
+    assert_eq!(cb.state().await, CircuitState::Closed);
+
+    // Make more failures (10 to definitely trip it since counters were reset)
+    for _ in 0..10 {
+        let _ = cb.call(()).await;
+    }
+
+    // Should open again due to continued failures (10 failures = 100% >= 50%)
+    assert_eq!(cb.state().await, CircuitState::Open);
+
+    // Force closed again
+    cb.force_closed().await;
+    assert_eq!(cb.state().await, CircuitState::Closed);
+}
+
+/// Test custom classifier with different error types
+#[tokio::test]
+async fn custom_classifier_transient_errors() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&call_count);
+
+    let service = tower::service_fn(move |_req: ()| {
+        let count = c.fetch_add(1, Ordering::Relaxed);
+        async move {
+            if count < 8 {
+                Err::<String, _>("transient_error")
+            } else {
+                Ok("success".to_string())
+            }
+        }
+    });
+
+    // Only "transient_error" counts as failure
+    let layer = CircuitBreakerConfig::<String, &str>::builder()
+        .sliding_window_size(10)
+        .failure_rate_threshold(0.7)
+        .minimum_number_of_calls(5)
+        .wait_duration_in_open(Duration::from_millis(50))
+        .failure_classifier(|result: &Result<String, &str>| {
+            result
+                .as_ref()
+                .err()
+                .map(|e| *e == "transient_error")
+                .unwrap_or(false)
+        })
+        .name("transient-classifier")
+        .build();
+
+    let mut cb = layer.layer(service);
+
+    // Make calls - 8 transient errors (80%) >= 70%, should open
+    for _ in 0..10 {
+        let _ = cb.call(()).await;
+    }
+
+    assert_eq!(cb.state().await, CircuitState::Open);
+}
+
+/// Test time-based with all features enabled
+#[tokio::test]
+async fn time_based_kitchen_sink() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&call_count);
+
+    let service = tower::service_fn(move |_req: ()| {
+        let count = c.fetch_add(1, Ordering::Relaxed);
+        async move {
+            // Varying durations and results
+            let duration = match count % 4 {
+                0 => 50,  // Fast
+                1 => 150, // Slow
+                2 => 50,  // Fast
+                _ => 150, // Slow
+            };
+            sleep(Duration::from_millis(duration)).await;
+
+            if count < 6 {
+                Err::<(), _>("error")
+            } else {
+                Ok(())
+            }
+        }
+    });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .sliding_window_type(SlidingWindowType::TimeBased)
+        .sliding_window_duration(Duration::from_secs(10))
+        .failure_rate_threshold(0.7)
+        .slow_call_duration_threshold(Duration::from_millis(100))
+        .slow_call_rate_threshold(0.6)
+        .minimum_number_of_calls(10)
+        .wait_duration_in_open(Duration::from_millis(100))
+        .permitted_calls_in_half_open(3)
+        .failure_classifier(|result: &Result<(), &str>| result.is_err())
+        .name("kitchen-sink")
+        .build();
+
+    let mut cb = layer.layer(service);
+
+    for _ in 0..10 {
+        let _ = cb.call(()).await;
+    }
+
+    // 6 failures (60%) < 70%, 5 slow (50%) < 60%
+    // Should stay closed
+    assert_eq!(cb.state().await, CircuitState::Closed);
+}

--- a/tests/circuitbreaker_edge_cases.rs
+++ b/tests/circuitbreaker_edge_cases.rs
@@ -1,0 +1,364 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+use std::time::Duration;
+use tokio::time::sleep;
+use tower::Service;
+use tower_circuitbreaker::{CircuitBreakerConfig, CircuitState};
+
+/// Test multiple event listeners on same event type
+#[tokio::test]
+async fn multiple_event_listeners() {
+    let counter1 = Arc::new(AtomicUsize::new(0));
+    let counter2 = Arc::new(AtomicUsize::new(0));
+    let counter3 = Arc::new(AtomicUsize::new(0));
+
+    let c1 = Arc::clone(&counter1);
+    let c2 = Arc::clone(&counter2);
+    let c3 = Arc::clone(&counter3);
+
+    let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(5)
+        .minimum_number_of_calls(5)
+        .wait_duration_in_open(Duration::from_millis(50))
+        .on_state_transition(move |_from, _to| {
+            c1.fetch_add(1, Ordering::Relaxed);
+        })
+        .on_state_transition(move |_from, _to| {
+            c2.fetch_add(1, Ordering::Relaxed);
+        })
+        .on_state_transition(move |_from, _to| {
+            c3.fetch_add(1, Ordering::Relaxed);
+        })
+        .build();
+
+    let mut cb = layer.layer(service);
+
+    // Trip circuit
+    for _ in 0..5 {
+        let _ = cb.call(()).await;
+    }
+
+    // All three listeners should have been called
+    assert_eq!(
+        counter1.load(Ordering::Relaxed),
+        1,
+        "Listener 1 should be called once"
+    );
+    assert_eq!(
+        counter2.load(Ordering::Relaxed),
+        1,
+        "Listener 2 should be called once"
+    );
+    assert_eq!(
+        counter3.load(Ordering::Relaxed),
+        1,
+        "Listener 3 should be called once"
+    );
+}
+
+/// Test failure classifier that classifies all results as success
+#[tokio::test]
+async fn failure_classifier_all_success() {
+    let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
+
+    // Classifier that treats all results as success (even errors)
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(10)
+        .minimum_number_of_calls(5)
+        .failure_classifier(|_result: &Result<(), &str>| false) // Nothing is a failure
+        .build();
+
+    let mut cb = layer.layer(service);
+
+    // Make 10 error calls
+    for _ in 0..10 {
+        let _ = cb.call(()).await;
+    }
+
+    // Circuit should stay closed (0% failure rate)
+    assert_eq!(cb.state().await, CircuitState::Closed);
+}
+
+/// Test failure classifier that classifies all results as failure
+#[tokio::test]
+async fn failure_classifier_all_failure() {
+    let service = tower::service_fn(|_req: ()| async { Ok::<(), &str>(()) });
+
+    // Classifier that treats all results as failure (even successes)
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(10)
+        .minimum_number_of_calls(5)
+        .failure_classifier(|_result: &Result<(), &str>| true) // Everything is a failure
+        .build();
+
+    let mut cb = layer.layer(service);
+
+    // Make 10 success calls
+    for _ in 0..10 {
+        let _ = cb.call(()).await;
+    }
+
+    // Circuit should open (100% failure rate)
+    assert_eq!(cb.state().await, CircuitState::Open);
+}
+
+/// Test slow call detection with exactly threshold duration
+#[tokio::test]
+async fn slow_call_exactly_at_threshold() {
+    let service = tower::service_fn(|_req: ()| async {
+        sleep(Duration::from_millis(100)).await;
+        Ok::<(), &str>(())
+    });
+
+    let slow_call_count = Arc::new(AtomicUsize::new(0));
+    let sc = Arc::clone(&slow_call_count);
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .slow_call_duration_threshold(Duration::from_millis(100))
+        .slow_call_rate_threshold(0.5)
+        .sliding_window_size(10)
+        .minimum_number_of_calls(10)
+        .on_slow_call(move |_duration| {
+            sc.fetch_add(1, Ordering::Relaxed);
+        })
+        .build();
+
+    let mut cb = layer.layer(service);
+
+    for _ in 0..10 {
+        let _ = cb.call(()).await;
+    }
+
+    // Calls at exactly 100ms should be considered slow (>=)
+    assert!(
+        slow_call_count.load(Ordering::Relaxed) > 0,
+        "Calls at exactly threshold should be detected as slow"
+    );
+}
+
+/// Test slow call detection with very fast calls
+#[tokio::test]
+async fn slow_call_very_fast_calls() {
+    let service = tower::service_fn(|_req: ()| async { Ok::<(), &str>(()) });
+
+    let slow_call_count = Arc::new(AtomicUsize::new(0));
+    let sc = Arc::clone(&slow_call_count);
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .slow_call_duration_threshold(Duration::from_secs(10))
+        .slow_call_rate_threshold(0.5)
+        .sliding_window_size(100)
+        .minimum_number_of_calls(100)
+        .on_slow_call(move |_duration| {
+            sc.fetch_add(1, Ordering::Relaxed);
+        })
+        .build();
+
+    let mut cb = layer.layer(service);
+
+    for _ in 0..100 {
+        let _ = cb.call(()).await;
+    }
+
+    // No calls should be detected as slow
+    assert_eq!(
+        slow_call_count.load(Ordering::Relaxed),
+        0,
+        "Fast calls should not be detected as slow"
+    );
+    assert_eq!(cb.state().await, CircuitState::Closed);
+}
+
+/// Test failure classifier with mixed error types
+#[tokio::test]
+async fn failure_classifier_mixed_error_types() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&call_count);
+
+    let service = tower::service_fn(move |_req: ()| {
+        let count = c.fetch_add(1, Ordering::Relaxed);
+        async move {
+            match count % 3 {
+                0 => Err::<(), _>("timeout"),
+                1 => Err("internal_error"),
+                _ => Err("rate_limited"),
+            }
+        }
+    });
+
+    // Only count "internal_error" as failures
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .failure_rate_threshold(0.4)
+        .sliding_window_size(12)
+        .minimum_number_of_calls(12)
+        .failure_classifier(|result: &Result<(), &str>| {
+            result
+                .as_ref()
+                .err()
+                .map(|e| *e == "internal_error")
+                .unwrap_or(false)
+        })
+        .build();
+
+    let mut cb = layer.layer(service);
+
+    for _ in 0..12 {
+        let _ = cb.call(()).await;
+    }
+
+    // 4 internal_errors out of 12 = 33.3% < 40%
+    assert_eq!(cb.state().await, CircuitState::Closed);
+}
+
+/// Test event listener with all event types
+#[tokio::test]
+async fn all_event_types_emitted() {
+    let permitted = Arc::new(AtomicUsize::new(0));
+    let rejected = Arc::new(AtomicUsize::new(0));
+    let success = Arc::new(AtomicUsize::new(0));
+    let failure = Arc::new(AtomicUsize::new(0));
+    let transition = Arc::new(AtomicUsize::new(0));
+
+    let p = Arc::clone(&permitted);
+    let r = Arc::clone(&rejected);
+    let s = Arc::clone(&success);
+    let f = Arc::clone(&failure);
+    let t = Arc::clone(&transition);
+
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&call_count);
+
+    let service = tower::service_fn(move |_req: ()| {
+        let count = c.fetch_add(1, Ordering::Relaxed);
+        async move {
+            if count < 5 {
+                Err::<(), _>("error")
+            } else {
+                Ok(())
+            }
+        }
+    });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(5)
+        .minimum_number_of_calls(5)
+        .wait_duration_in_open(Duration::from_millis(50))
+        .on_call_permitted(move |_state| {
+            p.fetch_add(1, Ordering::Relaxed);
+        })
+        .on_call_rejected(move || {
+            r.fetch_add(1, Ordering::Relaxed);
+        })
+        .on_success(move |_state| {
+            s.fetch_add(1, Ordering::Relaxed);
+        })
+        .on_failure(move |_state| {
+            f.fetch_add(1, Ordering::Relaxed);
+        })
+        .on_state_transition(move |_from, _to| {
+            t.fetch_add(1, Ordering::Relaxed);
+        })
+        .build();
+
+    let mut cb = layer.layer(service);
+
+    // Make 5 failing calls
+    for _ in 0..5 {
+        let _ = cb.call(()).await;
+    }
+
+    // Try one more call while open (should be rejected)
+    let _ = cb.call(()).await;
+
+    assert!(
+        permitted.load(Ordering::Relaxed) >= 5,
+        "Should have permitted calls"
+    );
+    assert_eq!(
+        rejected.load(Ordering::Relaxed),
+        1,
+        "Should have 1 rejected call"
+    );
+    assert_eq!(
+        success.load(Ordering::Relaxed),
+        0,
+        "Should have 0 successes"
+    );
+    assert_eq!(failure.load(Ordering::Relaxed), 5, "Should have 5 failures");
+    assert_eq!(
+        transition.load(Ordering::Relaxed),
+        1,
+        "Should have 1 transition (Closed -> Open)"
+    );
+}
+
+/// Test window size of 1
+#[tokio::test]
+async fn sliding_window_size_one() {
+    let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(1)
+        .minimum_number_of_calls(1)
+        .build();
+
+    let mut cb = layer.layer(service);
+
+    // Single failing call should trip it
+    let _ = cb.call(()).await;
+
+    assert_eq!(cb.state().await, CircuitState::Open);
+}
+
+/// Test permitted_calls_in_half_open = 1 (minimum)
+#[tokio::test]
+async fn half_open_one_permitted_call() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&call_count);
+
+    let service = tower::service_fn(move |_req: ()| {
+        let count = c.fetch_add(1, Ordering::Relaxed);
+        async move {
+            if count < 5 {
+                Err::<(), _>("error")
+            } else {
+                Ok(())
+            }
+        }
+    });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(5)
+        .minimum_number_of_calls(5)
+        .wait_duration_in_open(Duration::from_millis(50))
+        .permitted_calls_in_half_open(1)
+        .build();
+
+    let mut cb = layer.layer(service);
+
+    // Trip circuit
+    for _ in 0..5 {
+        let _ = cb.call(()).await;
+    }
+    assert_eq!(cb.state().await, CircuitState::Open);
+
+    // Wait for half-open
+    sleep(Duration::from_millis(60)).await;
+
+    // Make 1 successful call
+    let result = cb.call(()).await;
+    assert!(result.is_ok());
+
+    // Should transition to closed immediately
+    assert_eq!(cb.state().await, CircuitState::Closed);
+}

--- a/tests/circuitbreaker_half_open.rs
+++ b/tests/circuitbreaker_half_open.rs
@@ -1,0 +1,389 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+use std::time::Duration;
+use tokio::time::sleep;
+use tower::Service;
+use tower_circuitbreaker::{CircuitBreakerConfig, CircuitState};
+
+/// Test multiple concurrent calls in half-open state
+#[tokio::test]
+async fn concurrent_calls_in_half_open() {
+    let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(5)
+        .minimum_number_of_calls(3)
+        .wait_duration_in_open(Duration::from_millis(50))
+        .permitted_calls_in_half_open(3)
+        .name("concurrent-halfopen")
+        .build();
+
+    let mut cb = layer.layer(service);
+
+    // Trip circuit
+    for _ in 0..5 {
+        let _ = cb.call(()).await;
+    }
+    assert_eq!(cb.state().await, CircuitState::Open);
+
+    // Wait for half-open
+    sleep(Duration::from_millis(100)).await;
+
+    // Try concurrent calls - only permitted_calls should go through
+    let cb_mutex = Arc::new(tokio::sync::Mutex::new(cb));
+    let mut handles = vec![];
+
+    for _ in 0..10 {
+        let cb_clone = Arc::clone(&cb_mutex);
+        let handle = tokio::spawn(async move {
+            let mut breaker = cb_clone.lock().await;
+            breaker.call(()).await
+        });
+        handles.push(handle);
+    }
+
+    let mut results = vec![];
+    for handle in handles {
+        if let Ok(result) = handle.await {
+            results.push(result);
+        }
+    }
+
+    // Most should be rejected, only a few permitted in half-open
+    let errors = results.iter().filter(|r| r.is_err()).count();
+    assert!(
+        errors >= 7,
+        "Most concurrent calls should be rejected in half-open"
+    );
+}
+
+/// Test partial success in half-open (1 of 3 permitted calls succeeds)
+#[tokio::test]
+async fn partial_success_in_half_open() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&call_count);
+
+    let service = tower::service_fn(move |_req: ()| {
+        let count = c.fetch_add(1, Ordering::Relaxed);
+        async move {
+            // First call succeeds, rest fail
+            if count == 0 {
+                Ok::<(), _>(())
+            } else {
+                Err("error")
+            }
+        }
+    });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(5)
+        .minimum_number_of_calls(3)
+        .wait_duration_in_open(Duration::from_millis(50))
+        .permitted_calls_in_half_open(3)
+        .name("partial-success")
+        .build();
+
+    let mut cb = layer.layer(service);
+
+    // Trip circuit
+    for _ in 0..5 {
+        let _ = cb.call(()).await;
+    }
+    assert_eq!(cb.state().await, CircuitState::Open);
+
+    // Reset counter for half-open test
+    call_count.store(0, Ordering::Relaxed);
+
+    // Wait for half-open
+    sleep(Duration::from_millis(100)).await;
+
+    // Make 3 permitted calls (1 success, 2 failures)
+    let result1 = cb.call(()).await;
+    assert!(result1.is_ok(), "First call should succeed");
+
+    let result2 = cb.call(()).await;
+    assert!(result2.is_err(), "Second call should fail");
+
+    // After second failure in half-open, should reopen
+    assert_eq!(cb.state().await, CircuitState::Open);
+}
+
+/// Test all failures in half-open with different permitted counts
+#[tokio::test]
+async fn all_failures_in_half_open_various_permits() {
+    for permitted in [1, 2, 5, 10] {
+        let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
+
+        let layer = CircuitBreakerConfig::<(), &str>::builder()
+            .failure_rate_threshold(0.5)
+            .sliding_window_size(5)
+            .minimum_number_of_calls(3)
+            .wait_duration_in_open(Duration::from_millis(50))
+            .permitted_calls_in_half_open(permitted)
+            .name(format!("all-fail-{}", permitted))
+            .build();
+
+        let mut cb = layer.layer(service);
+
+        // Trip circuit
+        for _ in 0..5 {
+            let _ = cb.call(()).await;
+        }
+
+        // Wait for half-open
+        sleep(Duration::from_millis(100)).await;
+
+        // First call in half-open should fail and reopen
+        let _ = cb.call(()).await;
+        assert_eq!(
+            cb.state().await,
+            CircuitState::Open,
+            "Should reopen after failure in half-open (permitted={})",
+            permitted
+        );
+    }
+}
+
+/// Test rapid cycling: open→half-open→open→half-open
+#[tokio::test]
+async fn rapid_state_cycling() {
+    let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(5)
+        .minimum_number_of_calls(3)
+        .wait_duration_in_open(Duration::from_millis(50))
+        .permitted_calls_in_half_open(1)
+        .name("rapid-cycling")
+        .build();
+
+    let mut cb = layer.layer(service);
+
+    for cycle in 0..3 {
+        // Trip to open
+        for _ in 0..5 {
+            let _ = cb.call(()).await;
+        }
+        assert_eq!(
+            cb.state().await,
+            CircuitState::Open,
+            "Cycle {}: should be open",
+            cycle
+        );
+
+        // Wait for half-open
+        sleep(Duration::from_millis(100)).await;
+
+        // Fail in half-open, should reopen
+        let _ = cb.call(()).await;
+        assert_eq!(
+            cb.state().await,
+            CircuitState::Open,
+            "Cycle {}: should reopen after half-open failure",
+            cycle
+        );
+    }
+}
+
+/// Test half-open with time-based window
+#[tokio::test]
+async fn half_open_with_time_based_window() {
+    use tower_circuitbreaker::SlidingWindowType;
+
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&call_count);
+
+    let service = tower::service_fn(move |_req: ()| {
+        let count = c.fetch_add(1, Ordering::Relaxed);
+        async move {
+            // First 5 fail to trip circuit, then succeed
+            if count < 5 {
+                Err::<(), _>("error")
+            } else {
+                Ok(())
+            }
+        }
+    });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .sliding_window_type(SlidingWindowType::TimeBased)
+        .sliding_window_duration(Duration::from_secs(10))
+        .failure_rate_threshold(0.5)
+        .minimum_number_of_calls(5)
+        .wait_duration_in_open(Duration::from_millis(50))
+        .permitted_calls_in_half_open(3)
+        .name("halfopen-timebased")
+        .build();
+
+    let mut cb = layer.layer(service);
+
+    // Trip circuit (5 failures with 50% threshold and 5 minimum = 100% failure rate)
+    for _ in 0..5 {
+        let _ = cb.call(()).await;
+    }
+    assert_eq!(cb.state().await, CircuitState::Open);
+
+    // Wait for half-open (wait_duration is 50ms)
+    sleep(Duration::from_millis(60)).await;
+
+    // Make 3 successful calls (counts 5, 6, 7 should all succeed)
+    for i in 0..3 {
+        let result = cb.call(()).await;
+        assert!(result.is_ok(), "Should succeed in half-open (call {})", i);
+    }
+
+    // Should transition to closed after successes
+    assert_eq!(cb.state().await, CircuitState::Closed);
+}
+
+/// Test half-open with slow call detection active
+#[tokio::test]
+async fn half_open_with_slow_call_detection() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&call_count);
+
+    let service = tower::service_fn(move |_req: ()| {
+        let count = c.fetch_add(1, Ordering::Relaxed);
+        async move {
+            // All slow, first batch fails, second batch succeeds
+            sleep(Duration::from_millis(150)).await;
+            if count < 10 {
+                Err::<(), _>("error")
+            } else {
+                Ok(())
+            }
+        }
+    });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .failure_rate_threshold(0.5)
+        .slow_call_duration_threshold(Duration::from_millis(100))
+        .slow_call_rate_threshold(0.9)
+        .sliding_window_size(10)
+        .minimum_number_of_calls(5)
+        .wait_duration_in_open(Duration::from_millis(50))
+        .permitted_calls_in_half_open(5)
+        .name("halfopen-slow")
+        .build();
+
+    let mut cb = layer.layer(service);
+
+    // Trip circuit (all slow and failing)
+    for _ in 0..10 {
+        let _ = cb.call(()).await;
+    }
+    assert_eq!(cb.state().await, CircuitState::Open);
+
+    // Wait for half-open
+    sleep(Duration::from_millis(100)).await;
+
+    // Make successful (but still slow) calls
+    for _ in 0..5 {
+        let result = cb.call(()).await;
+        assert!(result.is_ok(), "Should succeed in half-open");
+    }
+
+    // Should close despite slow calls (successes)
+    assert_eq!(cb.state().await, CircuitState::Closed);
+}
+
+/// Test half-open state with minimum calls threshold
+#[tokio::test]
+async fn half_open_with_minimum_calls() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&call_count);
+
+    let service = tower::service_fn(move |_req: ()| {
+        let count = c.fetch_add(1, Ordering::Relaxed);
+        async move {
+            if count < 10 {
+                Err::<(), _>("error")
+            } else {
+                Ok(())
+            }
+        }
+    });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(10)
+        .minimum_number_of_calls(5)
+        .wait_duration_in_open(Duration::from_millis(50))
+        .permitted_calls_in_half_open(10) // More than minimum
+        .name("halfopen-minimum")
+        .build();
+
+    let mut cb = layer.layer(service);
+
+    // Trip circuit
+    for _ in 0..10 {
+        let _ = cb.call(()).await;
+    }
+    assert_eq!(cb.state().await, CircuitState::Open);
+
+    // Wait for half-open
+    sleep(Duration::from_millis(100)).await;
+
+    // Make all 10 permitted calls (all succeed)
+    for _ in 0..10 {
+        let _ = cb.call(()).await;
+    }
+
+    // Should transition to closed
+    assert_eq!(cb.state().await, CircuitState::Closed);
+}
+
+/// Test half-open rejected calls don't affect state
+#[tokio::test]
+async fn half_open_rejected_calls_no_effect() {
+    let service = tower::service_fn(|_req: ()| async { Ok::<(), String>(()) });
+
+    let layer = CircuitBreakerConfig::<(), String>::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(5)
+        .minimum_number_of_calls(3)
+        .wait_duration_in_open(Duration::from_millis(50))
+        .permitted_calls_in_half_open(2)
+        .name("halfopen-rejected")
+        .build();
+
+    let cb = layer.layer(service);
+
+    // Manually force open
+    cb.force_open().await;
+    assert_eq!(cb.state().await, CircuitState::Open);
+
+    // Wait for half-open
+    sleep(Duration::from_millis(100)).await;
+
+    // Make more calls than permitted
+    let cb_mutex = Arc::new(tokio::sync::Mutex::new(cb));
+
+    let mut handles = vec![];
+    for _ in 0..10 {
+        let cb_clone = Arc::clone(&cb_mutex);
+        handles.push(tokio::spawn(async move {
+            let mut breaker = cb_clone.lock().await;
+            breaker.call(()).await
+        }));
+    }
+
+    for handle in handles {
+        let _ = handle.await;
+    }
+
+    sleep(Duration::from_millis(50)).await;
+
+    // Rejected calls shouldn't prevent transition to closed
+    let breaker = cb_mutex.lock().await;
+    let state = breaker.state().await;
+    assert!(
+        state == CircuitState::Closed || state == CircuitState::HalfOpen,
+        "Should be closed or still half-open, not reopened"
+    );
+}

--- a/tests/circuitbreaker_reset.rs
+++ b/tests/circuitbreaker_reset.rs
@@ -1,0 +1,366 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+use std::time::Duration;
+use tower::Service;
+use tower_circuitbreaker::{CircuitBreakerConfig, CircuitState, SlidingWindowType};
+
+/// Test reset from open state
+#[tokio::test]
+async fn reset_from_open() {
+    let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(5)
+        .minimum_number_of_calls(3)
+        .wait_duration_in_open(Duration::from_millis(100))
+        .name("reset-open")
+        .build();
+
+    let mut cb: tower_circuitbreaker::CircuitBreaker<_, (), (), &str> = layer.layer(service);
+
+    // Trip circuit
+    for _ in 0..5 {
+        let _ = cb.call(()).await;
+    }
+    assert_eq!(cb.state().await, CircuitState::Open);
+
+    // Reset
+    cb.reset().await;
+    assert_eq!(cb.state().await, CircuitState::Closed);
+}
+
+/// Test reset from half-open state
+#[tokio::test]
+async fn reset_from_half_open() {
+    let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(5)
+        .minimum_number_of_calls(3)
+        .wait_duration_in_open(Duration::from_millis(50))
+        .permitted_calls_in_half_open(2)
+        .name("reset-halfopen")
+        .build();
+
+    let mut cb: tower_circuitbreaker::CircuitBreaker<_, (), (), &str> = layer.layer(service);
+
+    // Trip circuit
+    for _ in 0..5 {
+        let _ = cb.call(()).await;
+    }
+
+    // Wait for half-open
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Verify half-open (first call should be permitted)
+    let _ = cb.call(()).await;
+
+    // Reset from half-open
+    cb.reset().await;
+    assert_eq!(cb.state().await, CircuitState::Closed);
+}
+
+/// Test reset from closed state (should be no-op but safe)
+#[tokio::test]
+async fn reset_from_closed() {
+    let service = tower::service_fn(|_req: ()| async { Ok::<(), String>(()) });
+
+    let layer = CircuitBreakerConfig::<(), String>::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(5)
+        .minimum_number_of_calls(3)
+        .wait_duration_in_open(Duration::from_millis(100))
+        .name("reset-closed")
+        .build();
+
+    let cb: tower_circuitbreaker::CircuitBreaker<_, (), (), String> = layer.layer(service);
+
+    assert_eq!(cb.state().await, CircuitState::Closed);
+
+    // Reset closed circuit
+    cb.reset().await;
+    assert_eq!(cb.state().await, CircuitState::Closed);
+}
+
+/// Test reset clears all counters (count-based)
+#[tokio::test]
+async fn reset_clears_counters_count_based() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&call_count);
+
+    let service = tower::service_fn(move |_req: ()| {
+        let count = c.fetch_add(1, Ordering::Relaxed);
+        async move {
+            if count < 10 {
+                Err::<(), _>("error")
+            } else {
+                Ok(())
+            }
+        }
+    });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .sliding_window_type(SlidingWindowType::CountBased)
+        .sliding_window_size(10)
+        .failure_rate_threshold(0.5)
+        .minimum_number_of_calls(5)
+        .wait_duration_in_open(Duration::from_millis(100))
+        .name("reset-counters")
+        .build();
+
+    let mut cb: tower_circuitbreaker::CircuitBreaker<_, (), (), &str> = layer.layer(service);
+
+    // Make 4 failing calls (not enough to trip)
+    for _ in 0..4 {
+        let _ = cb.call(()).await;
+    }
+    assert_eq!(cb.state().await, CircuitState::Closed);
+
+    // Reset should clear counters
+    cb.reset().await;
+
+    // Make 4 more failing calls
+    for _ in 0..4 {
+        let _ = cb.call(()).await;
+    }
+
+    // Should still be closed (counters were reset, so only 4 calls in window now)
+    assert_eq!(cb.state().await, CircuitState::Closed);
+}
+
+/// Test reset clears time-based records
+#[tokio::test]
+async fn reset_clears_time_based_records() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&call_count);
+
+    let service = tower::service_fn(move |_req: ()| {
+        let count = c.fetch_add(1, Ordering::Relaxed);
+        async move {
+            if count < 10 {
+                Err::<(), _>("error")
+            } else {
+                Ok(())
+            }
+        }
+    });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .sliding_window_type(SlidingWindowType::TimeBased)
+        .sliding_window_duration(Duration::from_secs(10))
+        .failure_rate_threshold(0.5)
+        .minimum_number_of_calls(5)
+        .wait_duration_in_open(Duration::from_millis(100))
+        .name("reset-timebased")
+        .build();
+
+    let mut cb: tower_circuitbreaker::CircuitBreaker<_, (), (), &str> = layer.layer(service);
+
+    // Make 6 failing calls (would trip: 6 >= 5 minimum, 100% failure >= 50%)
+    for _ in 0..6 {
+        let _ = cb.call(()).await;
+    }
+
+    // Should be open
+    assert_eq!(cb.state().await, CircuitState::Open);
+
+    // Reset - clears time-based records
+    cb.reset().await;
+
+    // Make 4 more failing calls (not enough to trip: 4 < 5 minimum)
+    for _ in 0..4 {
+        let _ = cb.call(()).await;
+    }
+
+    // Should be closed (only 4 calls after reset, < minimum 5)
+    assert_eq!(cb.state().await, CircuitState::Closed);
+}
+
+/// Test reset during concurrent operations
+#[tokio::test]
+async fn reset_during_concurrent_operations() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&call_count);
+
+    let service = tower::service_fn(move |_req: ()| {
+        let count = c.fetch_add(1, Ordering::Relaxed);
+        async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            if count < 10 {
+                Err::<(), _>("error")
+            } else {
+                Ok(())
+            }
+        }
+    });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(10)
+        .minimum_number_of_calls(5)
+        .wait_duration_in_open(Duration::from_millis(100))
+        .name("reset-concurrent")
+        .build();
+
+    let cb = layer.layer(service);
+    let cb_mutex = Arc::new(tokio::sync::Mutex::new(cb));
+
+    // Spawn concurrent calls
+    let mut handles = vec![];
+    for _ in 0..20 {
+        let cb_clone = Arc::clone(&cb_mutex);
+        let handle = tokio::spawn(async move {
+            let mut breaker = cb_clone.lock().await;
+            breaker.call(()).await
+        });
+        handles.push(handle);
+    }
+
+    // Reset while calls are happening
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    {
+        let breaker = cb_mutex.lock().await;
+        breaker.reset().await;
+    }
+
+    // Wait for all calls
+    for handle in handles {
+        let _ = handle.await;
+    }
+
+    // Should be in a valid state
+    let breaker = cb_mutex.lock().await;
+    let state = breaker.state().await;
+    assert!(
+        state == CircuitState::Closed
+            || state == CircuitState::Open
+            || state == CircuitState::HalfOpen,
+        "Should be in valid state after concurrent reset"
+    );
+}
+
+/// Test multiple resets in succession
+#[tokio::test]
+async fn multiple_resets() {
+    let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(5)
+        .minimum_number_of_calls(3)
+        .wait_duration_in_open(Duration::from_millis(100))
+        .name("multiple-resets")
+        .build();
+
+    let mut cb: tower_circuitbreaker::CircuitBreaker<_, (), (), &str> = layer.layer(service);
+
+    for _ in 0..3 {
+        // Trip circuit
+        for _ in 0..5 {
+            let _ = cb.call(()).await;
+        }
+        assert_eq!(cb.state().await, CircuitState::Open);
+
+        // Reset
+        cb.reset().await;
+        assert_eq!(cb.state().await, CircuitState::Closed);
+    }
+}
+
+/// Test reset with slow call detection enabled
+#[tokio::test]
+async fn reset_with_slow_call_detection() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&call_count);
+
+    let service = tower::service_fn(move |_req: ()| {
+        let count = c.fetch_add(1, Ordering::Relaxed);
+        async move {
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            if count < 10 {
+                Err::<(), _>("error")
+            } else {
+                Ok(())
+            }
+        }
+    });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .failure_rate_threshold(0.5)
+        .slow_call_duration_threshold(Duration::from_millis(100))
+        .slow_call_rate_threshold(0.5)
+        .sliding_window_size(5)
+        .minimum_number_of_calls(3)
+        .wait_duration_in_open(Duration::from_millis(100))
+        .name("reset-slow")
+        .build();
+
+    let mut cb: tower_circuitbreaker::CircuitBreaker<_, (), (), &str> = layer.layer(service);
+
+    // Make slow failing calls
+    for _ in 0..5 {
+        let _ = cb.call(()).await;
+    }
+    assert_eq!(cb.state().await, CircuitState::Open);
+
+    // Reset should clear slow call counters too
+    cb.reset().await;
+    assert_eq!(cb.state().await, CircuitState::Closed);
+
+    // Make more slow failing calls
+    for _ in 0..2 {
+        let _ = cb.call(()).await;
+    }
+
+    // Should be closed (only 2 calls, < minimum 3)
+    assert_eq!(cb.state().await, CircuitState::Closed);
+}
+
+/// Test reset preserves configuration
+#[tokio::test]
+async fn reset_preserves_configuration() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&call_count);
+
+    let service = tower::service_fn(move |_req: ()| {
+        let count = c.fetch_add(1, Ordering::Relaxed);
+        async move {
+            if count < 20 {
+                Err::<(), _>("error")
+            } else {
+                Ok(())
+            }
+        }
+    });
+
+    let layer = CircuitBreakerConfig::<(), &str>::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(10)
+        .minimum_number_of_calls(5)
+        .wait_duration_in_open(Duration::from_millis(100))
+        .name("reset-config")
+        .build();
+
+    let mut cb: tower_circuitbreaker::CircuitBreaker<_, (), (), &str> = layer.layer(service);
+
+    // Trip circuit
+    for _ in 0..10 {
+        let _ = cb.call(()).await;
+    }
+    assert_eq!(cb.state().await, CircuitState::Open);
+
+    // Reset
+    cb.reset().await;
+
+    // Configuration should still work - make enough calls to trip again
+    for _ in 0..10 {
+        let _ = cb.call(()).await;
+    }
+
+    // Should trip again with same thresholds
+    assert_eq!(cb.state().await, CircuitState::Open);
+}


### PR DESCRIPTION
Adds comprehensive test coverage for circuit breaker implementing P1 and P2 requirements from #23.

## P1 Tests (Feature Combinations & Complex Scenarios)

### circuitbreaker_combinations.rs (7 tests)
- Time-based + slow call + failure classification
- Count-based with dual thresholds  
- Custom classifiers with slow calls
- Event listeners with complex configs
- Manual state overrides
- Kitchen sink (all features enabled)

### circuitbreaker_half_open.rs (8 tests)
- Concurrent calls in half-open state
- Partial success scenarios
- All failures with various permitted counts
- Rapid state cycling
- Time-based windows in half-open
- Slow call detection during half-open
- Minimum calls threshold behavior
- Rejected calls don't affect state

### circuitbreaker_reset.rs (9 tests)
- Reset from all states (open/half-open/closed)
- Counter clearing for count-based windows
- Time-based record clearing
- Concurrent reset operations
- Multiple successive resets
- Reset with slow call detection
- Configuration preservation after reset

## P2 Tests (Edge Cases)

### circuitbreaker_edge_cases.rs (9 tests)
- Multiple event listeners on same event
- Failure classifiers (all success, all failure, mixed)
- Slow call detection edge cases (exact threshold, very fast)
- Window size edge cases (size=1)
- Half-open with minimum permitted calls
- All event types emission verification

## Summary
- **Total**: 33 new tests
- **All tests pass** ✅
- **Clippy clean** ✅
- **Formatted** ✅

Closes #23