### PR TITLE
feat(retry): add comprehensive metrics and tracing support

### DIFF
--- a/crates/tower-resilience-retry/Cargo.toml
+++ b/crates/tower-resilience-retry/Cargo.toml
@@ -17,10 +17,14 @@ tokio = { workspace = true }
 thiserror = { workspace = true }
 rand = "0.9"
 
+# Optional dependencies
+metrics = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [features]
 default = []
-metrics = ["tower-resilience-core/metrics"]
-tracing = ["tower-resilience-core/tracing"]
+metrics = ["dep:metrics", "tower-resilience-core/metrics"]
+tracing = ["dep:tracing", "tower-resilience-core/tracing"]


### PR DESCRIPTION
Add comprehensive metrics and tracing support to the retry pattern.

## Metrics Added

- **retry_calls_total{retry,result}** - Counter tracking total retry operations
  - Labels: `retry` (instance name), `result` (success/exhausted)
- **retry_attempts_total{retry}** - Counter tracking total retry attempts across all calls
  - Labels: `retry` (instance name)
- **retry_attempts{retry}** - Histogram tracking number of attempts per successful call
  - Labels: `retry` (instance name)

## Tracing Added

- **debug** - First attempt success, individual retry attempts with delay
- **info** - Success after retries with attempt count
- **warn** - Retry exhausted with attempt count and max attempts

## Implementation Details

- All metrics follow Prometheus naming conventions
- Metrics are feature-gated behind `metrics` feature flag
- Tracing is feature-gated behind `tracing` feature flag
- Instance names default to `<unnamed>` but can be customized via `.name()` builder method
- Metric labels use instance name to distinguish multiple retry instances

Closes #59 (partial - retry pattern complete)