### PR TITLE
fix: increase timeout tolerance for Windows CI

### DIFF
--- a/tests/timelimiter/timeout_precision.rs
+++ b/tests/timelimiter/timeout_precision.rs
@@ -196,7 +196,12 @@ async fn timeout_just_after_completion() {
     let elapsed = start.elapsed();
 
     assert!(result.is_ok());
-    assert!(elapsed.as_millis() < 70);
+    // Windows CI has less precise timers, use larger tolerance
+    assert!(
+        elapsed.as_millis() < 90,
+        "Expected completion ~50ms, got {}ms",
+        elapsed.as_millis()
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

The `timeout_just_after_completion` test was failing intermittently on Windows CI with timing assertion violations. The test expected a 50ms operation to complete within 70ms, but Windows timer precision (~15.6ms) and scheduling variance occasionally caused it to exceed this tight margin.

## Solution

Increased the assertion tolerance from 70ms to 90ms and added a descriptive error message. This provides adequate tolerance for Windows timing variability while still validating correct behavior.

## Changes

- Increased tolerance in `tests/timelimiter/timeout_precision.rs:199` from 70ms to 90ms
- Added descriptive assertion message showing expected vs actual timing
- Added comment explaining Windows CI timing considerations

## Testing

- ✅ All timelimiter tests pass locally
- ✅ Clippy and fmt checks pass
- Test now has sufficient margin for Windows CI timing variance

Fixes the CI failure from the recent release.