### PR TITLE
fix: use gh-pages branch for benchmark storage

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -63,8 +63,8 @@ jobs:
           alert-threshold: "150%"
           fail-on-alert: false
           alert-comment-cc-users: "@joshrotenberg"
-          gh-pages-branch: main
-          benchmark-data-dir-path: ./cache
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
 
       - name: Store benchmark result (PR)
         uses: benchmark-action/github-action-benchmark@v1
@@ -78,7 +78,7 @@ jobs:
           alert-threshold: "150%"
           fail-on-alert: false
           save-data-file: false
-          external-data-json-path: "./cache/benchmark-data.json"
+          external-data-json-path: "./cache/dev/bench/data.json"
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fixes the benchmark workflow failure with Git 2.51.0+.

## Problem
The benchmark action was configured to use `gh-pages-branch: main`, which caused it to try fetching into the currently checked out main branch. Git 2.51.0+ refuses this operation for safety:
```
fatal: refusing to fetch into branch 'refs/heads/main' checked out at '/home/runner/work/tower-resilience/tower-resilience'
```

## Solution
- Changed `gh-pages-branch` from `main` to `gh-pages`
- Updated `benchmark-data-dir-path` to `dev/bench` (standard convention)
- Updated PR external data path to match new directory structure

The benchmark action will now properly store benchmark data in the gh-pages branch without conflicts.