### PR TITLE
fix: widen timing tolerance in retry backoff test for CI

### DIFF
--- a/tests/retry/retry_backoff.rs
+++ b/tests/retry/retry_backoff.rs
@@ -57,12 +57,13 @@ async fn fixed_interval_consistent_delays() {
     let times = timestamps.lock().unwrap();
     assert_eq!(times.len(), 4); // 1 initial + 3 retries
 
-    // Check delays are consistent (50ms ± 30ms for Windows compatibility)
+    // Check delays are at least the configured minimum (50ms)
+    // Upper bound is generous for CI environments with variable load
     for i in 1..times.len() {
         let delay = times[i].duration_since(times[i - 1]);
         assert!(
-            delay >= Duration::from_millis(20) && delay <= Duration::from_millis(80),
-            "Expected delay around 50ms, got {:?} at attempt {}",
+            delay >= Duration::from_millis(40) && delay <= Duration::from_millis(200),
+            "Expected delay around 50ms (got {:?} at attempt {})",
             delay,
             i
         );


### PR DESCRIPTION
## Problem

The `fixed_interval_consistent_delays` test was flaky in CI:

```
Expected delay around 50ms, got 109.505416ms at attempt 1
```

The test used tight timing bounds (20-80ms for a 50ms delay) which don't account for CI environment variability.

## Solution

Widened tolerance to 40-200ms which:
- Still validates that backoff is approximately correct
- Accounts for CI environments with variable load
- Keeps a reasonable lower bound to catch if delays are too short

## Testing

Ran locally and test passes.