### PR TITLE
feat: add metrics regression tests for all resilience patterns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ tower-resilience-cache = { path = "crates/tower-resilience-cache", features = ["
 tower-resilience-retry = { path = "crates/tower-resilience-retry", features = ["metrics"] }
 tower-resilience-timelimiter = { path = "crates/tower-resilience-timelimiter", features = ["metrics"] }
 tower-resilience-ratelimiter = { path = "crates/tower-resilience-ratelimiter", features = ["metrics"] }
-tower-resilience-chaos = { path = "crates/tower-resilience-chaos" }
+tower-resilience-chaos = { path = "crates/tower-resilience-chaos", features = ["metrics"] }
 tower = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 tracing-subscriber = "0.3"
@@ -25,6 +25,7 @@ futures = { workspace = true }
 metrics = { workspace = true }
 metrics-util = { version = "0.20", default-features = false, features = ["debugging"] }
 criterion = { workspace = true }
+serial_test = "3.2"
 
 [[bench]]
 name = "happy_path_overhead"

--- a/tests/metrics_regression.rs
+++ b/tests/metrics_regression.rs
@@ -1,0 +1,88 @@
+//! Metrics regression tests for all resilience patterns.
+//!
+//! These tests ensure that metric names, types, and labels remain stable
+//! across releases. Breaking changes to metrics can break user dashboards
+//! and alerts, so we treat them as part of the public API.
+
+#[cfg(feature = "metrics")]
+mod metrics_regression {
+    mod bulkhead;
+    mod cache;
+    mod chaos;
+    mod circuitbreaker;
+    mod core;
+    mod ratelimiter;
+    mod retry;
+    mod timelimiter;
+
+    /// Helper module with shared utilities for metrics testing
+    pub(crate) mod helpers {
+        use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+        use std::sync::LazyLock;
+
+        /// Global metrics recorder for testing
+        pub(crate) static RECORDER: LazyLock<DebuggingRecorder> =
+            LazyLock::new(DebuggingRecorder::default);
+
+        /// Initialize the global metrics recorder (call once per test)
+        pub(crate) fn init_recorder() {
+            let _ = metrics::set_global_recorder(&*RECORDER);
+        }
+
+        /// Get a snapshot of all recorded metrics
+        pub(crate) fn get_metrics_snapshot() -> Vec<(
+            metrics_util::CompositeKey,
+            Option<metrics::Unit>,
+            Option<metrics::SharedString>,
+            DebugValue,
+        )> {
+            RECORDER.snapshotter().snapshot().into_vec()
+        }
+
+        /// Assert that a counter with the given name exists
+        pub(crate) fn assert_counter_exists(name: &str) {
+            let snapshot = get_metrics_snapshot();
+            let found = snapshot.iter().any(|(composite_key, _, _, value)| {
+                composite_key.key().name() == name && matches!(value, DebugValue::Counter(_))
+            });
+            assert!(found, "Expected counter '{}' not found in metrics", name);
+        }
+
+        /// Assert that a gauge with the given name exists
+        pub(crate) fn assert_gauge_exists(name: &str) {
+            let snapshot = get_metrics_snapshot();
+            let found = snapshot.iter().any(|(composite_key, _, _, value)| {
+                composite_key.key().name() == name && matches!(value, DebugValue::Gauge(_))
+            });
+            assert!(found, "Expected gauge '{}' not found in metrics", name);
+        }
+
+        /// Assert that a histogram with the given name exists
+        pub(crate) fn assert_histogram_exists(name: &str) {
+            let snapshot = get_metrics_snapshot();
+            let found = snapshot.iter().any(|(composite_key, _, _, value)| {
+                composite_key.key().name() == name && matches!(value, DebugValue::Histogram(_))
+            });
+            assert!(found, "Expected histogram '{}' not found in metrics", name);
+        }
+
+        /// Assert that a metric has a specific label
+        pub(crate) fn assert_metric_has_label(name: &str, label_key: &str, label_value: &str) {
+            let snapshot = get_metrics_snapshot();
+            let found = snapshot.iter().any(|(composite_key, _, _, _)| {
+                let key = composite_key.key();
+                if key.name() == name {
+                    key.labels()
+                        .any(|label| label.key() == label_key && label.value() == label_value)
+                } else {
+                    false
+                }
+            });
+            assert!(
+                found,
+                "Expected metric '{}' with label {}='{}' not found",
+                name, label_key, label_value
+            );
+        }
+    }
+}

--- a/tests/metrics_regression/bulkhead.rs
+++ b/tests/metrics_regression/bulkhead.rs
@@ -1,0 +1,7 @@
+//! Bulkhead metrics regression tests
+//!
+//! Note: Bulkhead metrics tests are complex due to trait bounds on Service cloning.
+//! See tests/bulkhead/integration.rs for comprehensive bulkhead testing.
+//! The metrics emitted are: bulkhead_calls_permitted_total, bulkhead_calls_rejected_total,
+//! bulkhead_calls_finished_total, bulkhead_calls_failed_total, bulkhead_concurrent_calls,
+//! bulkhead_wait_duration_seconds, bulkhead_call_duration_seconds

--- a/tests/metrics_regression/cache.rs
+++ b/tests/metrics_regression/cache.rs
@@ -1,0 +1,71 @@
+//! Cache metrics regression tests
+
+use super::helpers::*;
+use serial_test::serial;
+use tower::{Layer, Service, ServiceExt};
+use tower_resilience_cache::CacheLayer;
+
+#[tokio::test]
+#[serial]
+async fn cache_metrics_exist() {
+    init_recorder();
+
+    let layer = CacheLayer::builder()
+        .name("test_cache")
+        .max_size(10)
+        .key_extractor(|req: &u64| *req)
+        .build();
+
+    let counter = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let counter_clone = counter.clone();
+    let service = tower::service_fn(move |_: u64| {
+        let c = counter_clone.clone();
+        async move {
+            c.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok::<_, &'static str>("response")
+        }
+    });
+
+    let mut service = layer.layer(service);
+
+    // First call - cache miss
+    let _ = service.ready().await.unwrap().call(1).await;
+
+    // Second call with same key - cache hit
+    let _ = service.ready().await.unwrap().call(1).await;
+
+    // Verify counter metrics
+    assert_counter_exists("cache_requests_total");
+    assert_metric_has_label("cache_requests_total", "cache", "test_cache");
+    assert_metric_has_label("cache_requests_total", "result", "hit");
+    assert_metric_has_label("cache_requests_total", "result", "miss");
+
+    // Verify gauge metric
+    assert_gauge_exists("cache_size");
+    assert_metric_has_label("cache_size", "cache", "test_cache");
+}
+
+#[tokio::test]
+#[serial]
+async fn cache_eviction_metrics() {
+    init_recorder();
+
+    let layer = CacheLayer::builder()
+        .name("eviction_cache")
+        .max_size(2)
+        .key_extractor(|req: &u64| *req)
+        .build();
+
+    let service = tower::service_fn(|req: u64| async move { Ok::<_, &'static str>(req) });
+
+    let mut service = layer.layer(service);
+
+    // Fill cache beyond capacity to trigger evictions
+    for i in 0..5 {
+        let _ = service.ready().await.unwrap().call(i).await;
+    }
+
+    // Verify eviction counter exists
+    assert_counter_exists("cache_evictions_total");
+    assert_metric_has_label("cache_evictions_total", "cache", "eviction_cache");
+}

--- a/tests/metrics_regression/chaos.rs
+++ b/tests/metrics_regression/chaos.rs
@@ -1,0 +1,80 @@
+//! Chaos metrics regression tests
+
+use super::helpers::*;
+use serial_test::serial;
+use std::time::Duration;
+use tower::{Layer, Service, ServiceExt};
+use tower_resilience_chaos::ChaosLayer;
+
+#[tokio::test]
+#[serial]
+async fn chaos_error_injection_metrics() {
+    init_recorder();
+
+    let layer = ChaosLayer::<u64, &'static str>::builder()
+        .name("error_chaos")
+        .error_rate(1.0)
+        .error_fn(|_req| "injected_error")
+        .build();
+
+    let service = tower::service_fn(|_: u64| async { Ok::<_, &'static str>("success") });
+
+    let mut service = layer.layer(service);
+
+    // Make a call that will have error injected
+    let _ = service.ready().await.unwrap().call(1).await;
+
+    // Verify error injection counter
+    assert_counter_exists("chaos.errors_injected");
+    assert_metric_has_label("chaos.errors_injected", "layer", "error_chaos");
+}
+
+#[tokio::test]
+#[serial]
+async fn chaos_latency_injection_metrics() {
+    init_recorder();
+
+    let layer = ChaosLayer::<u64, &'static str>::builder()
+        .name("latency_chaos")
+        .latency_rate(1.0)
+        .min_latency(Duration::from_millis(10))
+        .max_latency(Duration::from_millis(10))
+        .build();
+
+    let service = tower::service_fn(|_: u64| async { Ok::<_, &'static str>("success") });
+
+    let mut service = layer.layer(service);
+
+    // Make a call that will have latency injected
+    let _ = service.ready().await.unwrap().call(1).await;
+
+    // Verify latency injection metrics
+    assert_counter_exists("chaos.latency_injections");
+    assert_metric_has_label("chaos.latency_injections", "layer", "latency_chaos");
+
+    assert_histogram_exists("chaos.injected_latency_ms");
+    assert_metric_has_label("chaos.injected_latency_ms", "layer", "latency_chaos");
+}
+
+#[tokio::test]
+#[serial]
+async fn chaos_passthrough_metrics() {
+    init_recorder();
+
+    let layer = ChaosLayer::<u64, &'static str>::builder()
+        .name("passthrough_chaos")
+        .error_rate(0.0)
+        .error_fn(|_req| "error")
+        .build();
+
+    let service = tower::service_fn(|_: u64| async { Ok::<_, &'static str>("success") });
+
+    let mut service = layer.layer(service);
+
+    // Make a call that will pass through
+    let _ = service.ready().await.unwrap().call(1).await;
+
+    // Verify passthrough counter
+    assert_counter_exists("chaos.passed_through");
+    assert_metric_has_label("chaos.passed_through", "layer", "passthrough_chaos");
+}

--- a/tests/metrics_regression/circuitbreaker.rs
+++ b/tests/metrics_regression/circuitbreaker.rs
@@ -1,0 +1,152 @@
+//! Circuit breaker metrics regression tests
+
+use super::helpers::*;
+use serial_test::serial;
+use std::time::Duration;
+use tower::{Service, ServiceExt};
+use tower_resilience_circuitbreaker::CircuitBreakerLayer;
+
+#[tokio::test]
+#[serial]
+async fn circuitbreaker_metrics_exist() {
+    init_recorder();
+
+    // Create a circuit breaker with a low threshold to trigger state transitions
+    let layer = CircuitBreakerLayer::builder()
+        .name("test_cb")
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(4)
+        .minimum_number_of_calls(2)
+        .wait_duration_in_open(Duration::from_millis(100))
+        .build();
+
+    // Create a test service that can succeed or fail
+    let success_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let success_count_clone = success_count.clone();
+    let service = tower::service_fn(move |_: u64| {
+        let count = success_count_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        async move {
+            if count.is_multiple_of(2) {
+                Ok::<_, &'static str>("success")
+            } else {
+                Err("failure")
+            }
+        }
+    });
+
+    let mut service = layer.layer(service);
+
+    // Make some calls to generate metrics
+    for i in 0..6 {
+        let _ = service.ready().await.unwrap().call(i).await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    // Verify counter metrics
+    assert_counter_exists("circuitbreaker_calls_total");
+    assert_metric_has_label("circuitbreaker_calls_total", "circuitbreaker", "test_cb");
+    assert_metric_has_label("circuitbreaker_calls_total", "outcome", "success");
+    assert_metric_has_label("circuitbreaker_calls_total", "outcome", "failure");
+
+    // Verify transition counter
+    assert_counter_exists("circuitbreaker_transitions_total");
+    assert_metric_has_label(
+        "circuitbreaker_transitions_total",
+        "circuitbreaker",
+        "test_cb",
+    );
+
+    // Verify state gauge
+    assert_gauge_exists("circuitbreaker_state");
+    assert_metric_has_label("circuitbreaker_state", "circuitbreaker", "test_cb");
+
+    // Verify duration histogram
+    assert_histogram_exists("circuitbreaker_call_duration_seconds");
+    assert_metric_has_label(
+        "circuitbreaker_call_duration_seconds",
+        "circuitbreaker",
+        "test_cb",
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn circuitbreaker_slow_call_metrics() {
+    init_recorder();
+
+    // Create a circuit breaker with slow call detection
+    let layer = CircuitBreakerLayer::builder()
+        .name("slow_cb")
+        .slow_call_duration_threshold(Duration::from_millis(50))
+        .slow_call_rate_threshold(0.5)
+        .sliding_window_size(4)
+        .minimum_number_of_calls(2)
+        .build();
+
+    let service = tower::service_fn(move |req: u64| async move {
+        if req.is_multiple_of(2) {
+            tokio::time::sleep(Duration::from_millis(60)).await;
+        }
+        Ok::<_, &'static str>("success")
+    });
+
+    let mut service = layer.layer(service);
+
+    // Make some calls, some will be slow
+    for i in 0..4 {
+        let _ = service.ready().await.unwrap().call(i).await;
+    }
+
+    // Verify slow call counter exists
+    assert_counter_exists("circuitbreaker_slow_calls_total");
+    assert_metric_has_label(
+        "circuitbreaker_slow_calls_total",
+        "circuitbreaker",
+        "slow_cb",
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn circuitbreaker_state_transition_labels() {
+    init_recorder();
+
+    let layer = CircuitBreakerLayer::builder()
+        .name("transition_cb")
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(4)
+        .minimum_number_of_calls(2)
+        .wait_duration_in_open(Duration::from_millis(50))
+        .permitted_calls_in_half_open(1)
+        .build();
+
+    let fail_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let fail_count_clone = fail_count.clone();
+    let service = tower::service_fn(move |_: u64| {
+        let count = fail_count_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        async move {
+            if count < 3 {
+                Err::<&'static str, _>("failure")
+            } else {
+                Ok("success")
+            }
+        }
+    });
+
+    let mut service = layer.layer(service);
+
+    // Generate failures to trigger Closed -> Open transition
+    for i in 0..3 {
+        let _ = service.ready().await.unwrap().call(i).await;
+    }
+
+    // Wait for circuit to enter half-open
+    tokio::time::sleep(Duration::from_millis(60)).await;
+
+    // Make a successful call to trigger Open -> HalfOpen -> Closed transitions
+    let _ = service.ready().await.unwrap().call(100).await;
+
+    // Verify transition labels exist
+    assert_metric_has_label("circuitbreaker_transitions_total", "from", "Closed");
+    assert_metric_has_label("circuitbreaker_transitions_total", "to", "Open");
+}

--- a/tests/metrics_regression/core.rs
+++ b/tests/metrics_regression/core.rs
@@ -1,0 +1,4 @@
+//! Core metrics regression tests
+//!
+//! The core crate doesn't emit metrics directly - it provides infrastructure
+//! for other patterns to use. This module exists for completeness but has no tests.

--- a/tests/metrics_regression/ratelimiter.rs
+++ b/tests/metrics_regression/ratelimiter.rs
@@ -1,0 +1,66 @@
+//! Rate limiter metrics regression tests
+
+use super::helpers::*;
+use serial_test::serial;
+
+use std::time::Duration;
+use tower::{Layer, Service, ServiceExt};
+use tower_resilience_ratelimiter::RateLimiterLayer;
+
+#[tokio::test]
+#[serial]
+async fn ratelimiter_metrics_exist() {
+    init_recorder();
+
+    let layer = RateLimiterLayer::builder()
+        .name("test_ratelimiter")
+        .limit_for_period(10)
+        .refresh_period(Duration::from_secs(1))
+        .build();
+
+    let service = tower::service_fn(|_: u64| async { Ok::<_, &'static str>("success") });
+
+    let mut service = layer.layer(service);
+
+    // Make some calls
+    for i in 0..3 {
+        let _ = service.ready().await.unwrap().call(i).await;
+    }
+
+    // Verify counter metrics
+    assert_counter_exists("ratelimiter_calls_total");
+    assert_metric_has_label("ratelimiter_calls_total", "ratelimiter", "test_ratelimiter");
+    assert_metric_has_label("ratelimiter_calls_total", "result", "permitted");
+
+    // Verify histogram metric
+    assert_histogram_exists("ratelimiter_wait_duration_seconds");
+    assert_metric_has_label(
+        "ratelimiter_wait_duration_seconds",
+        "ratelimiter",
+        "test_ratelimiter",
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn ratelimiter_rejection_metrics() {
+    init_recorder();
+
+    let layer = RateLimiterLayer::builder()
+        .name("reject_ratelimiter")
+        .limit_for_period(2)
+        .refresh_period(Duration::from_secs(10))
+        .build();
+
+    let service = tower::service_fn(|_: u64| async { Ok::<_, &'static str>("success") });
+
+    let mut service = layer.layer(service);
+
+    // Make many rapid calls to trigger rejections (more than limit_for_period)
+    for i in 0..20 {
+        let _ = service.ready().await.unwrap().call(i).await;
+    }
+
+    // Verify rejection label exists
+    assert_metric_has_label("ratelimiter_calls_total", "result", "rejected");
+}

--- a/tests/metrics_regression/retry.rs
+++ b/tests/metrics_regression/retry.rs
@@ -1,0 +1,72 @@
+//! Retry metrics regression tests
+
+use super::helpers::*;
+use serial_test::serial;
+use std::time::Duration;
+use tower::{Layer, Service, ServiceExt};
+use tower_resilience_retry::RetryLayer;
+
+#[tokio::test]
+#[serial]
+async fn retry_metrics_exist() {
+    init_recorder();
+
+    let layer = RetryLayer::builder()
+        .name("test_retry")
+        .max_attempts(3)
+        .fixed_backoff(Duration::from_millis(10))
+        .build();
+
+    let counter = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let counter_clone = counter.clone();
+    let service = tower::service_fn(move |_: u64| {
+        let c = counter_clone.clone();
+        async move {
+            let count = c.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if count < 2 {
+                Err::<&'static str, _>("failure")
+            } else {
+                Ok("success")
+            }
+        }
+    });
+
+    let mut service = layer.layer(service);
+
+    // Make a call that will retry and eventually succeed
+    let _ = service.ready().await.unwrap().call(1).await;
+
+    // Verify counter metrics
+    assert_counter_exists("retry_calls_total");
+    assert_metric_has_label("retry_calls_total", "retry", "test_retry");
+    assert_metric_has_label("retry_calls_total", "result", "success");
+
+    assert_counter_exists("retry_attempts_total");
+    assert_metric_has_label("retry_attempts_total", "retry", "test_retry");
+
+    // Verify histogram metric
+    assert_histogram_exists("retry_attempts");
+    assert_metric_has_label("retry_attempts", "retry", "test_retry");
+}
+
+#[tokio::test]
+#[serial]
+async fn retry_exhausted_metrics() {
+    init_recorder();
+
+    let layer = RetryLayer::builder()
+        .name("exhausted_retry")
+        .max_attempts(2)
+        .fixed_backoff(Duration::from_millis(10))
+        .build();
+
+    let service = tower::service_fn(|_: u64| async { Err::<&'static str, _>("failure") });
+
+    let mut service = layer.layer(service);
+
+    // Make a call that will exhaust retries
+    let _ = service.ready().await.unwrap().call(1).await;
+
+    // Verify exhausted result label
+    assert_metric_has_label("retry_calls_total", "result", "exhausted");
+}

--- a/tests/metrics_regression/timelimiter.rs
+++ b/tests/metrics_regression/timelimiter.rs
@@ -1,0 +1,86 @@
+//! Time limiter metrics regression tests
+
+use super::helpers::*;
+use serial_test::serial;
+use std::time::Duration;
+use tower::{Layer, Service, ServiceExt};
+use tower_resilience_timelimiter::TimeLimiterLayer;
+
+#[tokio::test]
+#[serial]
+async fn timelimiter_metrics_exist() {
+    init_recorder();
+
+    let layer = TimeLimiterLayer::builder()
+        .name("test_timelimiter")
+        .timeout_duration(Duration::from_millis(100))
+        .build();
+
+    let service = tower::service_fn(|_: u64| async {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        Ok::<_, &'static str>("success")
+    });
+
+    let mut service = layer.layer(service);
+
+    // Make a successful call that completes before timeout
+    let _ = service.ready().await.unwrap().call(1).await;
+
+    // Verify counter metrics
+    assert_counter_exists("timelimiter_calls_total");
+    assert_metric_has_label("timelimiter_calls_total", "timelimiter", "test_timelimiter");
+    assert_metric_has_label("timelimiter_calls_total", "result", "success");
+
+    // Verify histogram metric
+    assert_histogram_exists("timelimiter_call_duration_seconds");
+    assert_metric_has_label(
+        "timelimiter_call_duration_seconds",
+        "timelimiter",
+        "test_timelimiter",
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn timelimiter_timeout_metrics() {
+    init_recorder();
+
+    let layer = TimeLimiterLayer::builder()
+        .name("timeout_timelimiter")
+        .timeout_duration(Duration::from_millis(30))
+        .build();
+
+    let service = tower::service_fn(|_: u64| async {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        Ok::<_, &'static str>("success")
+    });
+
+    let mut service = layer.layer(service);
+
+    // Make a call that will timeout
+    let _ = service.ready().await.unwrap().call(1).await;
+
+    // Verify timeout result label
+    assert_metric_has_label("timelimiter_calls_total", "result", "timeout");
+}
+
+#[tokio::test]
+#[serial]
+async fn timelimiter_error_metrics() {
+    init_recorder();
+
+    let layer = TimeLimiterLayer::builder()
+        .name("error_timelimiter")
+        .timeout_duration(Duration::from_millis(100))
+        .build();
+
+    let service = tower::service_fn(|_: u64| async { Err::<&'static str, _>("error") });
+
+    let mut service = layer.layer(service);
+
+    // Make a call that will error
+    let _ = service.ready().await.unwrap().call(1).await;
+
+    // Verify error result label
+    assert_metric_has_label("timelimiter_calls_total", "result", "error");
+}


### PR DESCRIPTION
## Summary

Adds comprehensive metrics regression test suite to ensure metric names, types, and labels remain stable across releases, preventing breaking changes to user dashboards and alerts.

## Changes

- Added  with shared helper infrastructure
- Pattern-specific test modules for 7 patterns:
  - Circuit breaker (3 tests): basic metrics, slow call detection, state transitions
  - Cache (2 tests): hit/miss metrics, eviction metrics  
  - Retry (2 tests): success/exhausted metrics, attempt tracking
  - Rate limiter (2 tests): permit/rejection metrics
  - Time limiter (3 tests): success/timeout/error metrics
  - Chaos (3 tests): error injection, latency injection, passthrough
  - Core: documented (no direct metrics)
  - Bulkhead: documented (complex trait bounds)
- All 15 tests passing with serial_test for isolation
- Added serial_test dev dependency
- Enabled metrics feature for chaos crate in test dependencies

## Testing

```bash
cargo test --test metrics_regression --all-features
```

All tests pass (15 passed; 0 failed)

## Notes

- Metrics are treated as part of the public API
- Breaking changes to metric names/types/labels must be avoided or carefully managed
- Tests use DebuggingRecorder from metrics-util to capture and verify metrics

Closes #125