### PR TITLE
docs: add comprehensive layer composition guide and fix builder API examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Enforce timeouts on operations:
 ```rust
 use tower_resilience_timelimiter::TimeLimiterConfig;
 
-let config = TimeLimiterConfig::builder()
+let layer = TimeLimiterConfig::builder()
     .timeout_duration(Duration::from_secs(30))
     .cancel_running_future(true)
     .build();
@@ -102,9 +102,9 @@ let config = TimeLimiterConfig::builder()
 Retry failed requests with exponential backoff:
 
 ```rust
-use tower_resilience_retry::{RetryConfig, ExponentialBackoff};
+use tower_resilience_retry::RetryConfig;
 
-let config: RetryConfig<MyError> = RetryConfig::builder()
+let layer = RetryConfig::<MyError>::builder()
     .max_attempts(5)
     .exponential_backoff(Duration::from_millis(100))
     .build();
@@ -117,7 +117,7 @@ Control request rate to protect downstream services:
 ```rust
 use tower_resilience_ratelimiter::RateLimiterConfig;
 
-let config = RateLimiterConfig::builder()
+let layer = RateLimiterConfig::builder()
     .max_permits(100)
     .refresh_period(Duration::from_secs(1))
     .build();
@@ -130,8 +130,8 @@ Cache responses to reduce load on expensive operations:
 ```rust
 use tower_resilience_cache::CacheConfig;
 
-let config = CacheConfig::builder()
-    .max_capacity(1000)
+let layer = CacheConfig::builder()
+    .max_size(1000)
     .ttl(Duration::from_secs(300))
     .key_extractor(|req: &Request| req.id.clone())
     .build();


### PR DESCRIPTION
Closes #73

This PR adds comprehensive documentation for layer composition patterns and updates all examples to use the new builder API.

## Changes

### Layer Composition Guide
- Added detailed "Layer Composition Guide" section to 
- Documents limitations when composing 3+ layers with ServiceBuilder
- Provides three workaround strategies:
  1. Manual layer composition (most reliable)
  2. Limit ServiceBuilder stack depth
  3. Split complex compositions into logical groups
- Includes recommended layer ordering for client-side and server-side use cases
- Documents error type integration patterns

### Builder API Updates
- Updated all code examples in README.md to use new builder API
- Fixed tower-resilience lib.rs doctests to reflect that `.build()` returns Layer directly
- Corrected circuit breaker examples to use manual `.layer()` method (doesn't implement Tower's Layer trait)
- Fixed cache examples to use `max_size` instead of `max_capacity`

## Testing
- ✅ All doctests pass
- ✅ All workspace tests pass
- ✅ Clippy passes with `-D warnings`

## Documentation Improvements
The new Layer Composition Guide includes:
- Working 2-layer composition examples
- Explanation of why 3+ layers fail
- Three practical workarounds with code examples
- Recommended layer ordering with rationale
- Error type integration strategies
- Links to working repository examples