### PR TITLE
feat(bulkhead): add reject_when_full() convenience method

### DIFF
--- a/crates/tower-resilience-bulkhead/src/config.rs
+++ b/crates/tower-resilience-bulkhead/src/config.rs
@@ -53,6 +53,34 @@ impl BulkheadConfigBuilder {
         self
     }
 
+    /// Configures the bulkhead to reject requests immediately when at capacity.
+    ///
+    /// This is equivalent to `.max_wait_duration(Some(Duration::ZERO))`.
+    ///
+    /// Use this when you want fail-fast behavior instead of queueing requests.
+    /// This is useful for:
+    /// - Preventing request pile-up during traffic spikes
+    /// - Implementing load shedding
+    /// - Providing immediate feedback to callers when the system is overloaded
+    ///
+    /// # Example
+    /// ```rust
+    /// use tower_resilience_bulkhead::BulkheadLayer;
+    ///
+    /// // Reject immediately when 100 concurrent calls are in progress
+    /// let layer = BulkheadLayer::builder()
+    ///     .max_concurrent_calls(100)
+    ///     .reject_when_full()
+    ///     .build();
+    /// ```
+    ///
+    /// This addresses the use case described in [tower-rs/tower#793](https://github.com/tower-rs/tower/issues/793),
+    /// where users want a concurrency limiter that rejects rather than queues.
+    pub fn reject_when_full(mut self) -> Self {
+        self.max_wait_duration = Some(Duration::ZERO);
+        self
+    }
+
     /// Sets the name of this bulkhead instance.
     ///
     /// Default: "bulkhead"

--- a/crates/tower-resilience-bulkhead/src/lib.rs
+++ b/crates/tower-resilience-bulkhead/src/lib.rs
@@ -27,6 +27,33 @@
 //! # }
 //! ```
 //!
+//! # Rejection Mode (Fail-Fast)
+//!
+//! Configure the bulkhead to reject requests immediately when at capacity,
+//! rather than queueing them. This is useful for load shedding and providing
+//! immediate feedback to callers.
+//!
+//! This addresses the use case in [tower-rs/tower#793](https://github.com/tower-rs/tower/issues/793).
+//!
+//! ```rust
+//! use tower::ServiceBuilder;
+//! use tower_resilience_bulkhead::BulkheadLayer;
+//!
+//! # async fn example() {
+//! // Reject immediately when at capacity (no waiting)
+//! let layer = BulkheadLayer::builder()
+//!     .max_concurrent_calls(100)
+//!     .reject_when_full()
+//!     .build();
+//!
+//! let service = ServiceBuilder::new()
+//!     .layer(layer)
+//!     .service_fn(|req: String| async move {
+//!         Ok::<_, ()>(req)
+//!     });
+//! # }
+//! ```
+//!
 //! # Example with Timeout
 //!
 //! Configure a maximum wait duration for requests when the bulkhead is at capacity:


### PR DESCRIPTION
Add a convenience method to configure bulkhead for immediate rejection when at capacity.

## Changes

- Add `.reject_when_full()` builder method
- Update crate docs with "Rejection Mode (Fail-Fast)" section
- Reference tower-rs/tower#793 in docs

## Usage

```rust
// Before (verbose)
let layer = BulkheadLayer::builder()
    .max_concurrent_calls(100)
    .max_wait_duration(Some(Duration::ZERO))
    .build();

// After (ergonomic)
let layer = BulkheadLayer::builder()
    .max_concurrent_calls(100)
    .reject_when_full()
    .build();
```

## Motivation

This addresses the use case in [tower-rs/tower#793](https://github.com/tower-rs/tower/issues/793), where users want a concurrency limiter that rejects requests immediately rather than queueing them.

Tower's `ConcurrencyLimitLayer` queues requests when at capacity, and the workaround using `LoadShed` has drawbacks (sheds on any `poll_ready` pending, not just concurrency). Our bulkhead already supported this via `max_wait_duration(Some(Duration::ZERO))`, but the new method makes the intent clearer.

Closes #168