### PR TITLE
fix: allow release-plz to run with uncommitted changes

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -5,6 +5,8 @@ git_release_enable = true
 git_tag_enable = true
 # Validate semantic versioning
 semver_check = true
+# Allow uncommitted changes (e.g., CLAUDE.md which is in .gitignore)
+allow_dirty = true
 
 # Generate separate changelogs for each crate
 [[package]]


### PR DESCRIPTION
## Problem

release-plz is failing with:
```
the working directory of this project has uncommitted changes.
["CLAUDE.md"]
```

## Root Cause

`CLAUDE.md` is in `.gitignore` (intentionally - it contains user/session-specific guidance for Claude Code) but may exist in the working directory when release-plz runs, causing it to fail on dirty working directory checks.

## Solution

Configure release-plz with `allow_dirty = true` in `release-plz.toml`. This allows release-plz to proceed when uncommitted files are present.

From the [release-plz docs](https://release-plz.dev/docs/config):
> If set to true, it allows release-plz to update dirty working directories. A directory is considered dirty if it contains uncommitted changes, which will be part of the update.

This option only affects `release-plz update` and `release-plz release-pr` commands, not the actual release/publish process.

## Testing

After this merges, release-plz should run successfully even when CLAUDE.md or other gitignored files exist in the working directory.