### PR TITLE
refactor!: change BulkheadLayer::max_wait_duration to accept Duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ use std::time::Duration;
 let layer = BulkheadLayer::builder()
     .name("worker-pool")
     .max_concurrent_calls(10)                    // Max 10 concurrent
-    .max_wait_duration(Some(Duration::from_secs(5)))  // Wait up to 5s
+    .max_wait_duration(Duration::from_secs(5))        // Wait up to 5s
     .on_call_permitted(|concurrent| {
         println!("Request permitted (concurrent: {})", concurrent);
     })

--- a/benches/comprehensive_benchmarks.rs
+++ b/benches/comprehensive_benchmarks.rs
@@ -239,7 +239,7 @@ fn bench_bulkhead_full(c: &mut Criterion) {
         b.to_async(&runtime).iter(|| async {
             let config = BulkheadLayer::builder()
                 .max_concurrent_calls(1) // Very limited
-                .max_wait_duration(Some(Duration::from_millis(1))) // Short timeout
+                .max_wait_duration(Duration::from_millis(1)) // Short timeout
                 .build();
 
             let mut service = ServiceBuilder::new().layer(config).service(BaselineService);

--- a/crates/tower-resilience-bulkhead/examples/bulkhead_advanced.rs
+++ b/crates/tower-resilience-bulkhead/examples/bulkhead_advanced.rs
@@ -37,7 +37,7 @@ async fn main() {
     // Create bulkhead configuration
     let config = BulkheadLayer::builder()
         .max_concurrent_calls(3)
-        .max_wait_duration(Some(Duration::from_millis(100)))
+        .max_wait_duration(Duration::from_millis(100))
         .name("demo-bulkhead")
         .on_call_permitted(move |concurrent| {
             p.fetch_add(1, Ordering::SeqCst);

--- a/crates/tower-resilience-bulkhead/src/config.rs
+++ b/crates/tower-resilience-bulkhead/src/config.rs
@@ -46,16 +46,26 @@ impl BulkheadConfigBuilder {
 
     /// Sets the maximum time to wait for a permit.
     ///
-    /// If `None`, calls will wait indefinitely.
-    /// Default: None
-    pub fn max_wait_duration(mut self, duration: Option<Duration>) -> Self {
-        self.max_wait_duration = duration;
+    /// If not called, calls will wait indefinitely (the default).
+    ///
+    /// # Example
+    /// ```rust
+    /// use tower_resilience_bulkhead::BulkheadLayer;
+    /// use std::time::Duration;
+    ///
+    /// let layer = BulkheadLayer::builder()
+    ///     .max_concurrent_calls(10)
+    ///     .max_wait_duration(Duration::from_secs(5))
+    ///     .build();
+    /// ```
+    pub fn max_wait_duration(mut self, duration: Duration) -> Self {
+        self.max_wait_duration = Some(duration);
         self
     }
 
     /// Configures the bulkhead to reject requests immediately when at capacity.
     ///
-    /// This is equivalent to `.max_wait_duration(Some(Duration::ZERO))`.
+    /// This is equivalent to `.max_wait_duration(Duration::ZERO)`.
     ///
     /// Use this when you want fail-fast behavior instead of queueing requests.
     /// This is useful for:

--- a/crates/tower-resilience-bulkhead/src/layer.rs
+++ b/crates/tower-resilience-bulkhead/src/layer.rs
@@ -34,7 +34,7 @@ impl BulkheadLayer {
     ///
     /// let layer = BulkheadLayer::builder()
     ///     .max_concurrent_calls(10)
-    ///     .max_wait_duration(Some(Duration::from_secs(5)))
+    ///     .max_wait_duration(Duration::from_secs(5))
     ///     .build();
     /// ```
     pub fn builder() -> crate::BulkheadConfigBuilder {

--- a/crates/tower-resilience-bulkhead/src/lib.rs
+++ b/crates/tower-resilience-bulkhead/src/lib.rs
@@ -66,7 +66,7 @@
 //! # async fn example() {
 //! let layer = BulkheadLayer::builder()
 //!     .max_concurrent_calls(5)
-//!     .max_wait_duration(Some(Duration::from_secs(2)))
+//!     .max_wait_duration(Duration::from_secs(2))
 //!     .name("timeout-bulkhead")
 //!     .build();
 //!
@@ -122,7 +122,7 @@
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let layer = BulkheadLayer::builder()
 //!     .max_concurrent_calls(5)
-//!     .max_wait_duration(Some(Duration::from_millis(100)))
+//!     .max_wait_duration(Duration::from_millis(100))
 //!     .build();
 //!
 //! let service = ServiceBuilder::new()
@@ -163,7 +163,7 @@
 //! let queue = Arc::new(Mutex::new(Vec::new()));
 //! let layer = BulkheadLayer::builder()
 //!     .max_concurrent_calls(10)
-//!     .max_wait_duration(Some(Duration::from_millis(50)))
+//!     .max_wait_duration(Duration::from_millis(50))
 //!     .build();
 //!
 //! let service = ServiceBuilder::new()
@@ -197,7 +197,7 @@
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let layer = BulkheadLayer::builder()
 //!     .max_concurrent_calls(5)
-//!     .max_wait_duration(Some(Duration::from_millis(10)))
+//!     .max_wait_duration(Duration::from_millis(10))
 //!     .build();
 //!
 //! let service = ServiceBuilder::new()
@@ -281,7 +281,7 @@ mod tests {
 
         let _layer = BulkheadLayer::builder()
             .max_concurrent_calls(5)
-            .max_wait_duration(Some(Duration::from_millis(100)))
+            .max_wait_duration(Duration::from_millis(100))
             .name("test-bulkhead")
             .on_call_permitted(move |_| {
                 c.fetch_add(1, Ordering::SeqCst);

--- a/crates/tower-resilience/examples/combined.rs
+++ b/crates/tower-resilience/examples/combined.rs
@@ -76,7 +76,7 @@ async fn main() {
     // Apply bulkhead first
     let bulkhead_layer = BulkheadLayer::builder()
         .max_concurrent_calls(3)
-        .max_wait_duration(Some(Duration::from_millis(100)))
+        .max_wait_duration(Duration::from_millis(100))
         .on_call_rejected(move |_| {
             bulkhead_clone.fetch_add(1, Ordering::SeqCst);
         })

--- a/crates/tower-resilience/src/composition.rs
+++ b/crates/tower-resilience/src/composition.rs
@@ -659,7 +659,7 @@ pub mod anti_patterns {
     //! // Good: Sized for expected concurrency + headroom
     //! BulkheadLayer::builder()
     //!     .max_concurrent_calls(50)  // Based on load testing
-    //!     .max_wait_duration(Some(Duration::from_secs(1)))
+    //!     .max_wait_duration(Duration::from_secs(1))
     //!     .build()
     //! ```
     //!

--- a/crates/tower-resilience/src/patterns.rs
+++ b/crates/tower-resilience/src/patterns.rs
@@ -413,7 +413,7 @@ pub mod bulkhead {
     //! # let expensive_operation = tower::service_fn(|_req: ()| async { Ok::<_, std::io::Error>(()) });
     //! let bulkhead = BulkheadLayer::builder()
     //!     .max_concurrent_calls(10)
-    //!     .max_wait_duration(Some(Duration::from_secs(5)))
+    //!     .max_wait_duration(Duration::from_secs(5))
     //!     .on_call_rejected(|max| {
     //!         eprintln!("Bulkhead exhausted (max: {})", max);
     //!     })

--- a/examples/bulkhead.rs
+++ b/examples/bulkhead.rs
@@ -47,7 +47,7 @@ async fn main() {
     // Wrap with bulkhead that limits to 3 concurrent calls
     let bulkhead = BulkheadLayer::builder()
         .max_concurrent_calls(3)
-        .max_wait_duration(Some(Duration::from_secs(1)))
+        .max_wait_duration(Duration::from_secs(1))
         .name("example-bulkhead")
         .on_call_permitted(|concurrent| {
             println!("  [BULKHEAD] Permitted (concurrent: {})", concurrent);

--- a/examples/message_queue_worker.rs
+++ b/examples/message_queue_worker.rs
@@ -228,7 +228,7 @@ async fn scenario_bulkhead() {
     // Configure bulkhead: process max 2 messages concurrently
     let bulkhead = BulkheadLayer::builder()
         .max_concurrent_calls(2)
-        .max_wait_duration(Some(Duration::from_millis(500)))
+        .max_wait_duration(Duration::from_millis(500))
         .name("message-processor")
         .on_call_permitted(|current| {
             println!("[Bulkhead] Message permitted (concurrent: {})", current);
@@ -328,7 +328,7 @@ async fn scenario_full_worker_stack() {
         .layer(
             BulkheadLayer::builder()
                 .max_concurrent_calls(3)
-                .max_wait_duration(Some(Duration::from_secs(1)))
+                .max_wait_duration(Duration::from_secs(1))
                 .name("worker-pool")
                 .on_call_permitted(|current| {
                     println!("[Bulkhead] Worker permitted (concurrent: {})", current);

--- a/examples/observability_metrics.rs
+++ b/examples/observability_metrics.rs
@@ -234,7 +234,7 @@ async fn demo_bulkhead() {
     let service = BulkheadLayer::builder()
         .name("payment-bulkhead") // ← Named instance for metrics
         .max_concurrent_calls(2)
-        .max_wait_duration(Some(Duration::from_millis(100)))
+        .max_wait_duration(Duration::from_millis(100))
         .build()
         .layer(base_service);
 

--- a/examples/server_api.rs
+++ b/examples/server_api.rs
@@ -182,7 +182,7 @@ async fn scenario_bulkhead() {
     // Configure bulkhead: max 2 concurrent requests to expensive endpoint
     let bulkhead = BulkheadLayer::builder()
         .max_concurrent_calls(2)
-        .max_wait_duration(Some(Duration::from_millis(200)))
+        .max_wait_duration(Duration::from_millis(200))
         .name("report-endpoint")
         .on_call_permitted(|current| {
             println!("[Bulkhead] Call permitted (current: {})", current);
@@ -248,7 +248,7 @@ async fn scenario_full_server_stack() {
         .layer(
             BulkheadLayer::builder()
                 .max_concurrent_calls(3)
-                .max_wait_duration(Some(Duration::from_millis(500)))
+                .max_wait_duration(Duration::from_millis(500))
                 .name("api-server")
                 .on_call_permitted(|current| {
                     println!("[Bulkhead] Call permitted (current: {})", current);

--- a/tests/bulkhead/concurrency.rs
+++ b/tests/bulkhead/concurrency.rs
@@ -122,7 +122,7 @@ async fn rejection_under_load_with_timeout() {
         .layer(
             BulkheadLayer::builder()
                 .max_concurrent_calls(2)
-                .max_wait_duration(Some(Duration::from_millis(10)))
+                .max_wait_duration(Duration::from_millis(10))
                 .build(),
         )
         .service_fn(|_req: ()| async {
@@ -322,7 +322,7 @@ async fn zero_concurrent_immediately_rejects() {
         .layer(
             BulkheadLayer::builder()
                 .max_concurrent_calls(0)
-                .max_wait_duration(Some(Duration::from_millis(10)))
+                .max_wait_duration(Duration::from_millis(10))
                 .build(),
         )
         .service_fn(|_req: ()| async { Ok::<_, TestError>(()) });

--- a/tests/bulkhead/config.rs
+++ b/tests/bulkhead/config.rs
@@ -107,7 +107,7 @@ async fn test_max_concurrent_calls_zero() {
     // Zero concurrent calls means all calls should be rejected immediately
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(0)
-        .max_wait_duration(Some(Duration::from_millis(10)))
+        .max_wait_duration(Duration::from_millis(10))
         .name("zero-capacity-bulkhead")
         .build();
 
@@ -228,14 +228,13 @@ async fn test_config_timeout_some_vs_none() {
     // Config with Some timeout
     let layer_some = BulkheadLayer::builder()
         .max_concurrent_calls(1)
-        .max_wait_duration(Some(Duration::from_millis(50)))
+        .max_wait_duration(Duration::from_millis(50))
         .name("timeout-some")
         .build();
 
-    // Config with None timeout
+    // Config with no timeout (default: wait indefinitely)
     let layer_none = BulkheadLayer::builder()
         .max_concurrent_calls(1)
-        .max_wait_duration(None)
         .name("timeout-none")
         .build();
 
@@ -288,7 +287,7 @@ async fn test_builder_pattern_chaining() {
     // Test that all builder methods can be chained
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(10)
-        .max_wait_duration(Some(Duration::from_secs(1)))
+        .max_wait_duration(Duration::from_secs(1))
         .name("chained-bulkhead")
         .on_call_permitted(move |_| {
             c.fetch_add(1, Ordering::SeqCst);
@@ -440,7 +439,7 @@ async fn test_config_with_all_options() {
 
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(2)
-        .max_wait_duration(Some(Duration::from_millis(50)))
+        .max_wait_duration(Duration::from_millis(50))
         .name("comprehensive-bulkhead")
         .on_call_permitted(move |_| {
             p.fetch_add(1, Ordering::SeqCst);
@@ -504,7 +503,7 @@ async fn test_config_different_timeouts() {
     for (idx, timeout) in timeouts.iter().enumerate() {
         let layer = BulkheadLayer::builder()
             .max_concurrent_calls(5)
-            .max_wait_duration(Some(*timeout))
+            .max_wait_duration(*timeout)
             .name(format!("bulkhead-{}", idx))
             .build();
 

--- a/tests/bulkhead/integration.rs
+++ b/tests/bulkhead/integration.rs
@@ -72,7 +72,7 @@ async fn test_bulkhead_rejects_when_full_with_timeout() {
         .layer(
             BulkheadLayer::builder()
                 .max_concurrent_calls(2)
-                .max_wait_duration(Some(Duration::from_millis(10)))
+                .max_wait_duration(Duration::from_millis(10))
                 .build(),
         )
         .service_fn(|_req: ()| async {
@@ -184,7 +184,7 @@ async fn test_bulkhead_without_timeout_waits() {
         .layer(
             BulkheadLayer::builder()
                 .max_concurrent_calls(1)
-                .max_wait_duration(None) // Wait indefinitely
+                // Default: wait indefinitely
                 .build(),
         )
         .service_fn(|_req: ()| async {

--- a/tests/bulkhead/permits.rs
+++ b/tests/bulkhead/permits.rs
@@ -196,7 +196,7 @@ async fn test_permits_not_leaked_on_timeout() {
 
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(1)
-        .max_wait_duration(Some(Duration::from_millis(50)))
+        .max_wait_duration(Duration::from_millis(50))
         .name("no-leak-timeout-bulkhead")
         .on_call_permitted(move |_| {
             p.fetch_add(1, Ordering::SeqCst);

--- a/tests/bulkhead/timeout.rs
+++ b/tests/bulkhead/timeout.rs
@@ -21,7 +21,7 @@ impl From<BulkheadError> for TestError {
 async fn test_zero_timeout() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(1)
-        .max_wait_duration(Some(Duration::ZERO))
+        .max_wait_duration(Duration::ZERO)
         .name("zero-timeout-bulkhead")
         .build();
 
@@ -71,7 +71,7 @@ async fn test_zero_timeout() {
 async fn test_very_short_timeout() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(1)
-        .max_wait_duration(Some(Duration::from_millis(1)))
+        .max_wait_duration(Duration::from_millis(1))
         .name("short-timeout-bulkhead")
         .build();
 
@@ -125,7 +125,7 @@ async fn test_very_short_timeout() {
 async fn test_long_timeout() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(1)
-        .max_wait_duration(Some(Duration::from_secs(5)))
+        .max_wait_duration(Duration::from_secs(5))
         .name("long-timeout-bulkhead")
         .build();
 
@@ -175,7 +175,7 @@ async fn test_long_timeout() {
 async fn test_no_timeout_none() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(1)
-        .max_wait_duration(None) // No timeout
+        // Default: wait indefinitely (no timeout)
         .name("no-timeout-bulkhead")
         .build();
 
@@ -222,7 +222,7 @@ async fn test_timeout_precision() {
     let timeout_duration = Duration::from_millis(100);
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(1)
-        .max_wait_duration(Some(timeout_duration))
+        .max_wait_duration(timeout_duration)
         .name("precision-timeout-bulkhead")
         .build();
 
@@ -277,7 +277,7 @@ async fn test_multiple_timeouts() {
 
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(1)
-        .max_wait_duration(Some(Duration::from_millis(50)))
+        .max_wait_duration(Duration::from_millis(50))
         .name("multiple-timeout-bulkhead")
         .on_call_rejected(move |_| {
             r.fetch_add(1, Ordering::SeqCst);
@@ -333,7 +333,7 @@ async fn test_multiple_timeouts() {
 async fn test_timeout_then_success() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(1)
-        .max_wait_duration(Some(Duration::from_millis(50)))
+        .max_wait_duration(Duration::from_millis(50))
         .name("timeout-success-bulkhead")
         .build();
 
@@ -394,7 +394,7 @@ async fn test_timeout_then_success() {
 async fn test_concurrent_timeouts() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(2)
-        .max_wait_duration(Some(Duration::from_millis(50)))
+        .max_wait_duration(Duration::from_millis(50))
         .name("concurrent-timeout-bulkhead")
         .build();
 
@@ -447,7 +447,7 @@ async fn test_timeout_boundary_conditions() {
     // Test with max duration (approximately 2 minutes)
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(1)
-        .max_wait_duration(Some(Duration::from_secs(120)))
+        .max_wait_duration(Duration::from_secs(120))
         .name("boundary-timeout-bulkhead")
         .build();
 
@@ -473,13 +473,13 @@ async fn test_changing_timeout_behavior() {
     // Create two bulkheads with different timeouts
     let short_timeout = BulkheadLayer::builder()
         .max_concurrent_calls(1)
-        .max_wait_duration(Some(Duration::from_millis(10)))
+        .max_wait_duration(Duration::from_millis(10))
         .name("short-timeout")
         .build();
 
     let long_timeout = BulkheadLayer::builder()
         .max_concurrent_calls(1)
-        .max_wait_duration(Some(Duration::from_millis(200)))
+        .max_wait_duration(Duration::from_millis(200))
         .name("long-timeout")
         .build();
 

--- a/tests/composition_stacks/server_side.rs
+++ b/tests/composition_stacks/server_side.rs
@@ -55,7 +55,7 @@ async fn server_side_stack_compiles() {
 
     let bulkhead = BulkheadLayer::builder()
         .max_concurrent_calls(100)
-        .max_wait_duration(Some(Duration::from_secs(1)))
+        .max_wait_duration(Duration::from_secs(1))
         .build();
 
     let rate_limiter = RateLimiterLayer::builder()
@@ -93,7 +93,7 @@ async fn rate_limiter_only_compiles() {
 async fn bulkhead_tenant_isolation_compiles() {
     let bulkhead = BulkheadLayer::builder()
         .max_concurrent_calls(10) // Per-tenant limit
-        .max_wait_duration(Some(Duration::from_secs(5)))
+        .max_wait_duration(Duration::from_secs(5))
         .build();
 
     let timeout = TimeLimiterLayer::<HttpRequest>::builder()

--- a/tests/property/bulkhead.rs
+++ b/tests/property/bulkhead.rs
@@ -157,7 +157,7 @@ proptest! {
 
             let layer = BulkheadLayer::builder()
                 .max_concurrent_calls(max_concurrent)
-                .max_wait_duration(Some(Duration::from_secs(10)))
+                .max_wait_duration(Duration::from_secs(10))
                 .build();
 
             let service = layer.layer(tracker);
@@ -202,7 +202,7 @@ proptest! {
 
             let layer = BulkheadLayer::builder()
                 .max_concurrent_calls(max_concurrent)
-                .max_wait_duration(Some(Duration::from_secs(30)))
+                .max_wait_duration(Duration::from_secs(30))
                 .build();
 
             let service = layer.layer(counting_svc);

--- a/tests/stress/bulkhead.rs
+++ b/tests/stress/bulkhead.rs
@@ -44,7 +44,7 @@ async fn stress_large_queue() {
 
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(10)
-        .max_wait_duration(Some(Duration::from_secs(30)))
+        .max_wait_duration(Duration::from_secs(30))
         .build();
 
     let service = layer.layer(svc);
@@ -95,7 +95,7 @@ async fn stress_permit_churn() {
 
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(50)
-        .max_wait_duration(None) // No timeout
+        // Default: wait indefinitely (no timeout)
         .build();
 
     let service = layer.layer(svc);
@@ -152,7 +152,7 @@ async fn stress_long_running_operations() {
 
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(5)
-        .max_wait_duration(Some(Duration::from_secs(10)))
+        .max_wait_duration(Duration::from_secs(10))
         .build();
 
     let service = layer.layer(svc);
@@ -207,7 +207,7 @@ async fn stress_timeout_under_load() {
 
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(10)
-        .max_wait_duration(Some(Duration::from_millis(100)))
+        .max_wait_duration(Duration::from_millis(100))
         .build();
 
     let service = layer.layer(svc);
@@ -259,7 +259,7 @@ async fn stress_memory_with_queue() {
 
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(10)
-        .max_wait_duration(Some(Duration::from_secs(60)))
+        .max_wait_duration(Duration::from_secs(60))
         .build();
 
     let service = layer.layer(svc);
@@ -317,7 +317,7 @@ async fn stress_burst_pattern() {
 
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(20)
-        .max_wait_duration(Some(Duration::from_secs(5)))
+        .max_wait_duration(Duration::from_secs(5))
         .build();
 
     let service = layer.layer(svc);
@@ -384,7 +384,7 @@ async fn stress_mixed_operation_speeds() {
 
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(50)
-        .max_wait_duration(Some(Duration::from_secs(10)))
+        .max_wait_duration(Duration::from_secs(10))
         .build();
 
     let service = layer.layer(svc);


### PR DESCRIPTION
## Summary

- Change `max_wait_duration` builder method to accept `Duration` directly instead of `Option<Duration>`
- Update all call sites across examples, tests, and documentation
- Default behavior (wait indefinitely) is achieved by not calling the method

## Breaking Change

Users must update their code:
```rust
// Before
.max_wait_duration(Some(Duration::from_secs(5)))

// After
.max_wait_duration(Duration::from_secs(5))
```

For "wait indefinitely" (previously `.max_wait_duration(None)`), simply don't call the method.

## Rationale

This makes the API consistent with other duration methods in the crate:
- `CircuitBreakerLayer::sliding_window_duration(Duration)`
- `CircuitBreakerLayer::wait_duration_in_open(Duration)`
- `TimeLimiterLayer::timeout_duration(Duration)`
- `RateLimiterLayer::refresh_period(Duration)`
- etc.

Closes #192