### PR TITLE
feat!: simplify CircuitBreakerLayer API with trait-based classifiers

### DIFF
--- a/benches/comprehensive_benchmarks.rs
+++ b/benches/comprehensive_benchmarks.rs
@@ -212,7 +212,7 @@ fn bench_circuit_breaker_open(c: &mut Criterion) {
 
     c.bench_function("worst_case_circuit_breaker_open", |b| {
         b.to_async(&runtime).iter(|| async {
-            let layer = CircuitBreakerLayer::<TestResponse, TestError>::builder()
+            let layer = CircuitBreakerLayer::builder()
                 .failure_rate_threshold(0.0) // Open immediately on any failure
                 .sliding_window_size(10)
                 .build();

--- a/benches/happy_path_overhead.rs
+++ b/benches/happy_path_overhead.rs
@@ -4,7 +4,7 @@ use std::hint::black_box;
 use std::time::Duration;
 use tower::{Layer, Service, ServiceBuilder, ServiceExt};
 use tower_resilience_adaptive::{AdaptiveLimiterLayer, Aimd};
-use tower_resilience_bulkhead::{BulkheadLayer, BulkheadServiceError};
+use tower_resilience_bulkhead::BulkheadLayer;
 use tower_resilience_cache::CacheLayer;
 use tower_resilience_circuitbreaker::CircuitBreakerLayer;
 use tower_resilience_coalesce::CoalesceLayer;
@@ -75,7 +75,7 @@ fn bench_circuit_breaker(c: &mut Criterion) {
 
     c.bench_function("circuitbreaker_closed", |b| {
         b.to_async(&runtime).iter(|| async {
-            let layer = CircuitBreakerLayer::<TestResponse, TestError>::builder()
+            let layer = CircuitBreakerLayer::builder()
                 .failure_rate_threshold(0.5)
                 .sliding_window_size(100)
                 .build();
@@ -314,10 +314,9 @@ fn bench_composition_simple(c: &mut Criterion) {
         b.to_async(&runtime).iter(|| async {
             // CircuitBreaker wraps BulkheadServiceError<TestError> since Bulkhead now
             // returns BulkheadServiceError<S::Error> instead of S::Error
-            let cb_layer =
-                CircuitBreakerLayer::<TestResponse, BulkheadServiceError<TestError>>::builder()
-                    .failure_rate_threshold(0.5)
-                    .build();
+            let cb_layer = CircuitBreakerLayer::builder()
+                .failure_rate_threshold(0.5)
+                .build();
             let bh_config = BulkheadLayer::builder().max_concurrent_calls(100).build();
 
             let mut service = cb_layer.layer(

--- a/crates/tower-resilience-chaos/src/lib.rs
+++ b/crates/tower-resilience-chaos/src/lib.rs
@@ -65,7 +65,7 @@
 //!     .build();
 //!
 //! // Wrap with a circuit breaker
-//! let circuit_breaker = CircuitBreakerLayer::<String, std::io::Error>::builder()
+//! let circuit_breaker = CircuitBreakerLayer::builder()
 //!     .name("test-breaker")
 //!     .failure_rate_threshold(0.5)
 //!     .sliding_window_size(10)

--- a/crates/tower-resilience-circuitbreaker/examples/circuitbreaker_example.rs
+++ b/crates/tower-resilience-circuitbreaker/examples/circuitbreaker_example.rs
@@ -4,7 +4,7 @@
 
 use std::time::Duration;
 use tokio::time::sleep;
-use tower::{service_fn, Service};
+use tower::{service_fn, Layer, Service};
 use tower_resilience_circuitbreaker::CircuitBreakerLayer;
 
 #[tokio::main]
@@ -25,7 +25,7 @@ async fn main() {
     // Wrap it in a circuit breaker: opens if ≥50% of last 2 calls failed,
     // stays open 1s, then allows 1 trial in half-open.
     // If the trial succeeds, goes back to closed.
-    let breaker_layer = CircuitBreakerLayer::<String, ()>::builder()
+    let breaker_layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(2) // of the past two calls fail
         .wait_duration_in_open(Duration::from_secs(1)) // open for 1 second

--- a/crates/tower-resilience-circuitbreaker/examples/circuitbreaker_fallback.rs
+++ b/crates/tower-resilience-circuitbreaker/examples/circuitbreaker_fallback.rs
@@ -11,7 +11,7 @@
 use futures::future::BoxFuture;
 use std::sync::Arc;
 use std::time::Duration;
-use tower::{Service, ServiceExt};
+use tower::{Layer, Service, ServiceExt};
 use tower_resilience_circuitbreaker::{CircuitBreakerLayer, CircuitState};
 
 #[derive(Debug, Clone)]
@@ -92,7 +92,7 @@ async fn demo_static_fallback() {
 
     let service = FlakyService::new();
 
-    let circuit_breaker = CircuitBreakerLayer::<String, ServiceError>::builder()
+    let circuit_breaker = CircuitBreakerLayer::builder()
         .name("static-fallback-demo")
         .failure_rate_threshold(0.5)
         .sliding_window_size(10)
@@ -139,7 +139,7 @@ async fn demo_cached_fallback() {
 
     let service = FlakyService::new();
 
-    let circuit_breaker = CircuitBreakerLayer::<String, ServiceError>::builder()
+    let circuit_breaker = CircuitBreakerLayer::builder()
         .name("cache-fallback-demo")
         .failure_rate_threshold(0.5)
         .sliding_window_size(10)
@@ -186,7 +186,7 @@ async fn demo_degraded_fallback() {
 
     let service = FlakyService::new();
 
-    let circuit_breaker = CircuitBreakerLayer::<String, ServiceError>::builder()
+    let circuit_breaker = CircuitBreakerLayer::builder()
         .name("degraded-fallback-demo")
         .failure_rate_threshold(0.5)
         .sliding_window_size(10)

--- a/crates/tower-resilience-circuitbreaker/src/circuit.rs
+++ b/crates/tower-resilience-circuitbreaker/src/circuit.rs
@@ -112,7 +112,7 @@ impl Circuit {
     ///
     /// This method provides a consistent view of all metrics at a point in time.
     /// For time-based windows, it includes all records within the current window.
-    pub fn metrics(&self, config: &CircuitBreakerConfig<impl Sized, impl Sized>) -> CircuitMetrics {
+    pub fn metrics<C>(&self, config: &CircuitBreakerConfig<C>) -> CircuitMetrics {
         let (total_calls, failure_count, success_count, slow_call_count) =
             match config.sliding_window_type {
                 SlidingWindowType::CountBased => (
@@ -182,9 +182,9 @@ impl Circuit {
         (total, failures, successes, slow)
     }
 
-    pub fn record_success(
+    pub fn record_success<C>(
         &mut self,
-        config: &CircuitBreakerConfig<impl Sized, impl Sized>,
+        config: &CircuitBreakerConfig<C>,
         duration: std::time::Duration,
     ) {
         let is_slow = config
@@ -261,9 +261,9 @@ impl Circuit {
         }
     }
 
-    pub fn record_failure(
+    pub fn record_failure<C>(
         &mut self,
-        config: &CircuitBreakerConfig<impl Sized, impl Sized>,
+        config: &CircuitBreakerConfig<C>,
         duration: std::time::Duration,
     ) {
         let is_slow = config
@@ -334,7 +334,7 @@ impl Circuit {
         }
     }
 
-    pub fn try_acquire(&mut self, config: &CircuitBreakerConfig<impl Sized, impl Sized>) -> bool {
+    pub fn try_acquire<C>(&mut self, config: &CircuitBreakerConfig<C>) -> bool {
         match self.state {
             CircuitState::Closed => {
                 config
@@ -391,23 +391,19 @@ impl Circuit {
         }
     }
 
-    pub fn force_open(&mut self, config: &CircuitBreakerConfig<impl Sized, impl Sized>) {
+    pub fn force_open<C>(&mut self, config: &CircuitBreakerConfig<C>) {
         self.transition_to(CircuitState::Open, config);
     }
 
-    pub fn force_closed(&mut self, config: &CircuitBreakerConfig<impl Sized, impl Sized>) {
+    pub fn force_closed<C>(&mut self, config: &CircuitBreakerConfig<C>) {
         self.transition_to(CircuitState::Closed, config);
     }
 
-    pub fn reset(&mut self, config: &CircuitBreakerConfig<impl Sized, impl Sized>) {
+    pub fn reset<C>(&mut self, config: &CircuitBreakerConfig<C>) {
         self.transition_to(CircuitState::Closed, config);
     }
 
-    fn transition_to(
-        &mut self,
-        state: CircuitState,
-        config: &CircuitBreakerConfig<impl Sized, impl Sized>,
-    ) {
+    fn transition_to<C>(&mut self, state: CircuitState, config: &CircuitBreakerConfig<C>) {
         if self.state == state {
             return;
         }
@@ -463,7 +459,7 @@ impl Circuit {
         self.call_records.clear();
     }
 
-    fn evaluate_window(&mut self, config: &CircuitBreakerConfig<impl Sized, impl Sized>) {
+    fn evaluate_window<C>(&mut self, config: &CircuitBreakerConfig<C>) {
         let (total_count, failure_count, _success_count, slow_call_count) =
             match config.sliding_window_type {
                 SlidingWindowType::CountBased => (

--- a/crates/tower-resilience-circuitbreaker/src/classifier.rs
+++ b/crates/tower-resilience-circuitbreaker/src/classifier.rs
@@ -1,0 +1,172 @@
+//! Failure classification for circuit breaker decisions.
+//!
+//! This module provides the [`FailureClassifier`] trait and implementations
+//! for determining whether a service call result should be considered a failure.
+
+use std::sync::Arc;
+
+/// Trait for classifying whether a result represents a failure.
+///
+/// Implementors determine whether a given `Result<Res, Err>` should be
+/// counted as a failure for circuit breaker purposes.
+///
+/// # Type Parameters
+///
+/// - `Res`: The success response type
+/// - `Err`: The error type
+pub trait FailureClassifier<Res, Err>: Send + Sync {
+    /// Determines if the given result should be classified as a failure.
+    ///
+    /// Returns `true` if the result represents a failure that should count
+    /// toward the circuit breaker's failure rate.
+    fn classify(&self, result: &Result<Res, Err>) -> bool;
+}
+
+/// Default failure classifier that treats all errors as failures.
+///
+/// This classifier implements `FailureClassifier<Res, Err>` for **all** `Res` and `Err` types,
+/// meaning it can be used without specifying concrete response/error types at configuration time.
+///
+/// # Behavior
+///
+/// - `Ok(_)` => not a failure
+/// - `Err(_)` => failure
+///
+/// # Example
+///
+/// ```rust
+/// use tower_resilience_circuitbreaker::classifier::{FailureClassifier, DefaultClassifier};
+///
+/// let classifier = DefaultClassifier;
+///
+/// // Works with any Result type - type inference from the result argument
+/// assert!(!FailureClassifier::<String, std::io::Error>::classify(&classifier, &Ok("success".to_string())));
+/// assert!(FailureClassifier::<String, std::io::Error>::classify(&classifier, &Err(std::io::Error::other("fail"))));
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DefaultClassifier;
+
+impl<Res, Err> FailureClassifier<Res, Err> for DefaultClassifier {
+    fn classify(&self, result: &Result<Res, Err>) -> bool {
+        result.is_err()
+    }
+}
+
+/// A failure classifier backed by a closure.
+///
+/// This allows custom failure classification logic while maintaining type safety.
+/// The closure captures the concrete `Res` and `Err` types.
+///
+/// # Example
+///
+/// ```rust
+/// use tower_resilience_circuitbreaker::classifier::{FailureClassifier, FnClassifier};
+/// use std::io::{Error, ErrorKind};
+///
+/// // Don't count timeouts as failures
+/// let classifier = FnClassifier::new(|result: &Result<String, Error>| {
+///     match result {
+///         Ok(_) => false,
+///         Err(e) if e.kind() == ErrorKind::TimedOut => false,
+///         Err(_) => true,
+///     }
+/// });
+///
+/// assert!(!classifier.classify(&Ok("success".to_string())));
+/// assert!(!classifier.classify(&Err(Error::new(ErrorKind::TimedOut, "timeout"))));
+/// assert!(classifier.classify(&Err(Error::new(ErrorKind::Other, "other error"))));
+/// ```
+#[derive(Clone)]
+pub struct FnClassifier<F> {
+    f: Arc<F>,
+}
+
+impl<F> FnClassifier<F> {
+    /// Creates a new `FnClassifier` from the given closure.
+    pub fn new(f: F) -> Self {
+        Self { f: Arc::new(f) }
+    }
+}
+
+impl<F, Res, Err> FailureClassifier<Res, Err> for FnClassifier<F>
+where
+    F: Fn(&Result<Res, Err>) -> bool + Send + Sync,
+{
+    fn classify(&self, result: &Result<Res, Err>) -> bool {
+        (self.f)(result)
+    }
+}
+
+impl<F> std::fmt::Debug for FnClassifier<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FnClassifier")
+            .field("f", &"<closure>")
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_classifier_treats_errors_as_failures() {
+        let classifier = DefaultClassifier;
+
+        assert!(!FailureClassifier::<(), ()>::classify(&classifier, &Ok(())));
+        assert!(FailureClassifier::<(), ()>::classify(&classifier, &Err(())));
+    }
+
+    #[test]
+    fn default_classifier_works_with_any_types() {
+        let classifier = DefaultClassifier;
+
+        // String, io::Error
+        assert!(!FailureClassifier::<String, std::io::Error>::classify(
+            &classifier,
+            &Ok("ok".to_string())
+        ));
+        assert!(FailureClassifier::<String, std::io::Error>::classify(
+            &classifier,
+            &Err(std::io::Error::other("fail"))
+        ));
+
+        // i32, &str
+        assert!(!FailureClassifier::<i32, &str>::classify(
+            &classifier,
+            &Ok(42)
+        ));
+        assert!(FailureClassifier::<i32, &str>::classify(
+            &classifier,
+            &Err("error")
+        ));
+    }
+
+    #[test]
+    fn fn_classifier_custom_logic() {
+        // Only count "fatal" errors as failures
+        let classifier = FnClassifier::new(
+            |result: &Result<(), String>| matches!(result, Err(e) if e.contains("fatal")),
+        );
+
+        assert!(!classifier.classify(&Ok(())));
+        assert!(!classifier.classify(&Err("warning".to_string())));
+        assert!(classifier.classify(&Err("fatal error".to_string())));
+    }
+
+    #[test]
+    fn fn_classifier_can_treat_some_successes_as_failures() {
+        // Treat 5xx responses as failures even though they're Ok
+        let classifier = FnClassifier::new(|result: &Result<u16, ()>| match result {
+            Ok(status) if *status >= 500 => true,
+            Err(_) => true,
+            _ => false,
+        });
+
+        assert!(!classifier.classify(&Ok(200)));
+        assert!(!classifier.classify(&Ok(404)));
+        assert!(classifier.classify(&Ok(500)));
+        assert!(classifier.classify(&Ok(503)));
+        assert!(classifier.classify(&Err(())));
+    }
+}

--- a/crates/tower-resilience/src/composition.rs
+++ b/crates/tower-resilience/src/composition.rs
@@ -966,7 +966,7 @@ pub mod advanced {
     //!     .build()
     //!     .layer(base_service);
     //!
-    //! let with_circuit_breaker = CircuitBreakerLayer::<Request, MyError>::builder()
+    //! let with_circuit_breaker = CircuitBreakerLayer::builder()
     //!     .failure_rate_threshold(0.5)
     //!     .build()
     //!     .layer(with_retry);

--- a/crates/tower-resilience/src/lib.rs
+++ b/crates/tower-resilience/src/lib.rs
@@ -77,7 +77,7 @@
 //! # async fn example() {
 //! # let http_client = tower::service_fn(|_req: ()| async { Ok::<_, MyError>(()) });
 //! // Build a resilient HTTP client
-//! let circuit_breaker = CircuitBreakerLayer::<(), MyError>::builder()
+//! let circuit_breaker = CircuitBreakerLayer::builder()
 //!     .name("api-client")
 //!     .failure_rate_threshold(0.5)
 //!     .sliding_window_size(100)
@@ -91,7 +91,7 @@
 //!
 //! // Compose manually for reliability
 //! let resilient_client = retry.layer(http_client);
-//! let resilient_client = circuit_breaker.layer::<_, ()>(resilient_client);
+//! let resilient_client = circuit_breaker.layer(resilient_client);
 //! # }
 //! # }
 //! ```

--- a/crates/tower-resilience/src/patterns.rs
+++ b/crates/tower-resilience/src/patterns.rs
@@ -78,14 +78,14 @@ pub mod circuit_breaker {
     //!
     //! # async fn example() {
     //! # let database_client = tower::service_fn(|_req: ()| async { Ok::<_, std::io::Error>(()) });
-    //! let circuit_breaker = CircuitBreakerLayer::<(), std::io::Error>::builder()
+    //! let circuit_breaker = CircuitBreakerLayer::builder()
     //!     .failure_rate_threshold(0.5)      // Open at 50% failures
     //!     .sliding_window_size(100)         // Over last 100 calls
     //!     .minimum_number_of_calls(10)      // Need at least 10 calls
     //!     .wait_duration_in_open(Duration::from_secs(30))  // Stay open 30s
     //!     .build();
     //!
-    //! let service = circuit_breaker.layer::<_, ()>(database_client);
+    //! let service = circuit_breaker.layer(database_client);
     //! # }
     //! # }
     //! ```

--- a/examples/axum-resilient-kv-store/src/main.rs
+++ b/examples/axum-resilient-kv-store/src/main.rs
@@ -28,8 +28,8 @@ use std::{
     time::Duration,
 };
 use tokio::net::TcpListener;
-use tower::{Service, ServiceExt};
-use tower_resilience_circuitbreaker::{CircuitBreaker, CircuitBreakerLayer};
+use tower::{Layer, Service, ServiceExt};
+use tower_resilience_circuitbreaker::{CircuitBreaker, CircuitBreakerLayer, DefaultClassifier};
 
 /// Database request
 #[derive(Clone, Debug)]
@@ -101,7 +101,7 @@ impl tower::Service<DbRequest> for DatabaseService {
     }
 }
 
-type DbService = CircuitBreaker<DatabaseService, DbRequest, DbResponse, DbError>;
+type DbService = CircuitBreaker<DatabaseService, DefaultClassifier>;
 
 #[derive(Clone)]
 struct AppState {

--- a/examples/circuitbreaker.rs
+++ b/examples/circuitbreaker.rs
@@ -4,7 +4,7 @@
 
 use std::time::Duration;
 use tokio::time::sleep;
-use tower::{Service, service_fn};
+use tower::{Layer, Service, service_fn};
 use tower_resilience_circuitbreaker::CircuitBreakerLayer;
 
 #[tokio::main]
@@ -25,7 +25,7 @@ async fn main() {
     // Wrap it in a circuit breaker: opens if ≥50% of last 2 calls failed,
     // stays open 1s, then allows 1 trial in half-open.
     // If the trial succeeds, goes back to closed.
-    let breaker_layer = CircuitBreakerLayer::<String, ()>::builder()
+    let breaker_layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(2) // of the past two calls fail
         .wait_duration_in_open(Duration::from_secs(1)) // open for 1 second

--- a/examples/composition_outbound.rs
+++ b/examples/composition_outbound.rs
@@ -217,7 +217,7 @@ async fn scenario_circuit_breaker() {
     });
 
     // Circuit breaker to fail fast
-    let circuit_breaker = CircuitBreakerLayer::<Response, ClientError>::builder()
+    let circuit_breaker = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(4)
         .minimum_number_of_calls(2)
@@ -314,7 +314,7 @@ async fn scenario_full_stack() {
     // Client resilience stack: Cache -> Circuit Breaker -> Retry
     // Note: Complex multi-layer stacks can hit trait bound limitations
     // In practice, layers can be applied at different architectural points
-    let circuit_breaker_layer = CircuitBreakerLayer::<Response, ClientError>::builder()
+    let circuit_breaker_layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.6)
         .sliding_window_size(6)
         .minimum_number_of_calls(3)
@@ -350,7 +350,7 @@ async fn scenario_full_stack() {
                 .build(),
         )
         // 2. Circuit breaker - fail fast when downstream is degraded
-        .layer(circuit_breaker_layer.for_request::<Request>())
+        .layer(circuit_breaker_layer)
         // 3. Retry - Handle transient failures
         .layer(
             RetryLayer::<Request, ClientError>::builder()

--- a/examples/database_client.rs
+++ b/examples/database_client.rs
@@ -166,7 +166,7 @@ async fn scenario_circuit_breaker() {
     });
 
     // Configure circuit breaker: open after 50% failure rate over 4 calls
-    let circuit_breaker = CircuitBreakerLayer::<Vec<String>, DbError>::builder()
+    let circuit_breaker = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(4)
         .minimum_number_of_calls(2)
@@ -230,7 +230,7 @@ async fn scenario_full_stack() {
         .retry_on(|err| matches!(err, DbError::Transient(_)))
         .build();
 
-    let circuit_breaker = CircuitBreakerLayer::<Vec<String>, DbError>::builder()
+    let circuit_breaker = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.6)
         .sliding_window_size(10)
         .minimum_number_of_calls(3)

--- a/examples/message_queue_worker.rs
+++ b/examples/message_queue_worker.rs
@@ -280,7 +280,7 @@ async fn scenario_circuit_breaker() {
     });
 
     // Configure circuit breaker
-    let circuit_breaker = CircuitBreakerLayer::<ProcessingResult, ProcessingError>::builder()
+    let circuit_breaker = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(4)
         .minimum_number_of_calls(2)

--- a/tests/circuitbreaker/combinations.rs
+++ b/tests/circuitbreaker/combinations.rs
@@ -4,7 +4,7 @@ use std::sync::{
 };
 use std::time::Duration;
 use tokio::time::sleep;
-use tower::Service;
+use tower::{Layer, Service};
 use tower_resilience_circuitbreaker::CircuitBreakerLayer;
 use tower_resilience_circuitbreaker::{CircuitState, SlidingWindowType};
 
@@ -43,7 +43,7 @@ async fn time_based_slow_call_failure_classification() {
         }
     });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .sliding_window_type(SlidingWindowType::TimeBased)
         .sliding_window_duration(Duration::from_secs(5))
         .failure_rate_threshold(0.7) // 60% failure rate < 70%
@@ -84,7 +84,7 @@ async fn count_based_dual_thresholds() {
         }
     });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .sliding_window_type(SlidingWindowType::CountBased)
         .sliding_window_size(10)
         .failure_rate_threshold(0.6) // 50% < 60%, won't trip
@@ -129,7 +129,7 @@ async fn custom_classifier_with_slow_calls() {
     });
 
     // Only count "fatal_error" as failures
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .sliding_window_size(10)
         .failure_rate_threshold(0.5)
         .slow_call_duration_threshold(Duration::from_millis(80)) // Lower threshold with more margin
@@ -185,7 +185,7 @@ async fn event_listeners_with_complex_config() {
         }
     });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .sliding_window_type(SlidingWindowType::TimeBased)
         .sliding_window_duration(Duration::from_secs(10))
         .failure_rate_threshold(0.5)
@@ -236,7 +236,7 @@ async fn event_listeners_with_complex_config() {
 async fn manual_override_during_failures() {
     let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(10)
         .minimum_number_of_calls(5)
@@ -287,7 +287,7 @@ async fn custom_classifier_transient_errors() {
     });
 
     // Only "transient_error" counts as failure
-    let layer = CircuitBreakerLayer::<String, &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .sliding_window_size(10)
         .failure_rate_threshold(0.7)
         .minimum_number_of_calls(5)
@@ -338,7 +338,7 @@ async fn time_based_kitchen_sink() {
         }
     });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .sliding_window_type(SlidingWindowType::TimeBased)
         .sliding_window_duration(Duration::from_secs(10))
         .failure_rate_threshold(0.7)

--- a/tests/circuitbreaker/config_validation.rs
+++ b/tests/circuitbreaker/config_validation.rs
@@ -3,14 +3,14 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering},
 };
 use std::time::Duration;
-use tower::Service;
+use tower::{Layer, Service};
 use tower_resilience_circuitbreaker::CircuitBreakerLayer;
 use tower_resilience_circuitbreaker::SlidingWindowType;
 
 /// Test that configuration builder accepts valid values
 #[test]
 fn valid_config_values() {
-    let _config = CircuitBreakerLayer::<(), String>::builder()
+    let _config = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .slow_call_rate_threshold(0.6)
         .sliding_window_size(100)
@@ -27,7 +27,7 @@ fn valid_config_values() {
 async fn failure_rate_threshold_zero() {
     let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.0)
         .sliding_window_size(10)
         .minimum_number_of_calls(5)
@@ -67,7 +67,7 @@ async fn failure_rate_threshold_one() {
         }
     });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(1.0)
         .sliding_window_size(10)
         .minimum_number_of_calls(5)
@@ -98,7 +98,7 @@ async fn slow_call_rate_threshold_zero() {
         Ok::<_, String>("success")
     });
 
-    let layer = CircuitBreakerLayer::<&str, String>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .slow_call_duration_threshold(Duration::from_millis(100))
         .slow_call_rate_threshold(0.0)
         .sliding_window_size(5)
@@ -128,7 +128,7 @@ async fn slow_call_rate_threshold_one() {
         Ok::<_, String>("success")
     });
 
-    let layer = CircuitBreakerLayer::<&str, String>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .slow_call_duration_threshold(Duration::from_millis(100))
         .slow_call_rate_threshold(1.0)
         .sliding_window_size(5)
@@ -155,7 +155,7 @@ async fn slow_call_rate_threshold_one() {
 async fn sliding_window_size_one() {
     let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(1)
         .minimum_number_of_calls(1)
@@ -178,7 +178,7 @@ async fn sliding_window_size_one() {
 async fn minimum_calls_zero() {
     let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(10)
         .minimum_number_of_calls(0)
@@ -200,7 +200,7 @@ async fn minimum_calls_zero() {
 async fn minimum_calls_greater_than_window() {
     let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(5)
         .minimum_number_of_calls(10) // More than window size
@@ -237,7 +237,7 @@ async fn minimum_calls_greater_than_window() {
 async fn minimum_calls_equals_window() {
     let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(5)
         .minimum_number_of_calls(5)
@@ -263,7 +263,7 @@ async fn minimum_calls_equals_window() {
 async fn zero_wait_duration() {
     let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(5)
         .minimum_number_of_calls(3)
@@ -296,7 +296,7 @@ async fn zero_wait_duration() {
 async fn zero_permitted_calls_half_open() {
     let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(5)
         .minimum_number_of_calls(3)
@@ -327,7 +327,7 @@ async fn zero_permitted_calls_half_open() {
 #[test]
 #[should_panic(expected = "sliding_window_duration must be set")]
 fn time_based_without_duration() {
-    let _layer = CircuitBreakerLayer::<(), String>::builder()
+    let _layer = CircuitBreakerLayer::builder()
         .sliding_window_type(SlidingWindowType::TimeBased)
         // Not setting sliding_window_duration - should panic
         .failure_rate_threshold(0.5)
@@ -342,7 +342,7 @@ fn time_based_without_duration() {
 async fn count_based_with_duration() {
     let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .sliding_window_type(SlidingWindowType::CountBased)
         .sliding_window_duration(Duration::from_secs(10)) // Should be ignored
         .sliding_window_size(5)
@@ -370,7 +370,7 @@ async fn count_based_with_duration() {
 async fn very_large_window_size() {
     let service = tower::service_fn(|_req: ()| async { Ok::<_, String>("success") });
 
-    let layer = CircuitBreakerLayer::<&str, String>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .sliding_window_size(10000)
         .minimum_number_of_calls(100)
         .failure_rate_threshold(0.5)

--- a/tests/circuitbreaker/edge_cases.rs
+++ b/tests/circuitbreaker/edge_cases.rs
@@ -4,7 +4,7 @@ use std::sync::{
 };
 use std::time::Duration;
 use tokio::time::sleep;
-use tower::Service;
+use tower::{Layer, Service};
 use tower_resilience_circuitbreaker::CircuitBreakerLayer;
 use tower_resilience_circuitbreaker::CircuitState;
 
@@ -21,7 +21,7 @@ async fn multiple_event_listeners() {
 
     let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(5)
         .minimum_number_of_calls(5)
@@ -68,7 +68,7 @@ async fn failure_classifier_all_success() {
     let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
 
     // Classifier that treats all results as success (even errors)
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(10)
         .minimum_number_of_calls(5)
@@ -92,7 +92,7 @@ async fn failure_classifier_all_failure() {
     let service = tower::service_fn(|_req: ()| async { Ok::<(), &str>(()) });
 
     // Classifier that treats all results as failure (even successes)
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(10)
         .minimum_number_of_calls(5)
@@ -121,7 +121,7 @@ async fn slow_call_exactly_at_threshold() {
     let slow_call_count = Arc::new(AtomicUsize::new(0));
     let sc = Arc::clone(&slow_call_count);
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .slow_call_duration_threshold(Duration::from_millis(100))
         .slow_call_rate_threshold(0.5)
         .sliding_window_size(10)
@@ -152,7 +152,7 @@ async fn slow_call_very_fast_calls() {
     let slow_call_count = Arc::new(AtomicUsize::new(0));
     let sc = Arc::clone(&slow_call_count);
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .slow_call_duration_threshold(Duration::from_secs(10))
         .slow_call_rate_threshold(0.5)
         .sliding_window_size(100)
@@ -195,7 +195,7 @@ async fn failure_classifier_mixed_error_types() {
     });
 
     // Only count "internal_error" as failures
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.4)
         .sliding_window_size(12)
         .minimum_number_of_calls(12)
@@ -247,7 +247,7 @@ async fn all_event_types_emitted() {
         }
     });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(5)
         .minimum_number_of_calls(5)
@@ -306,7 +306,7 @@ async fn all_event_types_emitted() {
 async fn sliding_window_size_one() {
     let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(1)
         .minimum_number_of_calls(1)
@@ -337,7 +337,7 @@ async fn half_open_one_permitted_call() {
         }
     });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(5)
         .minimum_number_of_calls(5)

--- a/tests/circuitbreaker/half_open.rs
+++ b/tests/circuitbreaker/half_open.rs
@@ -4,7 +4,7 @@ use std::sync::{
 };
 use std::time::Duration;
 use tokio::time::sleep;
-use tower::Service;
+use tower::{Layer, Service};
 use tower_resilience_circuitbreaker::CircuitBreakerLayer;
 use tower_resilience_circuitbreaker::CircuitState;
 
@@ -13,7 +13,7 @@ use tower_resilience_circuitbreaker::CircuitState;
 async fn concurrent_calls_in_half_open() {
     let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(5)
         .minimum_number_of_calls(3)
@@ -79,7 +79,7 @@ async fn partial_success_in_half_open() {
         }
     });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(5)
         .minimum_number_of_calls(3)
@@ -119,7 +119,7 @@ async fn all_failures_in_half_open_various_permits() {
     for permitted in [1, 2, 5, 10] {
         let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
 
-        let layer = CircuitBreakerLayer::<(), &str>::builder()
+        let layer = CircuitBreakerLayer::builder()
             .failure_rate_threshold(0.5)
             .sliding_window_size(5)
             .minimum_number_of_calls(3)
@@ -154,7 +154,7 @@ async fn all_failures_in_half_open_various_permits() {
 async fn rapid_state_cycling() {
     let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(5)
         .minimum_number_of_calls(3)
@@ -211,7 +211,7 @@ async fn half_open_with_time_based_window() {
         }
     });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .sliding_window_type(SlidingWindowType::TimeBased)
         .sliding_window_duration(Duration::from_secs(10))
         .failure_rate_threshold(0.5)
@@ -261,7 +261,7 @@ async fn half_open_with_slow_call_detection() {
         }
     });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .slow_call_duration_threshold(Duration::from_millis(100))
         .slow_call_rate_threshold(0.9)
@@ -310,7 +310,7 @@ async fn half_open_with_minimum_calls() {
         }
     });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(10)
         .minimum_number_of_calls(5)
@@ -344,7 +344,7 @@ async fn half_open_with_minimum_calls() {
 async fn half_open_rejected_calls_no_effect() {
     let service = tower::service_fn(|_req: ()| async { Ok::<(), String>(()) });
 
-    let layer = CircuitBreakerLayer::<(), String>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(5)
         .minimum_number_of_calls(3)

--- a/tests/circuitbreaker/integration.rs
+++ b/tests/circuitbreaker/integration.rs
@@ -7,9 +7,9 @@ use std::sync::{
 };
 use std::task::{Context, Poll};
 use std::time::Duration;
-use tower::{Service, ServiceBuilder, service_fn};
-use tower_resilience_circuitbreaker::CircuitBreakerLayer;
+use tower::{Layer, Service, ServiceBuilder, service_fn};
 use tower_resilience_circuitbreaker::{CircuitBreakerError, CircuitState};
+use tower_resilience_circuitbreaker::{CircuitBreakerLayer, DefaultClassifier};
 
 #[derive(Clone)]
 struct FlakyService {
@@ -47,7 +47,7 @@ impl Service<()> for FlakyService {
 async fn circuit_opens_after_consecutive_failures() {
     let service = FlakyService::new(3);
 
-    let layer = CircuitBreakerLayer::<&'static str, &'static str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(6)
         .wait_duration_in_open(Duration::from_millis(100))
@@ -69,7 +69,7 @@ async fn circuit_opens_after_consecutive_failures() {
 #[tokio::test]
 async fn circuit_transitions_through_half_open_and_recovers() {
     let failing_service = FlakyService::new(0);
-    let layer = CircuitBreakerLayer::<&'static str, &'static str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(4)
         .wait_duration_in_open(Duration::from_millis(100))
@@ -97,7 +97,7 @@ async fn circuit_transitions_through_half_open_and_recovers() {
 #[tokio::test]
 async fn circuit_rejects_when_open() {
     let service = FlakyService::new(0);
-    let layer = CircuitBreakerLayer::<&'static str, &'static str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(2)
         .wait_duration_in_open(Duration::from_secs(1))
@@ -116,7 +116,7 @@ async fn circuit_rejects_when_open() {
 #[tokio::test]
 async fn half_open_fails_and_reopens() {
     let service = FlakyService::new(0); // always fails
-    let layer = CircuitBreakerLayer::<&'static str, &'static str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(1.0)
         .sliding_window_size(2)
         .wait_duration_in_open(Duration::from_millis(100))
@@ -137,7 +137,7 @@ async fn half_open_fails_and_reopens() {
 #[tokio::test]
 async fn does_not_trip_before_window_full() {
     let service = FlakyService::new(1);
-    let layer = CircuitBreakerLayer::<&'static str, &'static str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(1.0)
         .sliding_window_size(10)
         .wait_duration_in_open(Duration::from_secs(1))
@@ -155,7 +155,7 @@ async fn does_not_trip_before_window_full() {
 #[tokio::test]
 async fn all_successes_keep_circuit_closed() {
     let service = FlakyService::new(100);
-    let layer = CircuitBreakerLayer::<&'static str, &'static str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.1)
         .sliding_window_size(5)
         .wait_duration_in_open(Duration::from_secs(1))
@@ -172,22 +172,18 @@ async fn all_successes_keep_circuit_closed() {
 
 #[tokio::test]
 async fn integrates_with_service_builder_layer() {
-    let layer = CircuitBreakerLayer::<&'static str, &'static str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(4)
         .wait_duration_in_open(Duration::from_secs(1))
         .build();
 
-    let mut service: tower_resilience_circuitbreaker::CircuitBreaker<
-        _,
-        (),
-        &'static str,
-        &'static str,
-    > = ServiceBuilder::new()
-        .layer(layer.for_request::<()>())
-        .service(service_fn(
-            |_: ()| async move { Ok::<_, &'static str>("ok") },
-        ));
+    let mut service: tower_resilience_circuitbreaker::CircuitBreaker<_, DefaultClassifier> =
+        ServiceBuilder::new()
+            .layer(layer)
+            .service(service_fn(
+                |_: ()| async move { Ok::<_, &'static str>("ok") },
+            ));
 
     let response = service.call(()).await.expect("call should succeed");
     assert_eq!(response, "ok");
@@ -196,7 +192,7 @@ async fn integrates_with_service_builder_layer() {
 #[tokio::test]
 async fn does_not_trip_if_minimum_not_met() {
     let service = FlakyService::new(0); // always fails
-    let layer = CircuitBreakerLayer::<&'static str, &'static str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.1)
         .sliding_window_size(10)
         .minimum_number_of_calls(6)
@@ -223,7 +219,7 @@ async fn does_not_trip_if_minimum_not_met() {
 async fn closed_open_halfopen_closed_cycle() {
     let service = service_fn(|req: bool| async move { if req { Ok("ok") } else { Err("fail") } });
 
-    let layer = CircuitBreakerLayer::<&'static str, &'static str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(2)
         .wait_duration_in_open(Duration::from_millis(50))
@@ -265,7 +261,7 @@ async fn metrics_are_emitted() {
     let _ = set_global_recorder(&*RECORDER);
 
     let service = FlakyService::new(0); // always fails
-    let layer = CircuitBreakerLayer::<&'static str, &'static str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(1.0)
         .sliding_window_size(1)
         .minimum_number_of_calls(1)
@@ -331,7 +327,7 @@ async fn metrics_are_emitted() {
 async fn fallback_is_called_when_circuit_open() {
     let service = FlakyService::new(0); // always fails
 
-    let layer = CircuitBreakerLayer::<&'static str, &'static str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(2)
         .wait_duration_in_open(Duration::from_secs(10))
@@ -361,7 +357,7 @@ async fn fallback_is_called_when_circuit_open() {
 async fn no_fallback_returns_error_when_circuit_open() {
     let service = FlakyService::new(0); // always fails
 
-    let layer = CircuitBreakerLayer::<&'static str, &'static str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(2)
         .wait_duration_in_open(Duration::from_secs(10))
@@ -402,18 +398,15 @@ async fn multi_layer_composition_with_timeout() {
         .timeout_duration(Duration::from_millis(100))
         .build();
 
-    let circuit_breaker_layer = CircuitBreakerLayer::<
-        &'static str,
-        tower_resilience_timelimiter::TimeLimiterError<&'static str>,
-    >::builder()
-    .failure_rate_threshold(0.5)
-    .sliding_window_size(4)
-    .minimum_number_of_calls(2)
-    .wait_duration_in_open(Duration::from_secs(10))
-    .build();
+    let circuit_breaker_layer = CircuitBreakerLayer::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(4)
+        .minimum_number_of_calls(2)
+        .wait_duration_in_open(Duration::from_secs(10))
+        .build();
 
     let mut composed = ServiceBuilder::new()
-        .layer(circuit_breaker_layer.for_request::<u64>())
+        .layer(circuit_breaker_layer)
         .layer(timeout_layer)
         .service(service);
 
@@ -452,7 +445,7 @@ async fn multi_layer_composition_with_retry() {
 
     // Compose circuit breaker + retry
     // Note: Retry is inner, so it retries before circuit breaker sees failures
-    let circuit_breaker_layer = CircuitBreakerLayer::<&'static str, &'static str>::builder()
+    let circuit_breaker_layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(4)
         .minimum_number_of_calls(2)
@@ -465,7 +458,7 @@ async fn multi_layer_composition_with_retry() {
         .build();
 
     let mut composed = ServiceBuilder::new()
-        .layer(circuit_breaker_layer.for_request::<()>())
+        .layer(circuit_breaker_layer)
         .layer(retry_layer)
         .service(service);
 

--- a/tests/circuitbreaker/thresholds.rs
+++ b/tests/circuitbreaker/thresholds.rs
@@ -4,7 +4,7 @@ use std::sync::{
 };
 use std::time::Duration;
 use tokio::time::sleep;
-use tower::Service;
+use tower::{Layer, Service};
 use tower_resilience_circuitbreaker::CircuitBreakerLayer;
 use tower_resilience_circuitbreaker::CircuitState;
 
@@ -26,7 +26,7 @@ async fn failure_rate_exactly_at_threshold() {
         }
     });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(10)
         .minimum_number_of_calls(10)
@@ -62,7 +62,7 @@ async fn failure_rate_just_below_threshold() {
         }
     });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(10)
         .minimum_number_of_calls(10)
@@ -98,7 +98,7 @@ async fn failure_rate_just_above_threshold() {
         }
     });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(10)
         .minimum_number_of_calls(10)
@@ -135,7 +135,7 @@ async fn slow_call_rate_exactly_at_threshold() {
         }
     });
 
-    let layer = CircuitBreakerLayer::<&str, String>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .slow_call_duration_threshold(Duration::from_millis(100))
         .slow_call_rate_threshold(0.5)
         .sliding_window_size(10)
@@ -163,7 +163,7 @@ async fn duration_exactly_at_slow_threshold() {
         Ok::<_, String>("success")
     });
 
-    let layer = CircuitBreakerLayer::<&str, String>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .slow_call_duration_threshold(Duration::from_millis(100))
         .slow_call_rate_threshold(0.5)
         .sliding_window_size(5)
@@ -191,7 +191,7 @@ async fn duration_just_below_slow_threshold() {
         Ok::<_, String>("success")
     });
 
-    let layer = CircuitBreakerLayer::<&str, String>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .slow_call_duration_threshold(Duration::from_millis(100))
         .slow_call_rate_threshold(0.5)
         .sliding_window_size(5)
@@ -219,7 +219,7 @@ async fn duration_just_above_slow_threshold() {
         Ok::<_, String>("success")
     });
 
-    let layer = CircuitBreakerLayer::<&str, String>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .slow_call_duration_threshold(Duration::from_millis(100))
         .slow_call_rate_threshold(0.5)
         .sliding_window_size(5)
@@ -268,7 +268,7 @@ async fn combined_failure_and_slow_thresholds() {
         }
     });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5) // 30% failure rate < 50%
         .slow_call_duration_threshold(Duration::from_millis(100))
         .slow_call_rate_threshold(0.4) // 30% slow rate < 40%
@@ -297,7 +297,7 @@ async fn either_threshold_can_trip() {
         Ok::<_, String>("success")
     });
 
-    let layer = CircuitBreakerLayer::<&str, String>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5) // 0% < 50%, would not trip
         .slow_call_duration_threshold(Duration::from_millis(100))
         .slow_call_rate_threshold(0.5) // 100% >= 50%, will trip
@@ -335,7 +335,7 @@ async fn floating_point_precision() {
         }
     });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.33) // 33.333...% > 33%
         .sliding_window_size(3)
         .minimum_number_of_calls(3)
@@ -358,7 +358,7 @@ async fn floating_point_precision() {
 async fn threshold_small_window() {
     let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.99) // Very high threshold
         .sliding_window_size(2)
         .minimum_number_of_calls(2)

--- a/tests/circuitbreaker/time_based.rs
+++ b/tests/circuitbreaker/time_based.rs
@@ -4,7 +4,7 @@ use std::sync::{
 };
 use std::time::Duration;
 use tokio::time::sleep;
-use tower::Service;
+use tower::{Layer, Service};
 use tower_resilience_circuitbreaker::CircuitBreakerLayer;
 use tower_resilience_circuitbreaker::{CircuitState, SlidingWindowType};
 
@@ -19,7 +19,7 @@ async fn time_window_fills_and_evaluates() {
         async { Err::<(), _>("error") }
     });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .sliding_window_type(SlidingWindowType::TimeBased)
         .sliding_window_duration(Duration::from_millis(500))
         .failure_rate_threshold(0.5)
@@ -45,7 +45,7 @@ async fn time_window_fills_and_evaluates() {
 async fn old_records_cleaned_up() {
     let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .sliding_window_type(SlidingWindowType::TimeBased)
         .sliding_window_duration(Duration::from_millis(200))
         .failure_rate_threshold(0.5)
@@ -69,7 +69,7 @@ async fn old_records_cleaned_up() {
 
     // Create new success service
     let success_service = tower::service_fn(|_req: ()| async { Ok::<_, String>("success") });
-    let layer2 = CircuitBreakerLayer::<&str, String>::builder()
+    let layer2 = CircuitBreakerLayer::builder()
         .sliding_window_type(SlidingWindowType::TimeBased)
         .sliding_window_duration(Duration::from_millis(200))
         .failure_rate_threshold(0.5)
@@ -98,7 +98,7 @@ async fn time_based_window_with_slow_calls() {
         Ok::<_, String>("success")
     });
 
-    let layer = CircuitBreakerLayer::<&str, String>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .sliding_window_type(SlidingWindowType::TimeBased)
         .sliding_window_duration(Duration::from_millis(500))
         .slow_call_duration_threshold(Duration::from_millis(100))
@@ -137,7 +137,7 @@ async fn time_based_window_with_failure_rate() {
         }
     });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .sliding_window_type(SlidingWindowType::TimeBased)
         .sliding_window_duration(Duration::from_millis(500))
         .failure_rate_threshold(0.6)
@@ -165,7 +165,7 @@ async fn calls_at_duration_boundary() {
 
     let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .sliding_window_type(SlidingWindowType::TimeBased)
         .sliding_window_duration(window_duration)
         .failure_rate_threshold(0.5)
@@ -195,7 +195,7 @@ async fn calls_at_duration_boundary() {
 async fn fast_calls_slow_duration() {
     let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .sliding_window_type(SlidingWindowType::TimeBased)
         .sliding_window_duration(Duration::from_secs(10)) // Long window
         .failure_rate_threshold(0.5)
@@ -233,7 +233,7 @@ async fn time_based_mixed_results() {
         }
     });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .sliding_window_type(SlidingWindowType::TimeBased)
         .sliding_window_duration(Duration::from_millis(500))
         .failure_rate_threshold(0.7)
@@ -258,7 +258,7 @@ async fn time_based_mixed_results() {
 async fn time_based_memory_bounds() {
     let service = tower::service_fn(|_req: ()| async { Ok::<_, String>("success") });
 
-    let layer = CircuitBreakerLayer::<&str, String>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .sliding_window_type(SlidingWindowType::TimeBased)
         .sliding_window_duration(Duration::from_millis(100))
         .failure_rate_threshold(0.5)
@@ -291,7 +291,7 @@ async fn time_based_memory_bounds() {
 async fn time_based_respects_minimum_calls() {
     let service = tower::service_fn(|_req: ()| async { Err::<(), _>("error") });
 
-    let layer = CircuitBreakerLayer::<(), &str>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .sliding_window_type(SlidingWindowType::TimeBased)
         .sliding_window_duration(Duration::from_millis(500))
         .failure_rate_threshold(0.5)

--- a/tests/composition_stacks/caching.rs
+++ b/tests/composition_stacks/caching.rs
@@ -46,7 +46,7 @@ async fn standard_cache_stack_compiles() {
     // Fallback to None (cache miss) on error - outermost to catch all errors
     let fallback = FallbackLayer::<CacheKey, CacheValue, RedisError>::value(CacheValue(None));
 
-    let circuit_breaker = CircuitBreakerLayer::<CacheKey, RedisError>::builder()
+    let circuit_breaker = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.3) // Sensitive threshold for cache
         .build();
 
@@ -59,7 +59,7 @@ async fn standard_cache_stack_compiles() {
     // Manual composition (innermost to outermost)
     // ServiceBuilder order: Fallback -> Timeout -> CircuitBreaker -> service
     // Manual order: apply CircuitBreaker first, then Timeout, then Fallback
-    let with_cb = circuit_breaker.layer::<_, CacheKey>(redis_client);
+    let with_cb = circuit_breaker.layer(redis_client);
     let with_timeout = timeout.layer(with_cb);
     let _service = fallback.layer(with_timeout);
 }

--- a/tests/composition_stacks/database.rs
+++ b/tests/composition_stacks/database.rs
@@ -92,7 +92,7 @@ async fn standard_database_stack_compiles() {
 async fn database_with_circuit_breaker_compiles() {
     let bulkhead = BulkheadLayer::builder().max_concurrent_calls(20).build();
 
-    let circuit_breaker = CircuitBreakerLayer::<Query, DbError>::builder()
+    let circuit_breaker = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .minimum_number_of_calls(10)
         .build();
@@ -105,7 +105,7 @@ async fn database_with_circuit_breaker_compiles() {
 
     // Manual composition
     let with_bulkhead = bulkhead.layer(db_client);
-    let with_cb = circuit_breaker.layer::<_, Query>(with_bulkhead);
+    let with_cb = circuit_breaker.layer(with_bulkhead);
     let _service = timeout.layer(with_cb);
 }
 

--- a/tests/composition_stacks/external_api.rs
+++ b/tests/composition_stacks/external_api.rs
@@ -89,7 +89,7 @@ async fn standard_stack_compiles() {
         .timeout_duration(Duration::from_secs(10))
         .build();
 
-    let circuit_breaker = CircuitBreakerLayer::<ApiRequest, ApiError>::builder()
+    let circuit_breaker = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .build();
 
@@ -106,7 +106,7 @@ async fn standard_stack_compiles() {
 
     // Manual composition (recommended for 3+ layers)
     let with_timeout = per_attempt_timeout.layer(http_client);
-    let with_cb = circuit_breaker.layer::<_, ApiRequest>(with_timeout);
+    let with_cb = circuit_breaker.layer(with_timeout);
     let with_retry = retry.layer(with_cb);
     let _service = total_timeout.layer(with_retry);
 }
@@ -122,7 +122,7 @@ async fn full_stack_with_fallback_compiles() {
         .timeout_duration(Duration::from_secs(10))
         .build();
 
-    let circuit_breaker = CircuitBreakerLayer::<ApiRequest, ApiError>::builder()
+    let circuit_breaker = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .wait_duration_in_open(Duration::from_secs(30))
         .build();
@@ -142,7 +142,7 @@ async fn full_stack_with_fallback_compiles() {
 
     // Manual composition
     let with_timeout = per_attempt_timeout.layer(http_client);
-    let with_cb = circuit_breaker.layer::<_, ApiRequest>(with_timeout);
+    let with_cb = circuit_breaker.layer(with_timeout);
     let with_retry = retry.layer(with_cb);
     let with_total_timeout = total_timeout.layer(with_retry);
     let _service = fallback.layer(with_total_timeout);
@@ -166,7 +166,7 @@ async fn stack_with_hedging_compiles() {
         .max_hedged_attempts(2)
         .build();
 
-    let circuit_breaker = CircuitBreakerLayer::<ApiRequest, ApiError>::builder()
+    let circuit_breaker = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .build();
 
@@ -189,7 +189,7 @@ async fn stack_with_hedging_compiles() {
     // 5. Total timeout bounds everything
     let with_timeout = per_attempt_timeout.layer(http_client);
     let with_hedge = hedge.layer(with_timeout);
-    let with_cb = circuit_breaker.layer::<_, ApiRequest>(with_hedge);
+    let with_cb = circuit_breaker.layer(with_hedge);
     let with_retry = retry.layer(with_cb);
     let _service = total_timeout.layer(with_retry);
 }

--- a/tests/composition_stacks/message_queues.rs
+++ b/tests/composition_stacks/message_queues.rs
@@ -79,7 +79,7 @@ fn mock_queue_producer()
 /// Consumer stack: Timeout + Retry (with backoff) + CircuitBreaker
 #[tokio::test]
 async fn consumer_stack_compiles() {
-    let circuit_breaker = CircuitBreakerLayer::<Message, MessageError>::builder()
+    let circuit_breaker = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .wait_duration_in_open(Duration::from_secs(60))
         .build();
@@ -96,7 +96,7 @@ async fn consumer_stack_compiles() {
     let message_handler = mock_message_handler();
 
     // Manual composition
-    let with_cb = circuit_breaker.layer::<_, Message>(message_handler);
+    let with_cb = circuit_breaker.layer(message_handler);
     let with_retry = retry.layer(with_cb);
     let _service = timeout.layer(with_retry);
 }

--- a/tests/composition_stacks/microservices.rs
+++ b/tests/composition_stacks/microservices.rs
@@ -51,7 +51,7 @@ fn mock_grpc_client()
 /// Standard microservices stack: Timeout + Retry + CircuitBreaker
 #[tokio::test]
 async fn standard_microservices_stack_compiles() {
-    let circuit_breaker = CircuitBreakerLayer::<GrpcRequest, ServiceError>::builder()
+    let circuit_breaker = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.6)
         .slow_call_rate_threshold(0.8)
         .slow_call_duration_threshold(Duration::from_secs(2))
@@ -69,7 +69,7 @@ async fn standard_microservices_stack_compiles() {
     let grpc_client = mock_grpc_client();
 
     // Manual composition
-    let with_cb = circuit_breaker.layer::<_, GrpcRequest>(grpc_client);
+    let with_cb = circuit_breaker.layer(grpc_client);
     let with_retry = retry.layer(with_cb);
     let _service = timeout.layer(with_retry);
 }

--- a/tests/metrics_regression/circuitbreaker.rs
+++ b/tests/metrics_regression/circuitbreaker.rs
@@ -3,7 +3,7 @@
 use super::helpers::*;
 use serial_test::serial;
 use std::time::Duration;
-use tower::{Service, ServiceExt};
+use tower::{Layer, Service, ServiceExt};
 use tower_resilience_circuitbreaker::CircuitBreakerLayer;
 
 #[tokio::test]

--- a/tests/property/circuit_breaker.rs
+++ b/tests/property/circuit_breaker.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 use tokio::runtime::Runtime;
-use tower::{Service, ServiceExt};
+use tower::{Layer, Service, ServiceExt};
 use tower_resilience_circuitbreaker::{CircuitBreakerError, CircuitBreakerLayer};
 
 /// A cloneable error type for testing
@@ -54,7 +54,7 @@ proptest! {
                 }
             });
 
-            let layer = CircuitBreakerLayer::<(), TestError>::builder()
+            let layer = CircuitBreakerLayer::builder()
                 .failure_rate_threshold(failure_threshold as f64)
                 .sliding_window_size(window_size)
                 .minimum_number_of_calls(min_failures.min(window_size))
@@ -110,7 +110,7 @@ proptest! {
                 }
             });
 
-            let layer = CircuitBreakerLayer::<(), TestError>::builder()
+            let layer = CircuitBreakerLayer::builder()
                 .failure_rate_threshold(failure_threshold as f64)
                 .sliding_window_size(window_size)
                 .minimum_number_of_calls(window_size)
@@ -168,7 +168,7 @@ proptest! {
                 }
             });
 
-            let layer = CircuitBreakerLayer::<(), TestError>::builder()
+            let layer = CircuitBreakerLayer::builder()
                 .failure_rate_threshold(0.5)
                 .sliding_window_size(window_size)
                 .minimum_number_of_calls(window_size)
@@ -242,7 +242,7 @@ proptest! {
                 }
             });
 
-            let layer = CircuitBreakerLayer::<(), TestError>::builder()
+            let layer = CircuitBreakerLayer::builder()
                 .failure_rate_threshold(0.5)
                 .sliding_window_size(window_size)
                 .minimum_number_of_calls(window_size)

--- a/tests/stress/circuitbreaker.rs
+++ b/tests/stress/circuitbreaker.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
-use tower::{Service, ServiceExt};
+use tower::{Layer, Service, ServiceExt};
 use tower_resilience_circuitbreaker::{CircuitBreakerLayer, CircuitState};
 
 use super::{ConcurrencyTracker, get_memory_usage_mb};
@@ -21,7 +21,7 @@ async fn stress_one_million_calls() {
         async { Ok::<_, ()>(()) }
     });
 
-    let layer = CircuitBreakerLayer::<(), ()>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(100)
         .build();
@@ -54,7 +54,7 @@ async fn stress_rapid_state_transitions() {
     let svc =
         tower::service_fn(|req: bool| async move { if req { Ok::<_, ()>(()) } else { Err(()) } });
 
-    let layer = CircuitBreakerLayer::<(), ()>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(10)
         .wait_duration_in_open(Duration::from_millis(10))
@@ -110,7 +110,7 @@ async fn stress_high_concurrency() {
         }
     });
 
-    let layer = CircuitBreakerLayer::<(), ()>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(1000)
         .build();
@@ -149,7 +149,7 @@ async fn stress_large_sliding_window() {
 
     let svc = tower::service_fn(|_req: u32| async { Ok::<_, ()>(()) });
 
-    let layer = CircuitBreakerLayer::<(), ()>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(10_000)
         .build();
@@ -192,7 +192,7 @@ async fn stress_time_based_window_high_load() {
         async { Ok::<_, ()>(()) }
     });
 
-    let layer = CircuitBreakerLayer::<(), ()>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_type(tower_resilience_circuitbreaker::SlidingWindowType::TimeBased)
         .sliding_window_duration(Duration::from_secs(1))
@@ -248,7 +248,7 @@ async fn stress_mixed_results_high_volume() {
         }
     });
 
-    let layer = CircuitBreakerLayer::<(), ()>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(100)
         .wait_duration_in_open(Duration::from_millis(100))
@@ -293,7 +293,7 @@ async fn stress_memory_stability() {
     let svc =
         tower::service_fn(|req: u32| async move { if req % 10 < 3 { Err(()) } else { Ok(()) } });
 
-    let layer = CircuitBreakerLayer::<(), ()>::builder()
+    let layer = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(1000)
         .wait_duration_in_open(Duration::from_millis(50))

--- a/tests/stress/composition.rs
+++ b/tests/stress/composition.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
 use tower::{Layer, Service, ServiceExt};
-use tower_resilience_bulkhead::{BulkheadLayer, BulkheadServiceError};
+use tower_resilience_bulkhead::BulkheadLayer;
 use tower_resilience_circuitbreaker::CircuitBreakerLayer;
 
 use super::{ConcurrencyTracker, get_memory_usage_mb};
@@ -48,11 +48,10 @@ async fn stress_circuit_breaker_plus_bulkhead() {
     let bulkhead = BulkheadLayer::builder().max_concurrent_calls(20).build();
 
     // CircuitBreaker now wraps BulkheadServiceError<InnerError>
-    let circuit_breaker =
-        CircuitBreakerLayer::<String, BulkheadServiceError<InnerError>>::builder()
-            .failure_rate_threshold(0.7)
-            .sliding_window_size(100)
-            .build();
+    let circuit_breaker = CircuitBreakerLayer::builder()
+        .failure_rate_threshold(0.7)
+        .sliding_window_size(100)
+        .build();
 
     // Compose: circuit breaker -> bulkhead -> service
     let service = circuit_breaker.layer(bulkhead.layer(svc));
@@ -162,7 +161,7 @@ async fn stress_two_layer_high_concurrency() {
 
     let bulkhead = BulkheadLayer::builder().max_concurrent_calls(100).build();
 
-    let circuit_breaker = CircuitBreakerLayer::<(), BulkheadServiceError<TestError>>::builder()
+    let circuit_breaker = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.9)
         .sliding_window_size(1000)
         .build();
@@ -204,7 +203,7 @@ async fn stress_composed_memory() {
 
     let bulkhead = BulkheadLayer::builder().max_concurrent_calls(100).build();
 
-    let circuit_breaker = CircuitBreakerLayer::<(), BulkheadServiceError<TestError>>::builder()
+    let circuit_breaker = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(1000)
         .build();
@@ -248,7 +247,7 @@ async fn stress_composed_burst_traffic() {
 
     let bulkhead = BulkheadLayer::builder().max_concurrent_calls(50).build();
 
-    let circuit_breaker = CircuitBreakerLayer::<(), BulkheadServiceError<TestError>>::builder()
+    let circuit_breaker = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.9)
         .sliding_window_size(100)
         .build();
@@ -305,7 +304,7 @@ async fn stress_composed_stability() {
 
     let bulkhead = BulkheadLayer::builder().max_concurrent_calls(20).build();
 
-    let circuit_breaker = CircuitBreakerLayer::<(), BulkheadServiceError<InnerError>>::builder()
+    let circuit_breaker = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
         .sliding_window_size(100)
         .build();


### PR DESCRIPTION
## Summary

- Remove the need for type parameters when using `CircuitBreakerLayer` with the default classifier
- The layer now implements `Layer<S>` directly without requiring `.for_request()`
- Custom classifiers bind types via closure signature inference

## Changes

- Add `FailureClassifier` trait with `DefaultClassifier` and `FnClassifier` implementations
- Change `CircuitBreaker<S, Req, Res, Err>` to `CircuitBreaker<S, C>` (2 type params instead of 4)
- `CircuitBreakerLayer::builder()` now works without type parameters
- Deprecate `.for_request()` method (no longer needed)
- Add `CircuitBreakerWithFallback<S, C, Req, Res, Err>` for fallback support

## Migration

```rust
// Before
CircuitBreakerLayer::<String, Error>::builder()
    .build()
    .for_request::<Request>()

// After  
CircuitBreakerLayer::builder().build()

// Custom classifier (types inferred from closure)
CircuitBreakerLayer::builder()
    .failure_classifier(|result: &Result<Response, Error>| {
        matches!(result, Err(e) if !e.is_retryable())
    })
    .build()
```

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --workspace --all-features`
- [x] `cargo test --test '*' --all-features` (89 circuitbreaker tests pass)
- [x] `cargo test --workspace --doc --all-features`