### PR TITLE
feat(timelimiter): add comprehensive metrics and tracing support

### DIFF
--- a/crates/tower-resilience-timelimiter/Cargo.toml
+++ b/crates/tower-resilience-timelimiter/Cargo.toml
@@ -18,11 +18,15 @@ futures = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
 thiserror = { workspace = true }
 
+# Optional dependencies
+metrics = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
 tower = { workspace = true, features = ["util"] }
 
 [features]
 default = []
-metrics = ["tower-resilience-core/metrics"]
-tracing = ["tower-resilience-core/tracing"]
+metrics = ["dep:metrics", "tower-resilience-core/metrics"]
+tracing = ["dep:tracing", "tower-resilience-core/tracing"]


### PR DESCRIPTION
Add comprehensive metrics and tracing support to the time limiter pattern.

## Metrics Added

- **timelimiter_calls_total{timelimiter,result}** - Counter tracking total calls
  - Labels: `timelimiter` (instance name), `result` (success/error/timeout)
- **timelimiter_call_duration_seconds{timelimiter}** - Histogram tracking call duration
  - Labels: `timelimiter` (instance name)
  - Recorded for successful and failed calls (not for timeouts)

## Tracing Added

- **debug** - Call succeeded/failed within timeout with duration
- **warn** - Call timed out with timeout duration

## Implementation Details

- All metrics follow Prometheus naming conventions
- Metrics are feature-gated behind `metrics` feature flag
- Tracing is feature-gated behind `tracing` feature flag
- Instance names default to `<unnamed>` but can be customized via `.name()` builder method
- Metric labels use instance name to distinguish multiple time limiter instances
- Duration histogram only records for completed calls, not timeouts

Partial progress on #59