### PR TITLE
fix: remove unnecessary Req: Clone bound from TimeLimiter

### DIFF
--- a/crates/tower-resilience-timelimiter/src/lib.rs
+++ b/crates/tower-resilience-timelimiter/src/lib.rs
@@ -205,11 +205,20 @@ mod events;
 mod layer;
 
 /// A Tower service that applies timeout limiting to an inner service.
-#[derive(Clone)]
 pub struct TimeLimiter<S, Req> {
     inner: S,
     config: Arc<TimeLimiterConfig<Req>>,
     _phantom: PhantomData<Req>,
+}
+
+impl<S: Clone, Req> Clone for TimeLimiter<S, Req> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            config: Arc::clone(&self.config),
+            _phantom: PhantomData,
+        }
+    }
 }
 
 impl<S, Req> TimeLimiter<S, Req> {


### PR DESCRIPTION
## Summary

- Replace `#[derive(Clone)]` with manual `Clone` impl that only requires `S: Clone`
- The derived Clone incorrectly required `Req: Clone` due to `PhantomData<Req>`

## Problem

`PhantomData<T>` is always `Clone` regardless of `T`, but `#[derive(Clone)]` generates a `where T: Clone` bound anyway. This prevented using `TimeLimiter` with request types that don't implement `Clone`.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p tower-resilience-timelimiter --all-features -- -D warnings`
- [x] `cargo test -p tower-resilience-timelimiter --all-features`

Fixes #200