### PR TITLE
fix: update doctests to use Layer::builder() instead of Config::builder()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,17 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
 
-      - name: Run tests
-        run: cargo test --workspace --all-features
+      - name: Run library tests
+        run: cargo test --lib --workspace --all-features
+
+      - name: Run integration tests
+        run: cargo test --test '*' --workspace --all-features
+
+      - name: Run doctests
+        run: cargo test --doc --workspace --all-features
+
+      - name: Build all examples
+        run: cargo build --examples --workspace --all-features
 
   fmt:
     name: Format

--- a/crates/tower-resilience-bulkhead/src/config.rs
+++ b/crates/tower-resilience-bulkhead/src/config.rs
@@ -73,7 +73,7 @@ impl BulkheadConfigBuilder {
     ///
     /// # Example
     /// ```rust,no_run
-    /// use tower_resilience_bulkhead::BulkheadConfig;
+    /// use tower_resilience_bulkhead::BulkheadLayer;
     ///
     /// let config = BulkheadLayer::builder()
     ///     .max_concurrent_calls(10)
@@ -112,7 +112,7 @@ impl BulkheadConfigBuilder {
     ///
     /// # Example
     /// ```rust,no_run
-    /// use tower_resilience_bulkhead::BulkheadConfig;
+    /// use tower_resilience_bulkhead::BulkheadLayer;
     /// use std::sync::atomic::{AtomicUsize, Ordering};
     /// use std::sync::Arc;
     ///
@@ -156,7 +156,7 @@ impl BulkheadConfigBuilder {
     ///
     /// # Example
     /// ```rust,no_run
-    /// use tower_resilience_bulkhead::BulkheadConfig;
+    /// use tower_resilience_bulkhead::BulkheadLayer;
     /// use std::time::Duration;
     ///
     /// let config = BulkheadLayer::builder()
@@ -193,7 +193,7 @@ impl BulkheadConfigBuilder {
     ///
     /// # Example
     /// ```rust,no_run
-    /// use tower_resilience_bulkhead::BulkheadConfig;
+    /// use tower_resilience_bulkhead::BulkheadLayer;
     /// use std::time::Duration;
     /// use std::sync::atomic::{AtomicUsize, Ordering};
     /// use std::sync::Arc;

--- a/crates/tower-resilience-bulkhead/src/lib.rs
+++ b/crates/tower-resilience-bulkhead/src/lib.rs
@@ -33,7 +33,7 @@
 //!
 //! ```rust
 //! use tower::ServiceBuilder;
-//! use tower_resilience_bulkhead::{BulkheadConfig, BulkheadError};
+//! use tower_resilience_bulkhead::{BulkheadLayer, BulkheadError};
 //! use std::time::Duration;
 //!
 //! # async fn example() {

--- a/crates/tower-resilience-cache/src/config.rs
+++ b/crates/tower-resilience-cache/src/config.rs
@@ -87,7 +87,7 @@ where
     ///
     /// # Example
     /// ```rust,no_run
-    /// use tower_resilience_cache::CacheConfig;
+    /// use tower_resilience_cache::CacheLayer;
     /// use std::sync::atomic::{AtomicUsize, Ordering};
     /// use std::sync::Arc;
     ///
@@ -129,7 +129,7 @@ where
     ///
     /// # Example
     /// ```rust,no_run
-    /// use tower_resilience_cache::CacheConfig;
+    /// use tower_resilience_cache::CacheLayer;
     /// use std::sync::atomic::{AtomicUsize, Ordering};
     /// use std::sync::Arc;
     ///
@@ -172,7 +172,7 @@ where
     ///
     /// # Example
     /// ```rust,no_run
-    /// use tower_resilience_cache::CacheConfig;
+    /// use tower_resilience_cache::CacheLayer;
     /// use std::sync::atomic::{AtomicUsize, Ordering};
     /// use std::sync::Arc;
     /// use std::time::Duration;

--- a/crates/tower-resilience-cache/src/layer.rs
+++ b/crates/tower-resilience-cache/src/layer.rs
@@ -12,7 +12,7 @@ use tower::Layer;
 /// # Examples
 ///
 /// ```
-/// use tower_resilience_cache::CacheConfig;
+/// use tower_resilience_cache::CacheLayer;
 /// use tower::ServiceBuilder;
 /// use std::time::Duration;
 ///

--- a/crates/tower-resilience-circuitbreaker/src/config.rs
+++ b/crates/tower-resilience-circuitbreaker/src/config.rs
@@ -179,9 +179,9 @@ impl<Res, Err> CircuitBreakerConfigBuilder<Res, Err> {
     ///
     /// # Example
     /// ```rust,no_run
-    /// use tower_resilience_circuitbreaker::{CircuitBreakerConfig, CircuitState};
+    /// use tower_resilience_circuitbreaker::{CircuitBreakerLayer, CircuitState};
     ///
-    /// let config = CircuitBreakerConfig::<(), ()>::builder()
+    /// let config = CircuitBreakerLayer::<(), ()>::builder()
     ///     .on_state_transition(|from, to| {
     ///         println!("Circuit breaker: {:?} -> {:?}", from, to);
     ///         match to {
@@ -223,14 +223,14 @@ impl<Res, Err> CircuitBreakerConfigBuilder<Res, Err> {
     ///
     /// # Example
     /// ```rust,no_run
-    /// use tower_resilience_circuitbreaker::{CircuitBreakerConfig, CircuitState};
+    /// use tower_resilience_circuitbreaker::{CircuitBreakerLayer, CircuitState};
     /// use std::sync::atomic::{AtomicUsize, Ordering};
     /// use std::sync::Arc;
     ///
     /// let call_count = Arc::new(AtomicUsize::new(0));
     /// let counter = Arc::clone(&call_count);
     ///
-    /// let config = CircuitBreakerConfig::<(), ()>::builder()
+    /// let config = CircuitBreakerLayer::<(), ()>::builder()
     ///     .on_call_permitted(move |state| {
     ///         let count = counter.fetch_add(1, Ordering::SeqCst);
     ///         println!("Call #{} permitted in state: {:?}", count + 1, state);
@@ -264,14 +264,14 @@ impl<Res, Err> CircuitBreakerConfigBuilder<Res, Err> {
     ///
     /// # Example
     /// ```rust,no_run
-    /// use tower_resilience_circuitbreaker::CircuitBreakerConfig;
+    /// use tower_resilience_circuitbreaker::CircuitBreakerLayer;
     /// use std::sync::atomic::{AtomicUsize, Ordering};
     /// use std::sync::Arc;
     ///
     /// let rejection_count = Arc::new(AtomicUsize::new(0));
     /// let counter = Arc::clone(&rejection_count);
     ///
-    /// let config = CircuitBreakerConfig::<(), ()>::builder()
+    /// let config = CircuitBreakerLayer::<(), ()>::builder()
     ///     .on_call_rejected(move || {
     ///         let count = counter.fetch_add(1, Ordering::SeqCst);
     ///         println!("Call rejected - circuit is open (total: {})", count + 1);
@@ -304,9 +304,9 @@ impl<Res, Err> CircuitBreakerConfigBuilder<Res, Err> {
     ///
     /// # Example
     /// ```rust,no_run
-    /// use tower_resilience_circuitbreaker::{CircuitBreakerConfig, CircuitState};
+    /// use tower_resilience_circuitbreaker::{CircuitBreakerLayer, CircuitState};
     ///
-    /// let config = CircuitBreakerConfig::<(), ()>::builder()
+    /// let config = CircuitBreakerLayer::<(), ()>::builder()
     ///     .on_success(|state| {
     ///         match state {
     ///             CircuitState::HalfOpen => println!("Success in half-open - may recover soon"),
@@ -342,14 +342,14 @@ impl<Res, Err> CircuitBreakerConfigBuilder<Res, Err> {
     ///
     /// # Example
     /// ```rust,no_run
-    /// use tower_resilience_circuitbreaker::{CircuitBreakerConfig, CircuitState};
+    /// use tower_resilience_circuitbreaker::{CircuitBreakerLayer, CircuitState};
     /// use std::sync::atomic::{AtomicUsize, Ordering};
     /// use std::sync::Arc;
     ///
     /// let failure_count = Arc::new(AtomicUsize::new(0));
     /// let counter = Arc::clone(&failure_count);
     ///
-    /// let config = CircuitBreakerConfig::<(), ()>::builder()
+    /// let config = CircuitBreakerLayer::<(), ()>::builder()
     ///     .on_failure(move |state| {
     ///         let count = counter.fetch_add(1, Ordering::SeqCst);
     ///         println!("Failure #{} recorded in state: {:?}", count + 1, state);
@@ -388,10 +388,10 @@ impl<Res, Err> CircuitBreakerConfigBuilder<Res, Err> {
     ///
     /// # Example
     /// ```rust,no_run
-    /// use tower_resilience_circuitbreaker::CircuitBreakerConfig;
+    /// use tower_resilience_circuitbreaker::CircuitBreakerLayer;
     /// use std::time::Duration;
     ///
-    /// let config = CircuitBreakerConfig::<(), ()>::builder()
+    /// let config = CircuitBreakerLayer::<(), ()>::builder()
     ///     .slow_call_duration_threshold(Duration::from_secs(2))
     ///     .slow_call_rate_threshold(0.5) // Open if >50% of calls are slow
     ///     .on_slow_call(|duration| {

--- a/crates/tower-resilience-circuitbreaker/src/lib.rs
+++ b/crates/tower-resilience-circuitbreaker/src/lib.rs
@@ -11,12 +11,12 @@
 //! ## Basic Example
 //!
 //! ```rust
-//! use tower_resilience_circuitbreaker::{CircuitBreakerConfig, CircuitBreaker};
+//! use tower_resilience_circuitbreaker::{CircuitBreakerLayer, CircuitBreaker};
 //! use tower::service_fn;
 //! use std::time::Duration;
 //!
 //! # async fn example() {
-//! let layer = CircuitBreakerConfig::<String, ()>::builder()
+//! let layer = CircuitBreakerLayer::<String, ()>::builder()
 //!     .failure_rate_threshold(0.5)  // Open at 50% failure rate
 //!     .sliding_window_size(100)     // Track last 100 calls
 //!     .wait_duration_in_open(Duration::from_secs(30))
@@ -34,12 +34,12 @@
 //! Use time-based windows instead of count-based:
 //!
 //! ```rust
-//! use tower_resilience_circuitbreaker::{CircuitBreakerConfig, CircuitBreaker, SlidingWindowType};
+//! use tower_resilience_circuitbreaker::{CircuitBreakerLayer, CircuitBreaker, SlidingWindowType};
 //! use tower::service_fn;
 //! use std::time::Duration;
 //!
 //! # async fn example() {
-//! let layer = CircuitBreakerConfig::<String, ()>::builder()
+//! let layer = CircuitBreakerLayer::<String, ()>::builder()
 //!     .failure_rate_threshold(0.5)
 //!     .sliding_window_type(SlidingWindowType::TimeBased)
 //!     .sliding_window_duration(Duration::from_secs(60))  // Last 60 seconds
@@ -58,13 +58,13 @@
 //! Provide fallback responses when circuit is open:
 //!
 //! ```rust
-//! use tower_resilience_circuitbreaker::CircuitBreakerConfig;
+//! use tower_resilience_circuitbreaker::CircuitBreakerLayer;
 //! use tower::service_fn;
 //! use std::time::Duration;
 //! use futures::future::BoxFuture;
 //!
 //! # async fn example() {
-//! let layer = CircuitBreakerConfig::<String, ()>::builder()
+//! let layer = CircuitBreakerLayer::<String, ()>::builder()
 //!     .failure_rate_threshold(0.5)
 //!     .sliding_window_size(100)
 //!     .build();
@@ -87,12 +87,12 @@
 //! Control what counts as a failure:
 //!
 //! ```rust
-//! use tower_resilience_circuitbreaker::{CircuitBreakerConfig, CircuitBreaker};
+//! use tower_resilience_circuitbreaker::{CircuitBreakerLayer, CircuitBreaker};
 //! use tower::service_fn;
 //! use std::time::Duration;
 //!
 //! # async fn example() {
-//! let layer = CircuitBreakerConfig::<String, std::io::Error>::builder()
+//! let layer = CircuitBreakerLayer::<String, std::io::Error>::builder()
 //!     .failure_rate_threshold(0.5)
 //!     .sliding_window_size(100)
 //!     .failure_classifier(|result: &Result<String, std::io::Error>| {
@@ -117,12 +117,12 @@
 //! Open circuit based on slow calls:
 //!
 //! ```rust
-//! use tower_resilience_circuitbreaker::{CircuitBreakerConfig, CircuitBreaker};
+//! use tower_resilience_circuitbreaker::{CircuitBreakerLayer, CircuitBreaker};
 //! use tower::service_fn;
 //! use std::time::Duration;
 //!
 //! # async fn example() {
-//! let layer = CircuitBreakerConfig::<String, ()>::builder()
+//! let layer = CircuitBreakerLayer::<String, ()>::builder()
 //!     .failure_rate_threshold(1.0)  // Don't open on failures
 //!     .slow_call_duration_threshold(Duration::from_secs(2))
 //!     .slow_call_rate_threshold(0.5)  // Open at 50% slow calls
@@ -141,12 +141,12 @@
 //! Monitor circuit breaker behavior:
 //!
 //! ```rust
-//! use tower_resilience_circuitbreaker::{CircuitBreakerConfig, CircuitBreaker};
+//! use tower_resilience_circuitbreaker::{CircuitBreakerLayer, CircuitBreaker};
 //! use tower::service_fn;
 //! use std::time::Duration;
 //!
 //! # async fn example() {
-//! let layer = CircuitBreakerConfig::<String, ()>::builder()
+//! let layer = CircuitBreakerLayer::<String, ()>::builder()
 //!     .failure_rate_threshold(0.5)
 //!     .sliding_window_size(100)
 //!     .on_state_transition(|from, to| {
@@ -173,11 +173,11 @@
 //! ## Error Handling
 //!
 //! ```rust
-//! use tower_resilience_circuitbreaker::{CircuitBreakerConfig, CircuitBreakerError};
+//! use tower_resilience_circuitbreaker::{CircuitBreakerLayer, CircuitBreakerError};
 //! use tower::{Service, service_fn};
 //!
 //! # async fn example() {
-//! let layer = CircuitBreakerConfig::<String, ()>::builder().build();
+//! let layer = CircuitBreakerLayer::<String, ()>::builder().build();
 //! let mut service = layer.layer(service_fn(|req: String| async move {
 //!     Ok::<_, ()>(req)
 //! }));
@@ -248,7 +248,7 @@ static METRICS_INIT: Once = Once::new();
 /// Returns a new builder for a `CircuitBreakerLayer`.
 ///
 /// This is a convenience function that returns a builder. You can also use
-/// `CircuitBreakerConfig::builder()` directly.
+/// `CircuitBreakerLayer::builder()` directly.
 pub fn circuit_breaker_builder<Res, Err>() -> CircuitBreakerConfigBuilder<Res, Err> {
     #[cfg(feature = "metrics")]
     {

--- a/crates/tower-resilience/src/lib.rs
+++ b/crates/tower-resilience/src/lib.rs
@@ -80,7 +80,7 @@
 //! ```rust,no_run
 //! # #[cfg(feature = "circuitbreaker")]
 //! # {
-//! use tower_resilience::circuitbreaker::CircuitBreakerConfig;
+//! use tower_resilience::circuitbreaker::CircuitBreakerLayer;
 //! use tower::Layer;
 //! use std::time::Duration;
 //!
@@ -219,7 +219,7 @@
 //! ```rust,no_run
 //! # #[cfg(feature = "timelimiter")]
 //! # {
-//! use tower_resilience::timelimiter::TimeLimiterConfig;
+//! use tower_resilience::timelimiter::TimeLimiterLayer;
 //! use tower::Layer;
 //! use std::time::Duration;
 //!
@@ -293,7 +293,7 @@
 //! ```rust,no_run
 //! # #[cfg(feature = "retry")]
 //! # {
-//! use tower_resilience::retry::RetryConfig;
+//! use tower_resilience::retry::RetryLayer;
 //! use tower::Layer;
 //! use std::time::Duration;
 //!
@@ -367,7 +367,7 @@
 //! ```rust,no_run
 //! # #[cfg(feature = "ratelimiter")]
 //! # {
-//! use tower_resilience::ratelimiter::RateLimiterConfig;
+//! use tower_resilience::ratelimiter::RateLimiterLayer;
 //! use tower::Layer;
 //! use std::time::Duration;
 //!
@@ -570,8 +570,8 @@
 //! # #[cfg(all(feature = "retry", feature = "timelimiter"))]
 //! # {
 //! use tower::ServiceBuilder;
-//! use tower_resilience::retry::RetryConfig;
-//! use tower_resilience::timelimiter::TimeLimiterConfig;
+//! use tower_resilience::retry::RetryLayer;
+//! use tower_resilience::timelimiter::TimeLimiterLayer;
 //! use std::time::Duration;
 //!
 //! # #[derive(Debug, Clone)]
@@ -624,8 +624,8 @@
 //! # #[cfg(all(feature = "retry", feature = "circuitbreaker", feature = "cache"))]
 //! # {
 //! use tower::Layer;
-//! use tower_resilience::retry::RetryConfig;
-//! use tower_resilience::circuitbreaker::CircuitBreakerConfig;
+//! use tower_resilience::retry::RetryLayer;
+//! use tower_resilience::circuitbreaker::CircuitBreakerLayer;
 //! use tower_resilience_cache::CacheLayer;
 //! use std::time::Duration;
 //!
@@ -664,8 +664,8 @@
 //! # #[cfg(all(feature = "retry", feature = "timelimiter", feature = "cache"))]
 //! # {
 //! use tower::{ServiceBuilder, Layer};
-//! use tower_resilience::retry::RetryConfig;
-//! use tower_resilience::timelimiter::TimeLimiterConfig;
+//! use tower_resilience::retry::RetryLayer;
+//! use tower_resilience::timelimiter::TimeLimiterLayer;
 //! use tower_resilience_cache::CacheLayer;
 //! use std::time::Duration;
 //!
@@ -704,8 +704,8 @@
 //! # #[cfg(all(feature = "retry", feature = "timelimiter"))]
 //! # {
 //! use tower::{ServiceBuilder, Layer};
-//! use tower_resilience::retry::RetryConfig;
-//! use tower_resilience::timelimiter::TimeLimiterConfig;
+//! use tower_resilience::retry::RetryLayer;
+//! use tower_resilience::timelimiter::TimeLimiterLayer;
 //! use std::time::Duration;
 //!
 //! # #[derive(Debug, Clone)]
@@ -782,7 +782,7 @@
 //! use tower::ServiceBuilder;
 //! use tower_resilience_core::ResilienceError;
 //! use tower_resilience_bulkhead::BulkheadLayer;
-//! use tower_resilience::ratelimiter::RateLimiterConfig;
+//! use tower_resilience::ratelimiter::RateLimiterLayer;
 //! use std::time::Duration;
 //!
 //! // Your application error
@@ -834,8 +834,8 @@
 //! # use std::time::Duration;
 //! # #[cfg(all(feature = "retry", feature = "circuitbreaker"))]
 //! # {
-//! use tower_resilience::retry::RetryConfig;
-//! use tower_resilience::circuitbreaker::CircuitBreakerConfig;
+//! use tower_resilience::retry::RetryLayer;
+//! use tower_resilience::circuitbreaker::CircuitBreakerLayer;
 //!
 //! #[derive(Debug, Clone)]
 //! enum ServiceError {
@@ -870,7 +870,7 @@
 //! # #[cfg(feature = "retry")]
 //! # {
 //! use tower::{ServiceBuilder, ServiceExt};
-//! use tower_resilience::retry::RetryConfig;
+//! use tower_resilience::retry::RetryLayer;
 //! use std::time::Duration;
 //!
 //! # #[derive(Debug)]


### PR DESCRIPTION
## Problem
After merging #86 which removed `Config::builder()` methods, doctests were still using the old API with `Config` imports, causing compilation failures.

## Solution
- Updated all doctests to use `Layer::builder()` instead of `Config::builder()`
- Changed imports from `*Config` to `*Layer` types in documentation examples
- Fixed doctests across:
  - tower-resilience (main crate)
  - tower-resilience-bulkhead
  - tower-resilience-cache
  - tower-resilience-circuitbreaker

## CI Improvements
Enhanced CI workflow to explicitly test doctests and build examples separately:
- Added `cargo test --doc --workspace --all-features` step
- Added `cargo build --examples --workspace --all-features` step
- Prevents similar failures from slipping through CI in the future

## Testing
- ✅ All doctests pass: `cargo test --doc --workspace --all-features`
- ✅ All unit tests pass: `cargo test --lib --workspace --all-features`
- ✅ All integration tests pass: `cargo test --test '*' --workspace --all-features`
- ✅ Clippy passes: `cargo clippy --all-targets --all-features -- -D warnings`
- ✅ Formatting checked: `cargo fmt --all -- --check`

Closes the doctest failures discovered after merging #86.