### PR TITLE
feat: add health check integration for circuit breaker (#106)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ thiserror = "2.0"
 tracing = "0.1"
 metrics = "0.24"
 criterion = { version = "0.5", features = ["async_tokio"] }
+serde = { version = "1.0", features = ["derive"] }
 
 tower-resilience-core = { version = "0.4.3", path = "crates/tower-resilience-core" }
 

--- a/crates/tower-resilience-circuitbreaker/Cargo.toml
+++ b/crates/tower-resilience-circuitbreaker/Cargo.toml
@@ -21,11 +21,13 @@ tower-resilience-core.workspace = true
 tracing = { workspace = true, optional = true }
 metrics = { workspace = true, optional = true }
 metrics-util = { version = "0.20", optional = true }
+serde = { workspace = true, optional = true }
 
 [features]
 default = []
 metrics = ["dep:metrics", "dep:metrics-util"]
 tracing = ["dep:tracing"]
+serde = ["dep:serde"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/tower-resilience-circuitbreaker/src/circuit.rs
+++ b/crates/tower-resilience-circuitbreaker/src/circuit.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant};
 
 /// Represents the state of the circuit breaker.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u8)]
 pub enum CircuitState {
     /// The circuit is closed and calls are allowed.
@@ -24,6 +25,7 @@ pub enum CircuitState {
 /// without requiring async access. All fields represent a consistent snapshot taken
 /// when the metrics were retrieved.
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct CircuitMetrics {
     /// Current state of the circuit breaker.
     pub state: CircuitState,


### PR DESCRIPTION
Add convenient health check helper methods and serde support for circuit breaker state and metrics.

## Changes
- Add optional 'serde' feature to workspace and circuit breaker crate
- Add Serialize derives to CircuitState and CircuitMetrics (behind feature flag)
- Add `health_status()` method returning "healthy"/"degraded"/"unhealthy"
- Add `http_status()` method returning HTTP status codes (200/503)
- Update documentation with health check integration examples
- Document serde feature flag

## Usage

```rust
// Simple health check endpoint (any framework)
async fn health(breaker: Extension<Arc<CircuitBreaker<...>>>) -> Response {
    let status_code = breaker.http_status(); // 200 or 503
    let body = json!({
        "status": breaker.health_status(), // "healthy", "degraded", "unhealthy"
    });
    Response::builder().status(status_code).json(body)
}
```

Both methods are sync (no `.await` needed) and use the existing lock-free `state_sync()` under the hood, making them perfect for health check endpoints.

## Design Decisions

- **Optional serde dependency**: Only included when `serde` feature is enabled
- **Framework-agnostic**: Works with any HTTP framework (Axum, Actix, Warp, Tonic)
- **Sync-first**: Health checks don't require async context
- **Simple helper methods**: No traits or abstractions, just convenient helpers

Closes #106