### PR TITLE
chore: update lru and rand dependencies

### DIFF
--- a/crates/tower-cache/Cargo.toml
+++ b/crates/tower-cache/Cargo.toml
@@ -15,7 +15,7 @@ tower-resilience-core = { path = "../tower-resilience-core", version = "0.1.0" }
 tower = "0.5"
 futures = "0.3"
 tokio = { version = "1", features = ["sync", "time"] }
-lru = "0.12"
+lru = "0.16"
 thiserror = "2.0"
 
 [dev-dependencies]

--- a/crates/tower-retry-plus/Cargo.toml
+++ b/crates/tower-retry-plus/Cargo.toml
@@ -14,7 +14,7 @@ tower = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true }
 thiserror = { workspace = true }
-rand = "0.8"
+rand = "0.9"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/tower-retry-plus/src/backoff.rs
+++ b/crates/tower-retry-plus/src/backoff.rs
@@ -114,11 +114,11 @@ impl ExponentialRandomBackoff {
 
     fn randomize(&self, duration: Duration) -> Duration {
         use rand::Rng;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let delta = duration.as_secs_f64() * self.randomization_factor;
         let min = duration.as_secs_f64() - delta;
         let max = duration.as_secs_f64() + delta;
-        let randomized = rng.gen_range(min..=max);
+        let randomized = rng.random_range(min..=max);
         Duration::from_secs_f64(randomized.max(0.0))
     }
 }


### PR DESCRIPTION
## Summary

Updates outdated dependencies to latest versions.

## Changes

- **lru**: 0.12.5 → 0.16.1 (used in tower-cache)
- **rand**: 0.8.5 → 0.9.2 (used in tower-retry-plus)

## Breaking Changes Handled

### rand 0.9 API changes:
- `thread_rng()` → `rng()`
- `gen_range()` → `random_range()`

Updated `tower-retry-plus/src/backoff.rs` to use new API in `ExponentialRandomBackoff::randomize()`.

## Testing

- [x] All 297 workspace tests pass
- [x] Clippy clean with `-D warnings`
- [x] Code formatted with `cargo fmt`
- [x] Verified lru upgrade is non-breaking (no API changes affecting our usage)
- [x] Verified rand upgrade works with updated method names

## Notes

Both upgrades were straightforward:
- lru 0.16 maintains API compatibility for our use case
- rand 0.9 only required updating deprecated method names

Closes #45