### PR TITLE
fix: add missing quote in benchmark workflow YAML

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -76,7 +76,7 @@ jobs:
           alert-threshold: "150%"
           fail-on-alert: false
           save-data-file: false
-          external-data-json-path: "./cache/benchmark-data.json
+          external-data-json-path: "./cache/benchmark-data.json"
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fixes YAML syntax error on line 79 - missing closing quote for `external-data-json-path` parameter.

Error:
```
Invalid workflow file: .github/workflows/benchmark.yml#L79
You have an error in your yaml syntax on line 79
```

Fix:
```diff
- external-data-json-path: "./cache/benchmark-data.json
+ external-data-json-path: "./cache/benchmark-data.json"
```