### PR TITLE
fix: bump tower-resilience to 0.4.0 for breaking sub-crate changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Resilience patterns for [Tower](https://docs.rs/tower) services, inspired by [Re
 
 ```toml
 [dependencies]
-tower-resilience = "0.1"
+tower-resilience = "0.4"
 tower = "0.5"
 ```
 

--- a/crates/tower-resilience/CHANGELOG.md
+++ b/crates/tower-resilience/CHANGELOG.md
@@ -7,16 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.10](https://github.com/joshrotenberg/tower-resilience/compare/tower-resilience-v0.3.9...tower-resilience-v0.3.10) - 2026-01-01
-
-### Other
-
-- add comprehensive pattern selection and composition guide ([#185](https://github.com/joshrotenberg/tower-resilience/pull/185))
-
-## [0.3.9](https://github.com/joshrotenberg/tower-resilience/compare/tower-resilience-v0.3.8...tower-resilience-v0.3.9) - 2026-01-01
+## [0.4.0](https://github.com/joshrotenberg/tower-resilience/compare/tower-resilience-v0.3.8...tower-resilience-v0.4.0) - 2026-01-02
 
 ### Added
 
+- add comprehensive pattern selection and composition guide ([#185](https://github.com/joshrotenberg/tower-resilience/pull/185))
 - add request coalescing (singleflight) pattern ([#180](https://github.com/joshrotenberg/tower-resilience/pull/180))
 - add adaptive concurrency limiter with AIMD and Vegas algorithms ([#178](https://github.com/joshrotenberg/tower-resilience/pull/178))
 - add executor delegation layer for parallel request processing ([#177](https://github.com/joshrotenberg/tower-resilience/pull/177))
@@ -31,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
+- [**breaking**] bump version to 0.4.0 due to breaking changes in sub-crates (retry 0.5.0, timelimiter 0.4.0 add Req type parameter)
 - simplify README and reduce marketing language ([#173](https://github.com/joshrotenberg/tower-resilience/pull/173))
 
 ## [0.3.8](https://github.com/joshrotenberg/tower-resilience/compare/tower-resilience-v0.3.7...tower-resilience-v0.3.8) - 2025-11-02

--- a/crates/tower-resilience/Cargo.toml
+++ b/crates/tower-resilience/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-resilience"
-version = "0.3.10"
+version = "0.4.0"
 edition = "2021"
 rust-version.workspace = true
 readme = "../../README.md"

--- a/crates/tower-resilience/src/lib.rs
+++ b/crates/tower-resilience/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tower-resilience = { version = "0.1", features = ["circuitbreaker", "bulkhead"] }
+//! tower-resilience = { version = "0.4", features = ["circuitbreaker", "bulkhead"] }
 //! ```
 //!
 //! # Resilience Patterns


### PR DESCRIPTION
## Summary

Bumps `tower-resilience` from 0.3.10 to 0.4.0 to properly signal breaking changes from sub-crates.

## Problem

Versions 0.3.9 and 0.3.10 incorrectly used patch bumps when sub-crates had breaking API changes:
- `tower-resilience-retry` 0.4.7 -> 0.5.0: Added `Req` type parameter
- `tower-resilience-timelimiter` 0.3.7 -> 0.4.0: Added `Req` type parameter

For 0.x semver, minor version changes can contain breaking changes. The umbrella crate should have bumped from 0.3.x to 0.4.0.

## Changes

- Bump version from 0.3.10 to 0.4.0
- Consolidate changelog entries from 0.3.9 and 0.3.10 into 0.4.0
- Update example versions in README and lib.rs from 0.1 to 0.4
- Add breaking change note to changelog

## Downstream Impact

Checked crates.io reverse dependencies:
- `redis-cloud`: Uses `retry` feature as dev-dependency only (no impact)
- `acton-service`: Uses default features (none) + direct sub-crates for bulkhead/circuitbreaker (no breaking changes in those)

## After Merge

Yank the incorrectly versioned releases:
```bash
cargo yank --version 0.3.9 tower-resilience
cargo yank --version 0.3.10 tower-resilience
```