### PR TITLE
feat: add standalone fallback middleware crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ tower-resilience-ratelimiter = { path = "crates/tower-resilience-ratelimiter", f
 tower-resilience-chaos = { path = "crates/tower-resilience-chaos", features = ["metrics"] }
 tower-resilience-reconnect = { path = "crates/tower-resilience-reconnect", features = ["metrics"] }
 tower-resilience-healthcheck = { path = "crates/tower-resilience-healthcheck" }
+tower-resilience-fallback = { path = "crates/tower-resilience-fallback", features = ["metrics"] }
 tower = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 tracing-subscriber = "0.3"
@@ -51,6 +52,7 @@ members = [
     "crates/tower-resilience-chaos",
     "crates/tower-resilience-reconnect",
     "crates/tower-resilience-healthcheck",
+    "crates/tower-resilience-fallback",
     "crates/tower-resilience",
     "examples/axum-resilient-kv-store",
     "examples/tonic-resilient-greeter",

--- a/crates/tower-resilience-fallback/Cargo.toml
+++ b/crates/tower-resilience-fallback/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "tower-resilience-fallback"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+description = "Fallback middleware for Tower services"
+keywords = ["tower", "resilience", "fallback", "fault-tolerance", "middleware"]
+categories = ["asynchronous", "network-programming"]
+
+[features]
+default = []
+metrics = ["dep:metrics"]
+tracing = ["dep:tracing"]
+
+[dependencies]
+tower-resilience-core = { version = "0.4.7", path = "../tower-resilience-core" }
+tower = { workspace = true }
+tower-layer = { workspace = true }
+tower-service = { workspace = true }
+futures = { workspace = true }
+metrics = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time"] }

--- a/crates/tower-resilience-fallback/examples/fallback_example.rs
+++ b/crates/tower-resilience-fallback/examples/fallback_example.rs
@@ -1,0 +1,198 @@
+//! Fallback pattern examples.
+//!
+//! Run with: cargo run --example fallback_example -p tower-resilience-fallback
+//!
+//! This example demonstrates:
+//! - Static value fallback
+//! - Dynamic fallback from error
+//! - Dynamic fallback from request and error
+//! - Service-based fallback
+//! - Selective fallback with predicates
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use tower::{Layer, Service, ServiceExt};
+use tower_resilience_fallback::FallbackLayer;
+
+#[derive(Debug, Clone)]
+struct ServiceError {
+    code: u16,
+    message: String,
+}
+
+impl std::fmt::Display for ServiceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Error {}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for ServiceError {}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Tower Fallback Example");
+    println!("======================\n");
+
+    // Example 1: Static value fallback
+    println!("Example 1: Static value fallback");
+
+    let service = tower::service_fn(|_req: String| async move {
+        println!("  Service called - returning error");
+        Err::<String, _>(ServiceError {
+            code: 500,
+            message: "Internal error".to_string(),
+        })
+    });
+
+    let fallback_layer =
+        FallbackLayer::<String, String, ServiceError>::value("default response".to_string());
+
+    let mut service = fallback_layer.layer(service);
+
+    let result = service.ready().await?.call("request".to_string()).await?;
+    println!("  Result: {}\n", result);
+
+    // Example 2: Fallback from error
+    println!("Example 2: Dynamic fallback from error");
+
+    let service = tower::service_fn(|_req: String| async move {
+        println!("  Service called - returning error");
+        Err::<String, _>(ServiceError {
+            code: 503,
+            message: "Service unavailable".to_string(),
+        })
+    });
+
+    let fallback_layer = FallbackLayer::<String, String, ServiceError>::from_error(|e| {
+        format!("Fallback due to error {}: {}", e.code, e.message)
+    });
+
+    let mut service = fallback_layer.layer(service);
+
+    let result = service.ready().await?.call("request".to_string()).await?;
+    println!("  Result: {}\n", result);
+
+    // Example 3: Fallback from request and error
+    println!("Example 3: Fallback using request context");
+
+    let service = tower::service_fn(|_req: String| async move {
+        println!("  Service called - returning error");
+        Err::<String, _>(ServiceError {
+            code: 404,
+            message: "Not found".to_string(),
+        })
+    });
+
+    let fallback_layer =
+        FallbackLayer::<String, String, ServiceError>::from_request_error(|req, e| {
+            format!("Request '{}' failed with {}: {}", req, e.code, e.message)
+        });
+
+    let mut service = fallback_layer.layer(service);
+
+    let result = service
+        .ready()
+        .await?
+        .call("get-user-123".to_string())
+        .await?;
+    println!("  Result: {}\n", result);
+
+    // Example 4: Service-based fallback
+    println!("Example 4: Service-based fallback");
+
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let cc = Arc::clone(&call_count);
+
+    let service = tower::service_fn(move |_req: String| {
+        let cc = Arc::clone(&cc);
+        async move {
+            let count = cc.fetch_add(1, Ordering::SeqCst);
+            println!("  Primary service called (attempt {})", count + 1);
+            Err::<String, _>(ServiceError {
+                code: 500,
+                message: "Primary failed".to_string(),
+            })
+        }
+    });
+
+    let fallback_layer = FallbackLayer::<String, String, ServiceError>::service(|req| {
+        Box::pin(async move {
+            println!("  Fallback service called");
+            Ok(format!("Fallback handled: {}", req))
+        })
+    });
+
+    let mut service = fallback_layer.layer(service);
+
+    let result = service
+        .ready()
+        .await?
+        .call("important-request".to_string())
+        .await?;
+    println!("  Result: {}\n", result);
+
+    // Example 5: Selective fallback with predicate
+    println!("Example 5: Selective fallback (only for 5xx errors)");
+
+    let service = tower::service_fn(|req: String| async move {
+        println!("  Service called with: {}", req);
+        if req.contains("client") {
+            Err::<String, _>(ServiceError {
+                code: 400,
+                message: "Bad request".to_string(),
+            })
+        } else {
+            Err(ServiceError {
+                code: 503,
+                message: "Service unavailable".to_string(),
+            })
+        }
+    });
+
+    let fallback_layer = FallbackLayer::<String, String, ServiceError>::builder()
+        .value("fallback for server errors".to_string())
+        .handle(|e: &ServiceError| e.code >= 500) // Only handle 5xx errors
+        .build();
+
+    let mut service = fallback_layer.layer(service);
+
+    // This should use fallback (503 error)
+    println!("  Request 'server-error':");
+    let result = service
+        .ready()
+        .await?
+        .call("server-error".to_string())
+        .await;
+    println!("  Result: {:?}", result);
+
+    // This should NOT use fallback (400 error) - error passes through
+    println!("  Request 'client-error':");
+    let result = service
+        .ready()
+        .await?
+        .call("client-error".to_string())
+        .await;
+    println!("  Result: {:?}\n", result);
+
+    // Example 6: Fallback when primary succeeds (no fallback triggered)
+    println!("Example 6: No fallback when primary succeeds");
+
+    let service = tower::service_fn(|req: String| async move {
+        println!("  Service called - returning success");
+        Ok::<_, ServiceError>(format!("Primary response for: {}", req))
+    });
+
+    let fallback_layer =
+        FallbackLayer::<String, String, ServiceError>::value("this won't be used".to_string());
+
+    let mut service = fallback_layer.layer(service);
+
+    let result = service
+        .ready()
+        .await?
+        .call("successful-request".to_string())
+        .await?;
+    println!("  Result: {}\n", result);
+
+    Ok(())
+}

--- a/crates/tower-resilience-fallback/src/config.rs
+++ b/crates/tower-resilience-fallback/src/config.rs
@@ -1,0 +1,130 @@
+//! Configuration for the fallback service.
+
+use crate::{FallbackEvent, FallbackStrategy, HandlePredicate};
+use tower_resilience_core::{EventListeners, FnListener};
+
+/// Configuration for the fallback service.
+pub struct FallbackConfig<Req, Res, E> {
+    pub(crate) name: String,
+    pub(crate) strategy: FallbackStrategy<Req, Res, E>,
+    pub(crate) handle_predicate: Option<HandlePredicate<E>>,
+    pub(crate) event_listeners: EventListeners<FallbackEvent>,
+}
+
+/// Builder for constructing a [`FallbackLayer`](crate::FallbackLayer).
+pub struct FallbackConfigBuilder<Req, Res, E> {
+    name: String,
+    strategy: Option<FallbackStrategy<Req, Res, E>>,
+    handle_predicate: Option<HandlePredicate<E>>,
+    event_listeners: EventListeners<FallbackEvent>,
+}
+
+impl<Req, Res, E> Default for FallbackConfigBuilder<Req, Res, E> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Req, Res, E> FallbackConfigBuilder<Req, Res, E> {
+    /// Creates a new builder with default settings.
+    pub fn new() -> Self {
+        Self {
+            name: "fallback".to_string(),
+            strategy: None,
+            handle_predicate: None,
+            event_listeners: EventListeners::new(),
+        }
+    }
+
+    /// Sets the name for this fallback instance (used in metrics and events).
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    /// Sets a static fallback value.
+    pub fn value(mut self, value: Res) -> Self
+    where
+        Res: Clone,
+    {
+        self.strategy = Some(FallbackStrategy::Value(value));
+        self
+    }
+
+    /// Sets a fallback function that computes a response from the error.
+    pub fn from_error<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&E) -> Res + Send + Sync + 'static,
+    {
+        self.strategy = Some(FallbackStrategy::FromError(std::sync::Arc::new(f)));
+        self
+    }
+
+    /// Sets a fallback function that has access to both request and error.
+    pub fn from_request_error<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&Req, &E) -> Res + Send + Sync + 'static,
+    {
+        self.strategy = Some(FallbackStrategy::FromRequestError(std::sync::Arc::new(f)));
+        self
+    }
+
+    /// Sets a backup service to call on failure.
+    pub fn service<S, Fut>(mut self, service: S) -> Self
+    where
+        S: Fn(Req) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = Result<Res, E>> + Send + 'static,
+    {
+        self.strategy = Some(FallbackStrategy::Service(std::sync::Arc::new(move |req| {
+            Box::pin(service(req))
+        })));
+        self
+    }
+
+    /// Sets an error transformation function.
+    pub fn exception<F>(mut self, f: F) -> Self
+    where
+        F: Fn(E) -> E + Send + Sync + 'static,
+    {
+        self.strategy = Some(FallbackStrategy::Exception(std::sync::Arc::new(f)));
+        self
+    }
+
+    /// Only trigger fallback for errors matching this predicate.
+    ///
+    /// Errors that don't match the predicate will be propagated as-is.
+    pub fn handle<F>(mut self, predicate: F) -> Self
+    where
+        F: Fn(&E) -> bool + Send + Sync + 'static,
+    {
+        self.handle_predicate = Some(std::sync::Arc::new(predicate));
+        self
+    }
+
+    /// Adds an event listener.
+    pub fn on_event<F>(mut self, listener: F) -> Self
+    where
+        F: Fn(&FallbackEvent) + Send + Sync + 'static,
+    {
+        self.event_listeners.add(FnListener::new(listener));
+        self
+    }
+
+    /// Builds the fallback layer.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no fallback strategy was configured.
+    pub fn build(self) -> crate::FallbackLayer<Req, Res, E>
+    where
+        Res: Clone,
+    {
+        let config = FallbackConfig {
+            name: self.name,
+            strategy: self.strategy.expect("fallback strategy must be set"),
+            handle_predicate: self.handle_predicate,
+            event_listeners: self.event_listeners,
+        };
+        crate::FallbackLayer::new(config)
+    }
+}

--- a/crates/tower-resilience-fallback/src/error.rs
+++ b/crates/tower-resilience-fallback/src/error.rs
@@ -1,0 +1,77 @@
+//! Error types for the fallback service.
+
+use std::fmt;
+
+/// Error type for the fallback service.
+#[derive(Debug)]
+pub enum FallbackError<E> {
+    /// The inner service failed and no fallback was applied (predicate didn't match),
+    /// or the error was transformed via the exception strategy.
+    Inner(E),
+
+    /// The fallback service itself failed.
+    FallbackFailed(E),
+}
+
+impl<E> FallbackError<E> {
+    /// Returns `true` if this is an inner service error.
+    pub fn is_inner(&self) -> bool {
+        matches!(self, Self::Inner(_))
+    }
+
+    /// Returns `true` if the fallback itself failed.
+    pub fn is_fallback_failed(&self) -> bool {
+        matches!(self, Self::FallbackFailed(_))
+    }
+
+    /// Converts into the inner error.
+    pub fn into_inner(self) -> E {
+        match self {
+            Self::Inner(e) | Self::FallbackFailed(e) => e,
+        }
+    }
+
+    /// Returns a reference to the inner error.
+    pub fn inner(&self) -> &E {
+        match self {
+            Self::Inner(e) | Self::FallbackFailed(e) => e,
+        }
+    }
+
+    /// Maps the inner error using the provided function.
+    pub fn map<F, U>(self, f: F) -> FallbackError<U>
+    where
+        F: FnOnce(E) -> U,
+    {
+        match self {
+            Self::Inner(e) => FallbackError::Inner(f(e)),
+            Self::FallbackFailed(e) => FallbackError::FallbackFailed(f(e)),
+        }
+    }
+}
+
+impl<E: Clone> Clone for FallbackError<E> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Inner(e) => Self::Inner(e.clone()),
+            Self::FallbackFailed(e) => Self::FallbackFailed(e.clone()),
+        }
+    }
+}
+
+impl<E: fmt::Display> fmt::Display for FallbackError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Inner(e) => write!(f, "inner service error: {}", e),
+            Self::FallbackFailed(e) => write!(f, "fallback failed: {}", e),
+        }
+    }
+}
+
+impl<E: std::error::Error + 'static> std::error::Error for FallbackError<E> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Inner(e) | Self::FallbackFailed(e) => Some(e),
+        }
+    }
+}

--- a/crates/tower-resilience-fallback/src/events.rs
+++ b/crates/tower-resilience-fallback/src/events.rs
@@ -1,0 +1,82 @@
+//! Events emitted by the fallback service.
+
+use std::time::Instant;
+use tower_resilience_core::ResilienceEvent;
+
+/// Events emitted by the fallback service.
+#[derive(Debug, Clone)]
+pub enum FallbackEvent {
+    /// The inner service succeeded; no fallback was needed.
+    Success {
+        /// Name of the fallback instance.
+        pattern_name: String,
+        /// When the event occurred.
+        timestamp: Instant,
+    },
+
+    /// The inner service failed; fallback will be attempted.
+    FailedAttempt {
+        /// Name of the fallback instance.
+        pattern_name: String,
+        /// When the event occurred.
+        timestamp: Instant,
+    },
+
+    /// The fallback was successfully applied.
+    Applied {
+        /// Name of the fallback instance.
+        pattern_name: String,
+        /// When the event occurred.
+        timestamp: Instant,
+        /// The strategy that was applied.
+        strategy: &'static str,
+    },
+
+    /// The fallback itself failed (only possible with service fallback).
+    Failed {
+        /// Name of the fallback instance.
+        pattern_name: String,
+        /// When the event occurred.
+        timestamp: Instant,
+    },
+
+    /// The error didn't match the predicate; propagated as-is.
+    Skipped {
+        /// Name of the fallback instance.
+        pattern_name: String,
+        /// When the event occurred.
+        timestamp: Instant,
+    },
+}
+
+impl ResilienceEvent for FallbackEvent {
+    fn event_type(&self) -> &'static str {
+        match self {
+            Self::Success { .. } => "success",
+            Self::FailedAttempt { .. } => "failed_attempt",
+            Self::Applied { .. } => "applied",
+            Self::Failed { .. } => "failed",
+            Self::Skipped { .. } => "skipped",
+        }
+    }
+
+    fn timestamp(&self) -> Instant {
+        match self {
+            Self::Success { timestamp, .. }
+            | Self::FailedAttempt { timestamp, .. }
+            | Self::Applied { timestamp, .. }
+            | Self::Failed { timestamp, .. }
+            | Self::Skipped { timestamp, .. } => *timestamp,
+        }
+    }
+
+    fn pattern_name(&self) -> &str {
+        match self {
+            Self::Success { pattern_name, .. }
+            | Self::FailedAttempt { pattern_name, .. }
+            | Self::Applied { pattern_name, .. }
+            | Self::Failed { pattern_name, .. }
+            | Self::Skipped { pattern_name, .. } => pattern_name,
+        }
+    }
+}

--- a/crates/tower-resilience-fallback/src/layer.rs
+++ b/crates/tower-resilience-fallback/src/layer.rs
@@ -1,0 +1,153 @@
+//! Tower layer for fallback.
+
+use crate::config::{FallbackConfig, FallbackConfigBuilder};
+use crate::Fallback;
+use std::sync::Arc;
+use tower::layer::Layer;
+
+/// A Tower layer that applies fallback behavior to a service.
+///
+/// See the [module-level documentation](crate) for usage examples.
+pub struct FallbackLayer<Req, Res, E> {
+    config: Arc<FallbackConfig<Req, Res, E>>,
+}
+
+impl<Req, Res, E> FallbackLayer<Req, Res, E> {
+    /// Creates a new fallback layer from the given configuration.
+    pub(crate) fn new(config: FallbackConfig<Req, Res, E>) -> Self {
+        Self {
+            config: Arc::new(config),
+        }
+    }
+
+    /// Creates a new builder for configuring a fallback layer.
+    pub fn builder() -> FallbackConfigBuilder<Req, Res, E> {
+        FallbackConfigBuilder::new()
+    }
+}
+
+// Convenience constructors for common patterns
+impl<Req, Res, E> FallbackLayer<Req, Res, E>
+where
+    Res: Clone,
+{
+    /// Creates a fallback layer that returns a static value on failure.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_resilience_fallback::FallbackLayer;
+    ///
+    /// # #[derive(Debug, Clone)]
+    /// # struct MyError;
+    /// let layer = FallbackLayer::<String, String, MyError>::value("default".to_string());
+    /// ```
+    pub fn value(value: Res) -> Self {
+        FallbackConfigBuilder::new().value(value).build()
+    }
+
+    /// Creates a fallback layer that computes a response from the error.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_resilience_fallback::FallbackLayer;
+    ///
+    /// # #[derive(Debug, Clone)]
+    /// # struct MyError { msg: String }
+    /// let layer = FallbackLayer::<String, String, MyError>::from_error(|e| {
+    ///     format!("Error: {}", e.msg)
+    /// });
+    /// ```
+    pub fn from_error<F>(f: F) -> Self
+    where
+        F: Fn(&E) -> Res + Send + Sync + 'static,
+    {
+        FallbackConfigBuilder::new().from_error(f).build()
+    }
+
+    /// Creates a fallback layer that computes a response from request and error.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_resilience_fallback::FallbackLayer;
+    ///
+    /// # #[derive(Debug, Clone)]
+    /// # struct MyError;
+    /// let layer = FallbackLayer::<String, String, MyError>::from_request_error(|req, _err| {
+    ///     format!("Fallback for request: {}", req)
+    /// });
+    /// ```
+    pub fn from_request_error<F>(f: F) -> Self
+    where
+        F: Fn(&Req, &E) -> Res + Send + Sync + 'static,
+    {
+        FallbackConfigBuilder::new().from_request_error(f).build()
+    }
+
+    /// Creates a fallback layer that routes to a backup service.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_resilience_fallback::FallbackLayer;
+    ///
+    /// # #[derive(Debug, Clone)]
+    /// # struct MyError;
+    /// let layer = FallbackLayer::<String, String, MyError>::service(|req: String| async move {
+    ///     Ok::<_, MyError>(format!("backup: {}", req))
+    /// });
+    /// ```
+    pub fn service<S, Fut>(service: S) -> Self
+    where
+        S: Fn(Req) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = Result<Res, E>> + Send + 'static,
+    {
+        FallbackConfigBuilder::new().service(service).build()
+    }
+
+    /// Creates a fallback layer that transforms errors.
+    ///
+    /// Note: This still returns an error, just a transformed one.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_resilience_fallback::FallbackLayer;
+    ///
+    /// # #[derive(Debug, Clone)]
+    /// # struct MyError { code: u32 }
+    /// let layer = FallbackLayer::<String, String, MyError>::exception(|e| {
+    ///     MyError { code: 500 }
+    /// });
+    /// ```
+    pub fn exception<F>(f: F) -> Self
+    where
+        F: Fn(E) -> E + Send + Sync + 'static,
+    {
+        FallbackConfigBuilder::new().exception(f).build()
+    }
+}
+
+impl<Req, Res, E> Clone for FallbackLayer<Req, Res, E>
+where
+    Res: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            config: Arc::clone(&self.config),
+        }
+    }
+}
+
+impl<S, Req, Res, E> Layer<S> for FallbackLayer<Req, Res, E>
+where
+    Res: Clone,
+{
+    type Service = Fallback<S, Req, Res, E>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        Fallback::new(service, Arc::clone(&self.config))
+    }
+}

--- a/crates/tower-resilience-fallback/src/lib.rs
+++ b/crates/tower-resilience-fallback/src/lib.rs
@@ -1,0 +1,742 @@
+//! Fallback middleware for Tower services.
+//!
+//! Provides alternative responses when the inner service fails, enabling
+//! graceful degradation and backup service routing.
+//!
+//! # Overview
+//!
+//! The fallback pattern allows you to provide alternative responses when your
+//! primary service fails. This is useful for:
+//!
+//! - Returning cached or stale data when the primary source is unavailable
+//! - Providing degraded functionality instead of complete failure
+//! - Routing to backup services
+//! - Transforming errors into user-friendly responses
+//!
+//! # Fallback Strategies
+//!
+//! ## Static Value
+//!
+//! Return a fixed value when the service fails:
+//!
+//! ```rust
+//! use tower_resilience_fallback::FallbackLayer;
+//! use tower::ServiceBuilder;
+//!
+//! # #[derive(Debug, Clone)]
+//! # struct MyError;
+//! let layer = FallbackLayer::<String, String, MyError>::value("default response".to_string());
+//! ```
+//!
+//! ## Fallback Function
+//!
+//! Compute a response based on the error:
+//!
+//! ```rust
+//! use tower_resilience_fallback::FallbackLayer;
+//!
+//! # #[derive(Debug, Clone)]
+//! # struct MyError { message: String }
+//! let layer = FallbackLayer::<String, String, MyError>::from_error(|error: &MyError| {
+//!     format!("Service unavailable: {}", error.message)
+//! });
+//! ```
+//!
+//! ## Fallback with Request Context
+//!
+//! Access both the original request and error:
+//!
+//! ```rust
+//! use tower_resilience_fallback::FallbackLayer;
+//! use std::sync::Arc;
+//! use std::collections::HashMap;
+//!
+//! # #[derive(Debug, Clone)]
+//! # struct MyError;
+//! let cache: Arc<HashMap<String, String>> = Arc::new(HashMap::new());
+//! let cache_clone = Arc::clone(&cache);
+//!
+//! let layer = FallbackLayer::<String, String, MyError>::from_request_error(move |req: &String, _err: &MyError| {
+//!     cache_clone.get(req).cloned().unwrap_or_else(|| "not found".to_string())
+//! });
+//! ```
+//!
+//! ## Backup Service
+//!
+//! Route to an alternative service (async):
+//!
+//! ```rust
+//! use tower_resilience_fallback::FallbackLayer;
+//!
+//! # #[derive(Debug, Clone)]
+//! # struct MyError;
+//! let layer = FallbackLayer::<String, String, MyError>::service(|req: String| async move {
+//!     Ok::<_, MyError>(format!("backup: {}", req))
+//! });
+//! ```
+//!
+//! ## Error Transformation
+//!
+//! Convert errors to a different type (still returns error, not success):
+//!
+//! ```rust
+//! use tower_resilience_fallback::FallbackLayer;
+//!
+//! # #[derive(Debug, Clone)]
+//! # struct InternalError { code: u32 }
+//! // Note: This changes the error type, so layer types must align
+//! let layer = FallbackLayer::<String, String, InternalError>::exception(|err: InternalError| {
+//!     InternalError { code: 500 } // Transform but still error
+//! });
+//! ```
+//!
+//! # Selective Error Handling
+//!
+//! Only trigger fallback for specific errors:
+//!
+//! ```rust
+//! use tower_resilience_fallback::FallbackLayer;
+//!
+//! # #[derive(Debug, Clone)]
+//! # struct MyError { retryable: bool }
+//! let layer: FallbackLayer<String, String, MyError> = FallbackLayer::builder()
+//!     .value("fallback".to_string())
+//!     .handle(|e: &MyError| e.retryable) // Only fallback on retryable errors
+//!     .build();
+//! ```
+//!
+//! # Composition with Other Layers
+//!
+//! Fallback works well with other resilience patterns:
+//!
+//! ```rust
+//! use tower_resilience_fallback::FallbackLayer;
+//! use tower::ServiceBuilder;
+//!
+//! # #[derive(Debug, Clone)]
+//! # struct MyError;
+//! # async fn example() {
+//! // Fallback catches anything that escapes retry + circuit breaker
+//! let service = ServiceBuilder::new()
+//!     .layer(FallbackLayer::<String, String, MyError>::value("unavailable".to_string()))
+//!     // .layer(CircuitBreakerLayer::new(cb_config))
+//!     // .layer(RetryLayer::new(retry_config))
+//!     .service(tower::service_fn(|req: String| async move {
+//!         Ok::<_, MyError>(req)
+//!     }));
+//! # }
+//! ```
+//!
+//! # Events
+//!
+//! The fallback service emits events for observability:
+//!
+//! - `Success`: Inner service succeeded, no fallback needed
+//! - `FailedAttempt`: Inner service failed, fallback will be attempted
+//! - `Applied`: Fallback was successfully applied
+//! - `Failed`: Fallback itself failed (service fallback only)
+//! - `Skipped`: Error didn't match predicate, propagated as-is
+
+mod config;
+mod error;
+mod events;
+mod layer;
+
+pub use config::{FallbackConfig, FallbackConfigBuilder};
+pub use error::FallbackError;
+pub use events::FallbackEvent;
+pub use layer::FallbackLayer;
+
+use futures::future::BoxFuture;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Instant;
+use tower::Service;
+
+#[cfg(feature = "metrics")]
+use metrics::{counter, describe_counter};
+
+#[cfg(feature = "metrics")]
+use std::sync::Once;
+
+#[cfg(feature = "metrics")]
+static METRICS_INIT: Once = Once::new();
+
+/// Function that computes a fallback response from an error.
+pub type FromErrorFn<Res, E> = Arc<dyn Fn(&E) -> Res + Send + Sync>;
+
+/// Function that computes a fallback response from request and error.
+pub type FromRequestErrorFn<Req, Res, E> = Arc<dyn Fn(&Req, &E) -> Res + Send + Sync>;
+
+/// Function that calls a backup service asynchronously.
+pub type ServiceFn<Req, Res, E> =
+    Arc<dyn Fn(Req) -> BoxFuture<'static, Result<Res, E>> + Send + Sync>;
+
+/// Function that transforms an error into a different error.
+pub type ExceptionFn<E> = Arc<dyn Fn(E) -> E + Send + Sync>;
+
+/// The strategy used to produce a fallback response.
+pub enum FallbackStrategy<Req, Res, E> {
+    /// Return a static value (cloned for each fallback).
+    Value(Res),
+
+    /// Compute a response from the error.
+    FromError(FromErrorFn<Res, E>),
+
+    /// Compute a response from both the request and error.
+    FromRequestError(FromRequestErrorFn<Req, Res, E>),
+
+    /// Call a backup service asynchronously.
+    /// The function takes the request and returns a future.
+    Service(ServiceFn<Req, Res, E>),
+
+    /// Transform the error into a different error (still fails, but with transformed error).
+    Exception(ExceptionFn<E>),
+}
+
+impl<Req, Res, E> Clone for FallbackStrategy<Req, Res, E>
+where
+    Res: Clone,
+{
+    fn clone(&self) -> Self {
+        match self {
+            Self::Value(v) => Self::Value(v.clone()),
+            Self::FromError(f) => Self::FromError(Arc::clone(f)),
+            Self::FromRequestError(f) => Self::FromRequestError(Arc::clone(f)),
+            Self::Service(s) => Self::Service(Arc::clone(s)),
+            Self::Exception(f) => Self::Exception(Arc::clone(f)),
+        }
+    }
+}
+
+/// Predicate to determine if an error should trigger the fallback.
+pub type HandlePredicate<E> = Arc<dyn Fn(&E) -> bool + Send + Sync>;
+
+/// A Tower service that provides fallback responses when the inner service fails.
+///
+/// See the [module-level documentation](crate) for usage examples.
+pub struct Fallback<S, Req, Res, E> {
+    inner: S,
+    config: Arc<FallbackConfig<Req, Res, E>>,
+}
+
+impl<S, Req, Res, E> Fallback<S, Req, Res, E> {
+    /// Creates a new `Fallback` service wrapping the given service.
+    pub fn new(inner: S, config: Arc<FallbackConfig<Req, Res, E>>) -> Self {
+        #[cfg(feature = "metrics")]
+        METRICS_INIT.call_once(|| {
+            describe_counter!(
+                "fallback_calls_total",
+                "Total number of fallback operations"
+            );
+        });
+
+        Self { inner, config }
+    }
+}
+
+impl<S, Req, Res, E> Clone for Fallback<S, Req, Res, E>
+where
+    S: Clone,
+    Res: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            config: Arc::clone(&self.config),
+        }
+    }
+}
+
+impl<S, Req, Res, E> Service<Req> for Fallback<S, Req, Res, E>
+where
+    S: Service<Req, Response = Res, Error = E> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    Req: Clone + Send + Sync + 'static,
+    Res: Clone + Send + Sync + 'static,
+    E: Clone + Send + Sync + 'static,
+{
+    type Response = Res;
+    type Error = FallbackError<E>;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(FallbackError::Inner)
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        let mut service = self.inner.clone();
+        let config = Arc::clone(&self.config);
+        let req_clone = req.clone();
+
+        Box::pin(async move {
+            #[cfg(feature = "tracing")]
+            tracing::debug!(fallback = %config.name, "Calling inner service");
+
+            let result = service.call(req).await;
+
+            match result {
+                Ok(response) => {
+                    #[cfg(feature = "tracing")]
+                    tracing::debug!(fallback = %config.name, "Inner service succeeded");
+
+                    #[cfg(feature = "metrics")]
+                    counter!(
+                        "fallback_calls_total",
+                        "fallback" => config.name.clone(),
+                        "result" => "success"
+                    )
+                    .increment(1);
+
+                    let event = FallbackEvent::Success {
+                        pattern_name: config.name.clone(),
+                        timestamp: Instant::now(),
+                    };
+                    config.event_listeners.emit(&event);
+
+                    Ok(response)
+                }
+                Err(error) => {
+                    // Check if we should handle this error
+                    let should_handle = config
+                        .handle_predicate
+                        .as_ref()
+                        .map(|p| p(&error))
+                        .unwrap_or(true);
+
+                    if !should_handle {
+                        #[cfg(feature = "tracing")]
+                        tracing::debug!(
+                            fallback = %config.name,
+                            "Error does not match predicate, skipping fallback"
+                        );
+
+                        #[cfg(feature = "metrics")]
+                        counter!(
+                            "fallback_calls_total",
+                            "fallback" => config.name.clone(),
+                            "result" => "skipped"
+                        )
+                        .increment(1);
+
+                        let event = FallbackEvent::Skipped {
+                            pattern_name: config.name.clone(),
+                            timestamp: Instant::now(),
+                        };
+                        config.event_listeners.emit(&event);
+
+                        return Err(FallbackError::Inner(error));
+                    }
+
+                    #[cfg(feature = "tracing")]
+                    tracing::debug!(fallback = %config.name, "Inner service failed, applying fallback");
+
+                    // Emit failed attempt event
+                    let event = FallbackEvent::FailedAttempt {
+                        pattern_name: config.name.clone(),
+                        timestamp: Instant::now(),
+                    };
+                    config.event_listeners.emit(&event);
+
+                    // Apply fallback strategy
+                    match &config.strategy {
+                        FallbackStrategy::Value(v) => {
+                            #[cfg(feature = "metrics")]
+                            counter!(
+                                "fallback_calls_total",
+                                "fallback" => config.name.clone(),
+                                "result" => "applied",
+                                "strategy" => "value"
+                            )
+                            .increment(1);
+
+                            let event = FallbackEvent::Applied {
+                                pattern_name: config.name.clone(),
+                                timestamp: Instant::now(),
+                                strategy: "value",
+                            };
+                            config.event_listeners.emit(&event);
+
+                            Ok(v.clone())
+                        }
+
+                        FallbackStrategy::FromError(f) => {
+                            let response = f(&error);
+
+                            #[cfg(feature = "metrics")]
+                            counter!(
+                                "fallback_calls_total",
+                                "fallback" => config.name.clone(),
+                                "result" => "applied",
+                                "strategy" => "from_error"
+                            )
+                            .increment(1);
+
+                            let event = FallbackEvent::Applied {
+                                pattern_name: config.name.clone(),
+                                timestamp: Instant::now(),
+                                strategy: "from_error",
+                            };
+                            config.event_listeners.emit(&event);
+
+                            Ok(response)
+                        }
+
+                        FallbackStrategy::FromRequestError(f) => {
+                            let response = f(&req_clone, &error);
+
+                            #[cfg(feature = "metrics")]
+                            counter!(
+                                "fallback_calls_total",
+                                "fallback" => config.name.clone(),
+                                "result" => "applied",
+                                "strategy" => "from_request_error"
+                            )
+                            .increment(1);
+
+                            let event = FallbackEvent::Applied {
+                                pattern_name: config.name.clone(),
+                                timestamp: Instant::now(),
+                                strategy: "from_request_error",
+                            };
+                            config.event_listeners.emit(&event);
+
+                            Ok(response)
+                        }
+
+                        FallbackStrategy::Service(backup) => {
+                            #[cfg(feature = "tracing")]
+                            tracing::debug!(fallback = %config.name, "Calling backup service");
+
+                            match backup(req_clone).await {
+                                Ok(response) => {
+                                    #[cfg(feature = "metrics")]
+                                    counter!(
+                                        "fallback_calls_total",
+                                        "fallback" => config.name.clone(),
+                                        "result" => "applied",
+                                        "strategy" => "service"
+                                    )
+                                    .increment(1);
+
+                                    let event = FallbackEvent::Applied {
+                                        pattern_name: config.name.clone(),
+                                        timestamp: Instant::now(),
+                                        strategy: "service",
+                                    };
+                                    config.event_listeners.emit(&event);
+
+                                    Ok(response)
+                                }
+                                Err(backup_error) => {
+                                    #[cfg(feature = "tracing")]
+                                    tracing::warn!(
+                                        fallback = %config.name,
+                                        "Backup service also failed"
+                                    );
+
+                                    #[cfg(feature = "metrics")]
+                                    counter!(
+                                        "fallback_calls_total",
+                                        "fallback" => config.name.clone(),
+                                        "result" => "failed",
+                                        "strategy" => "service"
+                                    )
+                                    .increment(1);
+
+                                    let event = FallbackEvent::Failed {
+                                        pattern_name: config.name.clone(),
+                                        timestamp: Instant::now(),
+                                    };
+                                    config.event_listeners.emit(&event);
+
+                                    Err(FallbackError::FallbackFailed(backup_error))
+                                }
+                            }
+                        }
+
+                        FallbackStrategy::Exception(transform) => {
+                            let transformed = transform(error);
+
+                            #[cfg(feature = "metrics")]
+                            counter!(
+                                "fallback_calls_total",
+                                "fallback" => config.name.clone(),
+                                "result" => "transformed",
+                                "strategy" => "exception"
+                            )
+                            .increment(1);
+
+                            let event = FallbackEvent::Applied {
+                                pattern_name: config.name.clone(),
+                                timestamp: Instant::now(),
+                                strategy: "exception",
+                            };
+                            config.event_listeners.emit(&event);
+
+                            Err(FallbackError::Inner(transformed))
+                        }
+                    }
+                }
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tower::{service_fn, Layer, ServiceExt};
+    use tower_resilience_core::ResilienceEvent;
+
+    #[derive(Debug, Clone)]
+    struct TestError {
+        message: String,
+        retryable: bool,
+    }
+
+    impl TestError {
+        fn new(message: &str) -> Self {
+            Self {
+                message: message.to_string(),
+                retryable: true,
+            }
+        }
+
+        fn non_retryable(message: &str) -> Self {
+            Self {
+                message: message.to_string(),
+                retryable: false,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn success_no_fallback() {
+        let service =
+            service_fn(
+                |req: String| async move { Ok::<_, TestError>(format!("response: {}", req)) },
+            );
+
+        let layer = FallbackLayer::<String, String, TestError>::value("fallback".to_string());
+        let mut service = layer.layer(service);
+
+        let response = service
+            .ready()
+            .await
+            .unwrap()
+            .call("test".to_string())
+            .await
+            .unwrap();
+
+        assert_eq!(response, "response: test");
+    }
+
+    #[tokio::test]
+    async fn failure_triggers_value_fallback() {
+        let service =
+            service_fn(|_req: String| async move { Err::<String, _>(TestError::new("failed")) });
+
+        let layer = FallbackLayer::<String, String, TestError>::value("fallback".to_string());
+        let mut service = layer.layer(service);
+
+        let response = service
+            .ready()
+            .await
+            .unwrap()
+            .call("test".to_string())
+            .await
+            .unwrap();
+
+        assert_eq!(response, "fallback");
+    }
+
+    #[tokio::test]
+    async fn failure_triggers_from_error_fallback() {
+        let service = service_fn(|_req: String| async move {
+            Err::<String, _>(TestError::new("something went wrong"))
+        });
+
+        let layer = FallbackLayer::<String, String, TestError>::from_error(|e: &TestError| {
+            format!("Error: {}", e.message)
+        });
+        let mut service = layer.layer(service);
+
+        let response = service
+            .ready()
+            .await
+            .unwrap()
+            .call("test".to_string())
+            .await
+            .unwrap();
+
+        assert_eq!(response, "Error: something went wrong");
+    }
+
+    #[tokio::test]
+    async fn failure_triggers_from_request_error_fallback() {
+        let service =
+            service_fn(|_req: String| async move { Err::<String, _>(TestError::new("failed")) });
+
+        let layer = FallbackLayer::<String, String, TestError>::from_request_error(
+            |req: &String, _e: &TestError| format!("fallback for: {}", req),
+        );
+        let mut service = layer.layer(service);
+
+        let response = service
+            .ready()
+            .await
+            .unwrap()
+            .call("my-request".to_string())
+            .await
+            .unwrap();
+
+        assert_eq!(response, "fallback for: my-request");
+    }
+
+    #[tokio::test]
+    async fn predicate_skips_non_matching_errors() {
+        let service = service_fn(|_req: String| async move {
+            Err::<String, _>(TestError::non_retryable("permanent failure"))
+        });
+
+        let layer = FallbackLayer::builder()
+            .value("fallback".to_string())
+            .handle(|e: &TestError| e.retryable) // Only handle retryable errors
+            .build();
+        let mut service = layer.layer(service);
+
+        let result = service
+            .ready()
+            .await
+            .unwrap()
+            .call("test".to_string())
+            .await;
+
+        // Should propagate the original error, not apply fallback
+        assert!(matches!(result, Err(FallbackError::Inner(_))));
+    }
+
+    #[tokio::test]
+    async fn backup_service_fallback() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let cc = Arc::clone(&call_count);
+
+        let primary = service_fn(move |_req: String| {
+            let cc = Arc::clone(&cc);
+            async move {
+                cc.fetch_add(1, Ordering::SeqCst);
+                Err::<String, _>(TestError::new("primary failed"))
+            }
+        });
+
+        let backup_calls = Arc::new(AtomicUsize::new(0));
+        let bc = Arc::clone(&backup_calls);
+
+        let layer = FallbackLayer::<String, String, TestError>::service(move |req: String| {
+            let bc = Arc::clone(&bc);
+            async move {
+                bc.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, TestError>(format!("backup: {}", req))
+            }
+        });
+        let mut service = layer.layer(primary);
+
+        let response = service
+            .ready()
+            .await
+            .unwrap()
+            .call("test".to_string())
+            .await
+            .unwrap();
+
+        assert_eq!(response, "backup: test");
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+        assert_eq!(backup_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn backup_service_also_fails() {
+        let primary =
+            service_fn(
+                |_req: String| async move { Err::<String, _>(TestError::new("primary failed")) },
+            );
+
+        let layer =
+            FallbackLayer::<String, String, TestError>::service(|_req: String| async move {
+                Err::<String, _>(TestError::new("backup also failed"))
+            });
+        let mut service = layer.layer(primary);
+
+        let result = service
+            .ready()
+            .await
+            .unwrap()
+            .call("test".to_string())
+            .await;
+
+        assert!(matches!(result, Err(FallbackError::FallbackFailed(_))));
+    }
+
+    #[tokio::test]
+    async fn exception_transforms_error() {
+        let service =
+            service_fn(
+                |_req: String| async move { Err::<String, _>(TestError::new("original error")) },
+            );
+
+        let layer = FallbackLayer::<String, String, TestError>::exception(|_e: TestError| {
+            TestError::new("transformed error")
+        });
+        let mut service = layer.layer(service);
+
+        let result = service
+            .ready()
+            .await
+            .unwrap()
+            .call("test".to_string())
+            .await;
+
+        match result {
+            Err(FallbackError::Inner(e)) => {
+                assert_eq!(e.message, "transformed error");
+            }
+            _ => panic!("expected transformed error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn event_listeners_called() {
+        use std::sync::Mutex;
+
+        let events: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_clone = Arc::clone(&events);
+
+        let service =
+            service_fn(|_req: String| async move { Err::<String, _>(TestError::new("failed")) });
+
+        let layer = FallbackLayer::builder()
+            .name("test-fallback")
+            .value("fallback".to_string())
+            .on_event(move |event: &FallbackEvent| {
+                events_clone
+                    .lock()
+                    .unwrap()
+                    .push(event.event_type().to_string());
+            })
+            .build();
+        let mut service = layer.layer(service);
+
+        let _ = service
+            .ready()
+            .await
+            .unwrap()
+            .call("test".to_string())
+            .await;
+
+        let recorded = events.lock().unwrap();
+        assert!(recorded.contains(&"failed_attempt".to_string()));
+        assert!(recorded.contains(&"applied".to_string()));
+    }
+}

--- a/crates/tower-resilience/Cargo.toml
+++ b/crates/tower-resilience/Cargo.toml
@@ -24,6 +24,7 @@ tower-resilience-retry = { version = "0.4.7", path = "../tower-resilience-retry"
 tower-resilience-ratelimiter = { version = "0.4.7", path = "../tower-resilience-ratelimiter", optional = true }
 tower-resilience-reconnect = { version = "0.4.7", path = "../tower-resilience-reconnect", optional = true }
 tower-resilience-healthcheck = { version = "0.1.1", path = "../tower-resilience-healthcheck", optional = true }
+tower-resilience-fallback = { version = "0.1.0", path = "../tower-resilience-fallback", optional = true }
 
 [features]
 default = []
@@ -36,8 +37,9 @@ retry = ["dep:tower-resilience-retry"]
 ratelimiter = ["dep:tower-resilience-ratelimiter"]
 reconnect = ["dep:tower-resilience-reconnect"]
 healthcheck = ["dep:tower-resilience-healthcheck"]
+fallback = ["dep:tower-resilience-fallback"]
 # Enable all patterns
-full = ["circuitbreaker", "bulkhead", "timelimiter", "cache", "retry", "ratelimiter", "reconnect", "healthcheck"]
+full = ["circuitbreaker", "bulkhead", "timelimiter", "cache", "retry", "ratelimiter", "reconnect", "healthcheck", "fallback"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/tower-resilience/src/lib.rs
+++ b/crates/tower-resilience/src/lib.rs
@@ -21,6 +21,7 @@
 //! - **[Cache]** - Response memoization to reduce load
 //! - **[Reconnect]** - Automatic reconnection with configurable backoff strategies
 //! - **[Health Check]** - Proactive health monitoring with intelligent resource selection
+//! - **[Fallback]** - Provides alternative responses when services fail
 //!
 //! [Circuit Breaker]: https://docs.rs/tower-resilience-circuitbreaker
 //! [Bulkhead]: https://docs.rs/tower-resilience-bulkhead
@@ -30,6 +31,7 @@
 //! [Cache]: https://docs.rs/tower-resilience-cache
 //! [Reconnect]: https://docs.rs/tower-resilience-reconnect
 //! [Health Check]: https://docs.rs/tower-resilience-healthcheck
+//! [Fallback]: https://docs.rs/tower-resilience-fallback
 //!
 //! # Documentation Guides
 //!
@@ -135,3 +137,6 @@ pub use tower_resilience_reconnect as reconnect;
 
 #[cfg(feature = "healthcheck")]
 pub use tower_resilience_healthcheck as healthcheck;
+
+#[cfg(feature = "fallback")]
+pub use tower_resilience_fallback as fallback;

--- a/tests/fallback.rs
+++ b/tests/fallback.rs
@@ -1,0 +1,4 @@
+//! Top-level test discovery file for tower-resilience-fallback tests.
+
+#[path = "fallback/mod.rs"]
+mod fallback;

--- a/tests/fallback/composition.rs
+++ b/tests/fallback/composition.rs
@@ -1,0 +1,131 @@
+//! Tests for composing fallback with other layers.
+
+use super::TestError;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tower::{Layer, Service, ServiceBuilder, ServiceExt, service_fn};
+use tower_resilience_fallback::FallbackLayer;
+
+#[tokio::test]
+async fn test_fallback_preserves_successful_responses() {
+    let service =
+        service_fn(|req: String| async move { Ok::<_, TestError>(format!("processed: {}", req)) });
+
+    let mut service = ServiceBuilder::new()
+        .layer(FallbackLayer::<String, String, TestError>::value(
+            "fallback".to_string(),
+        ))
+        .service(service);
+
+    let response = service
+        .ready()
+        .await
+        .unwrap()
+        .call("hello".to_string())
+        .await
+        .unwrap();
+
+    // Should get the actual response, not the fallback
+    assert_eq!(response, "processed: hello");
+}
+
+#[tokio::test]
+async fn test_fallback_layer_is_clone() {
+    let layer = FallbackLayer::<String, String, TestError>::value("fallback".to_string());
+    let _cloned = layer.clone();
+}
+
+#[tokio::test]
+async fn test_fallback_service_is_clone() {
+    let service =
+        service_fn(|_req: String| async move { Err::<String, _>(TestError::new("failed")) });
+
+    let layer = FallbackLayer::<String, String, TestError>::value("fallback".to_string());
+    let service = layer.layer(service);
+    let _cloned = service.clone();
+}
+
+#[tokio::test]
+async fn test_fallback_with_map_response() {
+    let service =
+        service_fn(|_req: String| async move { Err::<String, _>(TestError::new("failed")) });
+
+    let layer = FallbackLayer::<String, String, TestError>::value("fallback".to_string());
+    let service = layer.layer(service);
+
+    // Map the response to uppercase
+    let mut service = tower::ServiceBuilder::new()
+        .map_response(|r: String| r.to_uppercase())
+        .service(service);
+
+    let response = service
+        .ready()
+        .await
+        .unwrap()
+        .call("test".to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(response, "FALLBACK");
+}
+
+#[tokio::test]
+async fn test_fallback_concurrent_clones() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let cc = Arc::clone(&call_count);
+
+    let service = service_fn(move |_req: String| {
+        let cc = Arc::clone(&cc);
+        async move {
+            cc.fetch_add(1, Ordering::SeqCst);
+            Err::<String, _>(TestError::new("failed"))
+        }
+    });
+
+    let layer = FallbackLayer::<String, String, TestError>::value("fallback".to_string());
+    let service = layer.layer(service);
+
+    // Spawn multiple concurrent tasks using clones
+    let handles: Vec<_> = (0..5)
+        .map(|i| {
+            let mut svc = service.clone();
+            tokio::spawn(async move {
+                svc.ready()
+                    .await
+                    .unwrap()
+                    .call(format!("req-{}", i))
+                    .await
+                    .unwrap()
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        let result = handle.await.unwrap();
+        assert_eq!(result, "fallback");
+    }
+
+    assert_eq!(call_count.load(Ordering::SeqCst), 5);
+}
+
+#[tokio::test]
+async fn test_fallback_with_service_builder() {
+    let service =
+        service_fn(|_req: String| async move { Err::<String, _>(TestError::new("failed")) });
+
+    let mut service = ServiceBuilder::new()
+        .layer(FallbackLayer::<String, String, TestError>::from_error(
+            |e: &TestError| format!("Handled: {}", e.message),
+        ))
+        .service(service);
+
+    let response = service
+        .ready()
+        .await
+        .unwrap()
+        .call("test".to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(response, "Handled: failed");
+}

--- a/tests/fallback/integration.rs
+++ b/tests/fallback/integration.rs
@@ -1,0 +1,210 @@
+//! Integration tests for fallback basic functionality.
+
+use super::TestError;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tower::{Layer, Service, ServiceExt, service_fn};
+use tower_resilience_fallback::{FallbackError, FallbackLayer};
+
+#[tokio::test]
+async fn test_success_no_fallback_triggered() {
+    let service =
+        service_fn(|req: String| async move { Ok::<_, TestError>(format!("response: {}", req)) });
+
+    let layer = FallbackLayer::<String, String, TestError>::value("fallback".to_string());
+    let mut service = layer.layer(service);
+
+    let response = service
+        .ready()
+        .await
+        .unwrap()
+        .call("hello".to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(response, "response: hello");
+}
+
+#[tokio::test]
+async fn test_failure_triggers_fallback() {
+    let service =
+        service_fn(|_req: String| async move { Err::<String, _>(TestError::new("failed")) });
+
+    let layer = FallbackLayer::<String, String, TestError>::value("fallback response".to_string());
+    let mut service = layer.layer(service);
+
+    let response = service
+        .ready()
+        .await
+        .unwrap()
+        .call("hello".to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(response, "fallback response");
+}
+
+#[tokio::test]
+async fn test_multiple_sequential_calls() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let cc = Arc::clone(&call_count);
+
+    let service = service_fn(move |_req: String| {
+        let cc = Arc::clone(&cc);
+        async move {
+            let count = cc.fetch_add(1, Ordering::SeqCst);
+            if count.is_multiple_of(2) {
+                Ok::<_, TestError>("success".to_string())
+            } else {
+                Err(TestError::new("failed"))
+            }
+        }
+    });
+
+    let layer = FallbackLayer::<String, String, TestError>::value("fallback".to_string());
+    let mut service = layer.layer(service);
+
+    // First call succeeds
+    let r1 = service
+        .ready()
+        .await
+        .unwrap()
+        .call("1".to_string())
+        .await
+        .unwrap();
+    assert_eq!(r1, "success");
+
+    // Second call fails, triggers fallback
+    let r2 = service
+        .ready()
+        .await
+        .unwrap()
+        .call("2".to_string())
+        .await
+        .unwrap();
+    assert_eq!(r2, "fallback");
+
+    // Third call succeeds
+    let r3 = service
+        .ready()
+        .await
+        .unwrap()
+        .call("3".to_string())
+        .await
+        .unwrap();
+    assert_eq!(r3, "success");
+
+    assert_eq!(call_count.load(Ordering::SeqCst), 3);
+}
+
+#[tokio::test]
+async fn test_service_cloning_preserves_config() {
+    let service =
+        service_fn(|_req: String| async move { Err::<String, _>(TestError::new("failed")) });
+
+    let layer = FallbackLayer::<String, String, TestError>::value("fallback".to_string());
+    let service = layer.layer(service);
+
+    // Clone the service
+    let mut clone1 = service.clone();
+    let mut clone2 = service.clone();
+
+    // Both clones should have the same fallback behavior
+    let r1 = clone1
+        .ready()
+        .await
+        .unwrap()
+        .call("a".to_string())
+        .await
+        .unwrap();
+    let r2 = clone2
+        .ready()
+        .await
+        .unwrap()
+        .call("b".to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(r1, "fallback");
+    assert_eq!(r2, "fallback");
+}
+
+#[tokio::test]
+async fn test_named_fallback() {
+    let service =
+        service_fn(|_req: String| async move { Err::<String, _>(TestError::new("failed")) });
+
+    let layer = FallbackLayer::builder()
+        .name("my-fallback")
+        .value("fallback".to_string())
+        .build();
+    let mut service = layer.layer(service);
+
+    let response = service
+        .ready()
+        .await
+        .unwrap()
+        .call("test".to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(response, "fallback");
+}
+
+#[tokio::test]
+async fn test_error_types_preserved() {
+    let service = service_fn(|_req: String| async move {
+        Err::<String, _>(TestError::with_code("original error", 503))
+    });
+
+    // Use exception strategy to verify error is passed through
+    let layer = FallbackLayer::<String, String, TestError>::exception(|e: TestError| TestError {
+        message: format!("transformed: {}", e.message),
+        retryable: e.retryable,
+        code: e.code,
+    });
+    let mut service = layer.layer(service);
+
+    let result = service
+        .ready()
+        .await
+        .unwrap()
+        .call("test".to_string())
+        .await;
+
+    match result {
+        Err(FallbackError::Inner(e)) => {
+            assert_eq!(e.message, "transformed: original error");
+            assert_eq!(e.code, 503);
+        }
+        _ => panic!("expected transformed error"),
+    }
+}
+
+#[tokio::test]
+async fn test_concurrent_calls() {
+    let service =
+        service_fn(|_req: String| async move { Err::<String, _>(TestError::new("failed")) });
+
+    let layer = FallbackLayer::<String, String, TestError>::value("fallback".to_string());
+    let service = layer.layer(service);
+
+    let handles: Vec<_> = (0..10)
+        .map(|i| {
+            let mut svc = service.clone();
+            tokio::spawn(async move {
+                svc.ready()
+                    .await
+                    .unwrap()
+                    .call(format!("req-{}", i))
+                    .await
+                    .unwrap()
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        let result = handle.await.unwrap();
+        assert_eq!(result, "fallback");
+    }
+}

--- a/tests/fallback/mod.rs
+++ b/tests/fallback/mod.rs
@@ -1,0 +1,57 @@
+//! Comprehensive tests for tower-resilience-fallback.
+//!
+//! This test suite provides coverage for the fallback pattern, organized into:
+//!
+//! - **integration**: Basic integration tests verifying core functionality
+//! - **strategies**: Tests for different fallback strategies
+//! - **predicates**: Tests for selective error handling
+//! - **composition**: Tests for composing fallback with other layers
+
+mod composition;
+mod integration;
+mod predicates;
+mod strategies;
+
+use std::fmt;
+
+/// Test error type for use in test services.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TestError {
+    pub message: String,
+    pub retryable: bool,
+    pub code: u32,
+}
+
+impl TestError {
+    pub fn new(message: &str) -> Self {
+        Self {
+            message: message.to_string(),
+            retryable: true,
+            code: 500,
+        }
+    }
+
+    pub fn non_retryable(message: &str) -> Self {
+        Self {
+            message: message.to_string(),
+            retryable: false,
+            code: 400,
+        }
+    }
+
+    pub fn with_code(message: &str, code: u32) -> Self {
+        Self {
+            message: message.to_string(),
+            retryable: true,
+            code,
+        }
+    }
+}
+
+impl fmt::Display for TestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TestError({}): {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for TestError {}

--- a/tests/fallback/predicates.rs
+++ b/tests/fallback/predicates.rs
@@ -1,0 +1,212 @@
+//! Tests for selective error handling with predicates.
+
+use super::TestError;
+use tower::{Layer, Service, ServiceExt, service_fn};
+use tower_resilience_fallback::{FallbackError, FallbackLayer};
+
+#[tokio::test]
+async fn test_predicate_matches_triggers_fallback() {
+    let service =
+        service_fn(
+            |_req: String| async move { Err::<String, _>(TestError::new("retryable error")) },
+        );
+
+    let layer = FallbackLayer::builder()
+        .value("fallback".to_string())
+        .handle(|e: &TestError| e.retryable)
+        .build();
+    let mut service = layer.layer(service);
+
+    let response = service
+        .ready()
+        .await
+        .unwrap()
+        .call("test".to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(response, "fallback");
+}
+
+#[tokio::test]
+async fn test_predicate_no_match_propagates_error() {
+    let service = service_fn(|_req: String| async move {
+        Err::<String, _>(TestError::non_retryable("permanent error"))
+    });
+
+    let layer = FallbackLayer::builder()
+        .value("fallback".to_string())
+        .handle(|e: &TestError| e.retryable) // Only handle retryable errors
+        .build();
+    let mut service = layer.layer(service);
+
+    let result = service
+        .ready()
+        .await
+        .unwrap()
+        .call("test".to_string())
+        .await;
+
+    match result {
+        Err(FallbackError::Inner(e)) => {
+            assert_eq!(e.message, "permanent error");
+            assert!(!e.retryable);
+        }
+        _ => panic!("expected inner error to be propagated"),
+    }
+}
+
+#[tokio::test]
+async fn test_predicate_by_error_code() {
+    let service = service_fn(|req: String| async move {
+        let code: u32 = req.parse().unwrap_or(500);
+        Err::<String, _>(TestError::with_code("error", code))
+    });
+
+    // Only handle 5xx errors
+    let layer = FallbackLayer::builder()
+        .value("server error fallback".to_string())
+        .handle(|e: &TestError| e.code >= 500)
+        .build();
+    let mut service = layer.layer(service);
+
+    // 503 should trigger fallback
+    let r1 = service
+        .ready()
+        .await
+        .unwrap()
+        .call("503".to_string())
+        .await
+        .unwrap();
+    assert_eq!(r1, "server error fallback");
+
+    // 400 should propagate
+    let r2 = service.ready().await.unwrap().call("400".to_string()).await;
+    assert!(matches!(r2, Err(FallbackError::Inner(e)) if e.code == 400));
+}
+
+#[tokio::test]
+async fn test_predicate_by_message_content() {
+    let service = service_fn(|req: String| async move { Err::<String, _>(TestError::new(&req)) });
+
+    // Only handle timeout errors
+    let layer = FallbackLayer::builder()
+        .value("timeout fallback".to_string())
+        .handle(|e: &TestError| e.message.contains("timeout"))
+        .build();
+    let mut service = layer.layer(service);
+
+    // Timeout error triggers fallback
+    let r1 = service
+        .ready()
+        .await
+        .unwrap()
+        .call("connection timeout".to_string())
+        .await
+        .unwrap();
+    assert_eq!(r1, "timeout fallback");
+
+    // Other errors propagate
+    let r2 = service
+        .ready()
+        .await
+        .unwrap()
+        .call("connection refused".to_string())
+        .await;
+    assert!(matches!(r2, Err(FallbackError::Inner(_))));
+}
+
+#[tokio::test]
+async fn test_no_predicate_handles_all_errors() {
+    let service =
+        service_fn(|_req: String| async move { Err::<String, _>(TestError::new("any error")) });
+
+    // No handle() call means handle all errors
+    let layer = FallbackLayer::builder()
+        .value("fallback".to_string())
+        .build();
+    let mut service = layer.layer(service);
+
+    let response = service
+        .ready()
+        .await
+        .unwrap()
+        .call("test".to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(response, "fallback");
+}
+
+#[tokio::test]
+async fn test_predicate_always_false_never_triggers() {
+    let service =
+        service_fn(|_req: String| async move { Err::<String, _>(TestError::new("error")) });
+
+    let layer = FallbackLayer::builder()
+        .value("fallback".to_string())
+        .handle(|_e: &TestError| false) // Never handle
+        .build();
+    let mut service = layer.layer(service);
+
+    let result = service
+        .ready()
+        .await
+        .unwrap()
+        .call("test".to_string())
+        .await;
+
+    assert!(matches!(result, Err(FallbackError::Inner(_))));
+}
+
+#[tokio::test]
+async fn test_predicate_always_true_always_triggers() {
+    let service =
+        service_fn(
+            |_req: String| async move { Err::<String, _>(TestError::non_retryable("error")) },
+        );
+
+    let layer = FallbackLayer::builder()
+        .value("fallback".to_string())
+        .handle(|_e: &TestError| true) // Always handle
+        .build();
+    let mut service = layer.layer(service);
+
+    let response = service
+        .ready()
+        .await
+        .unwrap()
+        .call("test".to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(response, "fallback");
+}
+
+#[tokio::test]
+async fn test_predicate_with_from_error_strategy() {
+    let service = service_fn(|req: String| async move {
+        let code: u32 = req.parse().unwrap_or(500);
+        Err::<String, _>(TestError::with_code("error", code))
+    });
+
+    let layer = FallbackLayer::builder()
+        .from_error(|e: &TestError| format!("Handled error code: {}", e.code))
+        .handle(|e: &TestError| e.code >= 500)
+        .build();
+    let mut service = layer.layer(service);
+
+    // 500 triggers fallback with error info
+    let r1 = service
+        .ready()
+        .await
+        .unwrap()
+        .call("500".to_string())
+        .await
+        .unwrap();
+    assert_eq!(r1, "Handled error code: 500");
+
+    // 404 propagates
+    let r2 = service.ready().await.unwrap().call("404".to_string()).await;
+    assert!(matches!(r2, Err(FallbackError::Inner(e)) if e.code == 404));
+}

--- a/tests/fallback/strategies.rs
+++ b/tests/fallback/strategies.rs
@@ -1,0 +1,237 @@
+//! Tests for different fallback strategies.
+
+use super::TestError;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tower::{Layer, Service, ServiceExt, service_fn};
+use tower_resilience_fallback::{FallbackError, FallbackLayer};
+
+#[tokio::test]
+async fn test_value_strategy() {
+    let service =
+        service_fn(|_req: String| async move { Err::<String, _>(TestError::new("failed")) });
+
+    let layer = FallbackLayer::<String, String, TestError>::value("static fallback".to_string());
+    let mut service = layer.layer(service);
+
+    let response = service
+        .ready()
+        .await
+        .unwrap()
+        .call("test".to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(response, "static fallback");
+}
+
+#[tokio::test]
+async fn test_from_error_strategy() {
+    let service = service_fn(|_req: String| async move {
+        Err::<String, _>(TestError::with_code("something broke", 503))
+    });
+
+    let layer = FallbackLayer::<String, String, TestError>::from_error(|e: &TestError| {
+        format!("Error {}: {}", e.code, e.message)
+    });
+    let mut service = layer.layer(service);
+
+    let response = service
+        .ready()
+        .await
+        .unwrap()
+        .call("test".to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(response, "Error 503: something broke");
+}
+
+#[tokio::test]
+async fn test_from_request_error_strategy() {
+    let service =
+        service_fn(|_req: String| async move { Err::<String, _>(TestError::new("failed")) });
+
+    let layer = FallbackLayer::<String, String, TestError>::from_request_error(
+        |req: &String, e: &TestError| format!("Request '{}' failed: {}", req, e.message),
+    );
+    let mut service = layer.layer(service);
+
+    let response = service
+        .ready()
+        .await
+        .unwrap()
+        .call("my-request".to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(response, "Request 'my-request' failed: failed");
+}
+
+#[tokio::test]
+async fn test_from_request_error_with_cache() {
+    let cache: Arc<HashMap<String, String>> = Arc::new({
+        let mut m = HashMap::new();
+        m.insert("key1".to_string(), "cached-value-1".to_string());
+        m.insert("key2".to_string(), "cached-value-2".to_string());
+        m
+    });
+    let cache_clone = Arc::clone(&cache);
+
+    let service =
+        service_fn(|_req: String| async move { Err::<String, _>(TestError::new("failed")) });
+
+    let layer = FallbackLayer::<String, String, TestError>::from_request_error(
+        move |req: &String, _e: &TestError| {
+            cache_clone
+                .get(req)
+                .cloned()
+                .unwrap_or_else(|| "not in cache".to_string())
+        },
+    );
+    let mut service = layer.layer(service);
+
+    // Request for cached key
+    let r1 = service
+        .ready()
+        .await
+        .unwrap()
+        .call("key1".to_string())
+        .await
+        .unwrap();
+    assert_eq!(r1, "cached-value-1");
+
+    // Request for non-cached key
+    let r2 = service
+        .ready()
+        .await
+        .unwrap()
+        .call("key3".to_string())
+        .await
+        .unwrap();
+    assert_eq!(r2, "not in cache");
+}
+
+#[tokio::test]
+async fn test_service_strategy_success() {
+    let primary_calls = Arc::new(AtomicUsize::new(0));
+    let backup_calls = Arc::new(AtomicUsize::new(0));
+
+    let pc = Arc::clone(&primary_calls);
+    let primary = service_fn(move |_req: String| {
+        let pc = Arc::clone(&pc);
+        async move {
+            pc.fetch_add(1, Ordering::SeqCst);
+            Err::<String, _>(TestError::new("primary failed"))
+        }
+    });
+
+    let bc = Arc::clone(&backup_calls);
+    let layer = FallbackLayer::<String, String, TestError>::service(move |req: String| {
+        let bc = Arc::clone(&bc);
+        async move {
+            bc.fetch_add(1, Ordering::SeqCst);
+            Ok::<_, TestError>(format!("backup handled: {}", req))
+        }
+    });
+    let mut service = layer.layer(primary);
+
+    let response = service
+        .ready()
+        .await
+        .unwrap()
+        .call("test".to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(response, "backup handled: test");
+    assert_eq!(primary_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(backup_calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn test_service_strategy_also_fails() {
+    let primary =
+        service_fn(
+            |_req: String| async move { Err::<String, _>(TestError::new("primary failed")) },
+        );
+
+    let layer = FallbackLayer::<String, String, TestError>::service(|_req: String| async move {
+        Err::<String, _>(TestError::new("backup also failed"))
+    });
+    let mut service = layer.layer(primary);
+
+    let result = service
+        .ready()
+        .await
+        .unwrap()
+        .call("test".to_string())
+        .await;
+
+    match result {
+        Err(FallbackError::FallbackFailed(e)) => {
+            assert_eq!(e.message, "backup also failed");
+        }
+        _ => panic!("expected FallbackFailed error"),
+    }
+}
+
+#[tokio::test]
+async fn test_exception_strategy() {
+    let service = service_fn(|_req: String| async move {
+        Err::<String, _>(TestError::with_code("internal error", 500))
+    });
+
+    let layer = FallbackLayer::<String, String, TestError>::exception(|_e: TestError| TestError {
+        message: "Service temporarily unavailable".to_string(),
+        retryable: false,
+        code: 503,
+    });
+    let mut service = layer.layer(service);
+
+    let result = service
+        .ready()
+        .await
+        .unwrap()
+        .call("test".to_string())
+        .await;
+
+    match result {
+        Err(FallbackError::Inner(e)) => {
+            assert_eq!(e.message, "Service temporarily unavailable");
+            assert_eq!(e.code, 503);
+            assert!(!e.retryable);
+        }
+        _ => panic!("expected transformed error"),
+    }
+}
+
+#[tokio::test]
+async fn test_exception_preserves_original_info() {
+    let service = service_fn(|_req: String| async move {
+        Err::<String, _>(TestError::with_code("database connection failed", 500))
+    });
+
+    let layer = FallbackLayer::<String, String, TestError>::exception(|e: TestError| TestError {
+        message: format!("Wrapped: {}", e.message),
+        retryable: e.retryable,
+        code: e.code,
+    });
+    let mut service = layer.layer(service);
+
+    let result = service
+        .ready()
+        .await
+        .unwrap()
+        .call("test".to_string())
+        .await;
+
+    match result {
+        Err(FallbackError::Inner(e)) => {
+            assert_eq!(e.message, "Wrapped: database connection failed");
+            assert_eq!(e.code, 500);
+        }
+        _ => panic!("expected transformed error"),
+    }
+}


### PR DESCRIPTION
## Summary

Add `tower-resilience-fallback` crate inspired by [failsafe.dev](https://failsafe.dev)'s standalone Fallback pattern.

## Features

The new crate provides 5 fallback strategies:

- **Value**: Return a static fallback value
- **FromError**: Compute fallback from the error
- **FromRequestError**: Compute fallback from request and error  
- **Service**: Delegate to a fallback service
- **Exception**: Transform the error (for error mapping)

Additional features:
- Selective error handling via predicates (e.g., only handle 5xx errors)
- Event system for observability (`FallbackEvent` with Success, FailedAttempt, Applied, Failed, Skipped variants)
- Optional `metrics` and `tracing` feature flags
- Full Tower Layer/Service implementation with Send + Sync bounds

## Changes

- New crate: `crates/tower-resilience-fallback/`
- 29 integration tests across 4 modules (integration, strategies, predicates, composition)
- 3 benchmarks added to `comprehensive_benchmarks.rs`
- Example: `fallback_example.rs` demonstrating all strategies

## Testing

```bash
cargo fmt --all -- --check  # Pass
cargo clippy --all-targets --all-features -- -D warnings  # Pass
cargo test --all-features  # 321 tests pass
```

## Motivation

Previously, fallback functionality was only available via the circuit breaker's `.with_fallback()` method. This standalone implementation allows fallback to be composed with any middleware, matching how failsafe.dev treats Fallback as a first-class resilience pattern.