### PR TITLE
fix: remove CLAUDE.md from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 *.pdb
 Cargo.lock
 .DS_Store
-CLAUDE.md
 .claude/AGENTS.md
 AGENTS.md
 


### PR DESCRIPTION
## Problem

release-plz is failing with this error:
```
the working directory of this project has uncommitted changes. If these files are both committed and in .gitignore, either delete them or remove them from .gitignore. Otherwise, please commit or stash these changes:
   ["CLAUDE.md"]
```

## Root Cause

`CLAUDE.md` is both:
1. Committed to the repository (it provides project-specific instructions for Claude Code)
2. Listed in `.gitignore`

This creates a conflict where the file is tracked but also ignored.

## Solution

Remove `CLAUDE.md` from `.gitignore` since it's an intentionally tracked file that should be committed to the repository.

## Testing

After this merge, release-plz should run successfully without the uncommitted changes error.