### PR TITLE
fix: add version to tower-resilience-core workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 metrics = []
 
 [dependencies]
-tower-resilience-core = { path = "crates/tower-resilience-core" }
+tower-resilience-core = { version = "0.2.0", path = "crates/tower-resilience-core" }
 tower-circuitbreaker = { path = "crates/tower-circuitbreaker", features = ["metrics", "tracing"] }
 tower-bulkhead = { path = "crates/tower-bulkhead" }
 tower-cache = { path = "crates/tower-cache" }
@@ -55,7 +55,7 @@ thiserror = "2.0"
 tracing = "0.1"
 metrics = "0.24"
 
-tower-resilience-core = { path = "crates/tower-resilience-core" }
+tower-resilience-core = { version = "0.2.0", path = "crates/tower-resilience-core" }
 
 [workspace.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
## Problem

Crates.io requires all dependencies to have explicit versions when publishing. The release was failing with:

```
all dependencies must have a version requirement specified when publishing.
dependency `tower-resilience-core` does not specify a version
```

## Solution

Add `version = "0.2.0"` to `tower-resilience-core` in both:
- Top-level `[dependencies]`
- `[workspace.dependencies]`

## Testing

- [x] Workspace builds successfully: `cargo build --workspace`

This should allow the release to proceed once merged.