### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Overview

Adds Dependabot configuration to automatically keep dependencies up to date while you're away.

## What's Added

**Cargo Dependencies**:
- Weekly updates on Mondays
- Up to 10 open PRs at a time
- Auto-labeled with `dependencies`

**GitHub Actions**:
- Weekly updates on Mondays
- Auto-labeled with `dependencies`

## Benefits

- Automatic security updates
- Keep dependencies current
- Reduces manual maintenance while you're away

## Testing

Configuration follows GitHub's standard dependabot.yml format and should be automatically recognized once merged.