### PR TITLE
feat!: reduce type parameter verbosity for ChaosLayer and HedgeLayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,10 +417,11 @@ Inject failures and latency to test your resilience patterns:
 use tower_resilience_chaos::ChaosLayer;
 use std::time::Duration;
 
-let chaos = ChaosLayer::<String, std::io::Error>::builder()
+// Types inferred from closure signature - no type parameters needed!
+let chaos = ChaosLayer::builder()
     .name("test-chaos")
     .error_rate(0.1)                               // 10% of requests fail
-    .error_fn(|_req| std::io::Error::new(
+    .error_fn(|_req: &String| std::io::Error::new(
         std::io::ErrorKind::Other, "chaos!"
     ))
     .latency_rate(0.2)                             // 20% delayed

--- a/benches/comprehensive_benchmarks.rs
+++ b/benches/comprehensive_benchmarks.rs
@@ -549,7 +549,7 @@ fn bench_hedge_parallel_mode(c: &mut Criterion) {
 
     c.bench_function("hedge_parallel_mode", |b| {
         b.to_async(&runtime).iter(|| async {
-            let layer = HedgeLayer::<TestRequest, TestResponse, TestError>::builder()
+            let layer = HedgeLayer::builder()
                 .no_delay()
                 .max_hedged_attempts(3)
                 .build();

--- a/benches/happy_path_overhead.rs
+++ b/benches/happy_path_overhead.rs
@@ -271,7 +271,7 @@ fn bench_hedge(c: &mut Criterion) {
 
     c.bench_function("hedge_primary_succeeds", |b| {
         b.to_async(&runtime).iter(|| async {
-            let layer = HedgeLayer::<TestRequest, TestResponse, TestError>::builder()
+            let layer = HedgeLayer::builder()
                 .delay(Duration::from_millis(100))
                 .max_hedged_attempts(2)
                 .build();

--- a/crates/tower-resilience-chaos/src/config.rs
+++ b/crates/tower-resilience-chaos/src/config.rs
@@ -7,17 +7,90 @@ use std::sync::Arc;
 use std::time::Duration;
 use tower_resilience_core::{EventListeners, FnListener};
 
-/// Type alias for error generation function
-type ErrorFn<Req, Err> = Arc<dyn Fn(&Req) -> Err + Send + Sync>;
+/// Trait for error injection behavior.
+///
+/// This trait is implemented by both the default (no injection) and custom error
+/// injectors, enabling type inference for the common case of latency-only chaos.
+pub trait ErrorInjector<Req, Err>: Send + Sync {
+    /// Check if an error should be injected and return it.
+    fn inject_error(&self, req: &Req, roll: f64) -> Option<Err>;
+
+    /// Get the error rate for this injector.
+    fn error_rate(&self) -> f64;
+}
+
+/// No error injection - only latency chaos.
+///
+/// This is the default error injector. Since it never injects errors,
+/// it implements `ErrorInjector<Req, Err>` for ALL types, enabling
+/// type inference at the point of use.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoErrorInjection;
+
+impl<Req, Err> ErrorInjector<Req, Err> for NoErrorInjection {
+    fn inject_error(&self, _req: &Req, _roll: f64) -> Option<Err> {
+        None
+    }
+
+    fn error_rate(&self) -> f64 {
+        0.0
+    }
+}
+
+/// Custom error injection function.
+///
+/// This injector calls a function to generate errors based on the request.
+pub struct CustomErrorFn<F> {
+    f: Arc<F>,
+    rate: f64,
+}
+
+impl<F> Clone for CustomErrorFn<F> {
+    fn clone(&self) -> Self {
+        Self {
+            f: Arc::clone(&self.f),
+            rate: self.rate,
+        }
+    }
+}
+
+impl<F> CustomErrorFn<F> {
+    /// Create a new custom error injector.
+    pub fn new(f: F, rate: f64) -> Self {
+        Self {
+            f: Arc::new(f),
+            rate: rate.clamp(0.0, 1.0),
+        }
+    }
+}
+
+impl<Req, Err, F> ErrorInjector<Req, Err> for CustomErrorFn<F>
+where
+    F: Fn(&Req) -> Err + Send + Sync + 'static,
+{
+    fn inject_error(&self, req: &Req, roll: f64) -> Option<Err> {
+        if roll < self.rate {
+            Some((self.f)(req))
+        } else {
+            None
+        }
+    }
+
+    fn error_rate(&self) -> f64 {
+        self.rate
+    }
+}
 
 /// Configuration for the chaos engineering layer.
-pub struct ChaosConfig<Req, Err> {
+///
+/// The type parameter `E` is the error injector type:
+/// - `ChaosConfig<NoErrorInjection>` - latency-only chaos (works with any types)
+/// - `ChaosConfig<CustomErrorFn<F>>` - custom error injection
+pub struct ChaosConfig<E> {
     /// Name of this chaos layer instance for observability
     pub(crate) name: String,
-    /// Probability of injecting an error (0.0 - 1.0)
-    pub(crate) error_rate: f64,
-    /// Function to generate errors when injecting
-    pub(crate) error_fn: Option<ErrorFn<Req, Err>>,
+    /// Error injector
+    pub(crate) error_injector: E,
     /// Probability of injecting latency (0.0 - 1.0)
     pub(crate) latency_rate: f64,
     /// Minimum latency to inject
@@ -30,12 +103,11 @@ pub struct ChaosConfig<Req, Err> {
     pub(crate) event_listeners: EventListeners<ChaosEvent>,
 }
 
-impl<Req, Err> Clone for ChaosConfig<Req, Err> {
+impl<E: Clone> Clone for ChaosConfig<E> {
     fn clone(&self) -> Self {
         Self {
             name: self.name.clone(),
-            error_rate: self.error_rate,
-            error_fn: self.error_fn.clone(),
+            error_injector: self.error_injector.clone(),
             latency_rate: self.latency_rate,
             min_latency: self.min_latency,
             max_latency: self.max_latency,
@@ -45,12 +117,7 @@ impl<Req, Err> Clone for ChaosConfig<Req, Err> {
     }
 }
 
-impl<Req, Err> ChaosConfig<Req, Err> {
-    /// Create a new builder for chaos configuration.
-    pub fn builder() -> ChaosConfigBuilder<Req, Err> {
-        ChaosConfigBuilder::new()
-    }
-
+impl<E> ChaosConfig<E> {
     /// Get the RNG for this configuration.
     pub(crate) fn create_rng(&self) -> StdRng {
         match self.seed {
@@ -61,10 +128,39 @@ impl<Req, Err> ChaosConfig<Req, Err> {
 }
 
 /// Builder for chaos configuration.
-pub struct ChaosConfigBuilder<Req, Err> {
+///
+/// The type parameter `E` is the error injector type. By default, this is
+/// `NoErrorInjection` which works with any request/error type. When you call
+/// `.error_fn()`, the type changes to `CustomErrorFn<F>`.
+///
+/// # Latency-Only Chaos (no type parameters needed)
+///
+/// ```rust
+/// use tower_resilience_chaos::ChaosLayer;
+/// use std::time::Duration;
+///
+/// // No type parameters required for latency-only chaos!
+/// let layer = ChaosLayer::builder()
+///     .latency_rate(0.2)  // 20% of requests delayed
+///     .min_latency(Duration::from_millis(50))
+///     .max_latency(Duration::from_millis(200))
+///     .build();
+/// ```
+///
+/// # Error Injection (types inferred from closure)
+///
+/// ```rust
+/// use tower_resilience_chaos::ChaosLayer;
+///
+/// // Types inferred from closure signature
+/// let layer = ChaosLayer::builder()
+///     .error_rate(0.1)
+///     .error_fn(|_req: &String| std::io::Error::other("chaos!"))
+///     .build();
+/// ```
+pub struct ChaosConfigBuilder<E = NoErrorInjection> {
     name: String,
-    error_rate: f64,
-    error_fn: Option<ErrorFn<Req, Err>>,
+    error_injector: E,
     latency_rate: f64,
     min_latency: Duration,
     max_latency: Duration,
@@ -72,13 +168,20 @@ pub struct ChaosConfigBuilder<Req, Err> {
     event_listeners: EventListeners<ChaosEvent>,
 }
 
-impl<Req, Err> ChaosConfigBuilder<Req, Err> {
+impl Default for ChaosConfigBuilder<NoErrorInjection> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ChaosConfigBuilder<NoErrorInjection> {
     /// Create a new chaos configuration builder.
+    ///
+    /// No type parameters are required when using latency-only chaos.
     pub fn new() -> Self {
         Self {
             name: "<unnamed>".to_string(),
-            error_rate: 0.0,
-            error_fn: None,
+            error_injector: NoErrorInjection,
             latency_rate: 0.0,
             min_latency: Duration::from_millis(10),
             max_latency: Duration::from_millis(100),
@@ -86,15 +189,18 @@ impl<Req, Err> ChaosConfigBuilder<Req, Err> {
             event_listeners: EventListeners::new(),
         }
     }
+}
 
+impl<E> ChaosConfigBuilder<E> {
     /// Set the name of this chaos layer instance.
     ///
     /// # Example
     /// ```
-    /// use tower_resilience_chaos::ChaosConfig;
+    /// use tower_resilience_chaos::ChaosLayer;
     ///
-    /// let config = ChaosConfig::<(), ()>::builder()
+    /// let layer = ChaosLayer::builder()
     ///     .name("test-chaos")
+    ///     .latency_rate(0.1)
     ///     .build();
     /// ```
     pub fn name(mut self, name: impl Into<String>) -> Self {
@@ -102,49 +208,44 @@ impl<Req, Err> ChaosConfigBuilder<Req, Err> {
         self
     }
 
-    /// Set the error injection rate (0.0 - 1.0).
+    /// Set the error injection rate and function.
+    ///
+    /// This configures error injection with a probability (0.0 - 1.0) and
+    /// a function to generate errors. Types are inferred from the closure.
     ///
     /// # Example
     /// ```
-    /// use tower_resilience_chaos::ChaosConfig;
+    /// use tower_resilience_chaos::ChaosLayer;
     ///
-    /// let config = ChaosConfig::<(), ()>::builder()
-    ///     .error_rate(0.1)  // 10% of requests will fail
+    /// // Types inferred from closure signature
+    /// let layer = ChaosLayer::builder()
+    ///     .error_rate(0.1)  // 10% of requests fail
+    ///     .error_fn(|_req: &String| std::io::Error::other("chaos!"))
     ///     .build();
     /// ```
-    pub fn error_rate(mut self, rate: f64) -> Self {
-        self.error_rate = rate.clamp(0.0, 1.0);
-        self
-    }
-
-    /// Set the function to generate errors.
-    ///
-    /// # Example
-    /// ```
-    /// use tower_resilience_chaos::ChaosConfig;
-    ///
-    /// let config = ChaosConfig::<(), std::io::Error>::builder()
-    ///     .error_rate(0.1)
-    ///     .error_fn(|_req| {
-    ///         std::io::Error::new(std::io::ErrorKind::Other, "chaos!")
-    ///     })
-    ///     .build();
-    /// ```
-    pub fn error_fn<F>(mut self, f: F) -> Self
+    pub fn error_fn<Req, Err, F>(self, f: F) -> ChaosConfigBuilder<CustomErrorFn<F>>
     where
         F: Fn(&Req) -> Err + Send + Sync + 'static,
     {
-        self.error_fn = Some(Arc::new(f));
-        self
+        ChaosConfigBuilder {
+            name: self.name,
+            error_injector: CustomErrorFn::new(f, 0.0), // rate will be set by error_rate()
+            latency_rate: self.latency_rate,
+            min_latency: self.min_latency,
+            max_latency: self.max_latency,
+            seed: self.seed,
+            event_listeners: self.event_listeners,
+        }
     }
 
     /// Set the latency injection rate (0.0 - 1.0).
     ///
     /// # Example
     /// ```
-    /// use tower_resilience_chaos::ChaosConfig;
+    /// use tower_resilience_chaos::ChaosLayer;
     ///
-    /// let config = ChaosConfig::<(), ()>::builder()
+    /// // No type parameters needed for latency-only chaos!
+    /// let layer = ChaosLayer::builder()
     ///     .latency_rate(0.2)  // 20% of requests will be delayed
     ///     .build();
     /// ```
@@ -157,10 +258,10 @@ impl<Req, Err> ChaosConfigBuilder<Req, Err> {
     ///
     /// # Example
     /// ```
-    /// use tower_resilience_chaos::ChaosConfig;
+    /// use tower_resilience_chaos::ChaosLayer;
     /// use std::time::Duration;
     ///
-    /// let config = ChaosConfig::<(), ()>::builder()
+    /// let layer = ChaosLayer::builder()
     ///     .latency_rate(0.2)
     ///     .min_latency(Duration::from_millis(50))
     ///     .build();
@@ -174,10 +275,10 @@ impl<Req, Err> ChaosConfigBuilder<Req, Err> {
     ///
     /// # Example
     /// ```
-    /// use tower_resilience_chaos::ChaosConfig;
+    /// use tower_resilience_chaos::ChaosLayer;
     /// use std::time::Duration;
     ///
-    /// let config = ChaosConfig::<(), ()>::builder()
+    /// let layer = ChaosLayer::builder()
     ///     .latency_rate(0.2)
     ///     .max_latency(Duration::from_millis(500))
     ///     .build();
@@ -193,10 +294,10 @@ impl<Req, Err> ChaosConfigBuilder<Req, Err> {
     ///
     /// # Example
     /// ```
-    /// use tower_resilience_chaos::ChaosConfig;
+    /// use tower_resilience_chaos::ChaosLayer;
     ///
-    /// let config = ChaosConfig::<(), ()>::builder()
-    ///     .error_rate(0.1)
+    /// let layer = ChaosLayer::builder()
+    ///     .latency_rate(0.1)
     ///     .seed(42)  // Deterministic behavior
     ///     .build();
     /// ```
@@ -209,10 +310,10 @@ impl<Req, Err> ChaosConfigBuilder<Req, Err> {
     ///
     /// # Example
     /// ```
-    /// use tower_resilience_chaos::ChaosConfig;
+    /// use tower_resilience_chaos::ChaosLayer;
     ///
-    /// let config = ChaosConfig::<(), ()>::builder()
-    ///     .error_rate(0.1)
+    /// let layer = ChaosLayer::builder()
+    ///     .latency_rate(0.1)
     ///     .on_error_injected(|| {
     ///         println!("Chaos: error injected!");
     ///     })
@@ -234,10 +335,10 @@ impl<Req, Err> ChaosConfigBuilder<Req, Err> {
     ///
     /// # Example
     /// ```
-    /// use tower_resilience_chaos::ChaosConfig;
+    /// use tower_resilience_chaos::ChaosLayer;
     /// use std::time::Duration;
     ///
-    /// let config = ChaosConfig::<(), ()>::builder()
+    /// let layer = ChaosLayer::builder()
     ///     .latency_rate(0.2)
     ///     .on_latency_injected(|delay: Duration| {
     ///         println!("Chaos: injected {:?} latency", delay);
@@ -260,10 +361,10 @@ impl<Req, Err> ChaosConfigBuilder<Req, Err> {
     ///
     /// # Example
     /// ```
-    /// use tower_resilience_chaos::ChaosConfig;
+    /// use tower_resilience_chaos::ChaosLayer;
     ///
-    /// let config = ChaosConfig::<(), ()>::builder()
-    ///     .error_rate(0.1)
+    /// let layer = ChaosLayer::builder()
+    ///     .latency_rate(0.1)
     ///     .on_passed_through(|| {
     ///         println!("Chaos: request passed through");
     ///     })
@@ -282,11 +383,10 @@ impl<Req, Err> ChaosConfigBuilder<Req, Err> {
     }
 
     /// Build the chaos configuration and return a ChaosLayer.
-    pub fn build(self) -> crate::layer::ChaosLayer<Req, Err> {
+    pub fn build(self) -> crate::layer::ChaosLayer<E> {
         let config = ChaosConfig {
             name: self.name,
-            error_rate: self.error_rate,
-            error_fn: self.error_fn,
+            error_injector: self.error_injector,
             latency_rate: self.latency_rate,
             min_latency: self.min_latency,
             max_latency: self.max_latency,
@@ -297,8 +397,160 @@ impl<Req, Err> ChaosConfigBuilder<Req, Err> {
     }
 }
 
-impl<Req, Err> Default for ChaosConfigBuilder<Req, Err> {
-    fn default() -> Self {
-        Self::new()
+// Special impl for CustomErrorFn to set the error rate
+impl<F> ChaosConfigBuilder<CustomErrorFn<F>> {
+    /// Set the error injection rate (0.0 - 1.0).
+    ///
+    /// This should be called before `error_fn()` or the rate will need to be updated.
+    ///
+    /// # Example
+    /// ```
+    /// use tower_resilience_chaos::ChaosLayer;
+    ///
+    /// let layer = ChaosLayer::builder()
+    ///     .error_rate(0.1)  // 10% of requests fail
+    ///     .error_fn(|_req: &String| std::io::Error::other("chaos!"))
+    ///     .build();
+    /// ```
+    pub fn error_rate(mut self, rate: f64) -> Self {
+        self.error_injector.rate = rate.clamp(0.0, 1.0);
+        self
+    }
+}
+
+// Also allow error_rate on any builder (for the common case of calling it before error_fn)
+impl ChaosConfigBuilder<NoErrorInjection> {
+    /// Set the error injection rate (0.0 - 1.0).
+    ///
+    /// Note: This only takes effect when combined with `error_fn()`.
+    /// For latency-only chaos, this has no effect.
+    ///
+    /// # Example
+    /// ```
+    /// use tower_resilience_chaos::ChaosLayer;
+    ///
+    /// let layer = ChaosLayer::builder()
+    ///     .error_rate(0.1)  // Will be used when error_fn is called
+    ///     .error_fn(|_req: &String| std::io::Error::other("chaos!"))
+    ///     .build();
+    /// ```
+    pub fn error_rate(self, _rate: f64) -> ChaosConfigBuilderWithRate {
+        ChaosConfigBuilderWithRate {
+            name: self.name,
+            error_rate: _rate.clamp(0.0, 1.0),
+            latency_rate: self.latency_rate,
+            min_latency: self.min_latency,
+            max_latency: self.max_latency,
+            seed: self.seed,
+            event_listeners: self.event_listeners,
+        }
+    }
+}
+
+/// Builder that has an error rate set but no error function yet.
+pub struct ChaosConfigBuilderWithRate {
+    name: String,
+    error_rate: f64,
+    latency_rate: f64,
+    min_latency: Duration,
+    max_latency: Duration,
+    seed: Option<u64>,
+    event_listeners: EventListeners<ChaosEvent>,
+}
+
+impl ChaosConfigBuilderWithRate {
+    /// Set the error injection function.
+    ///
+    /// # Example
+    /// ```
+    /// use tower_resilience_chaos::ChaosLayer;
+    ///
+    /// let layer = ChaosLayer::builder()
+    ///     .error_rate(0.1)
+    ///     .error_fn(|_req: &String| std::io::Error::other("chaos!"))
+    ///     .build();
+    /// ```
+    pub fn error_fn<Req, Err, F>(self, f: F) -> ChaosConfigBuilder<CustomErrorFn<F>>
+    where
+        F: Fn(&Req) -> Err + Send + Sync + 'static,
+    {
+        ChaosConfigBuilder {
+            name: self.name,
+            error_injector: CustomErrorFn::new(f, self.error_rate),
+            latency_rate: self.latency_rate,
+            min_latency: self.min_latency,
+            max_latency: self.max_latency,
+            seed: self.seed,
+            event_listeners: self.event_listeners,
+        }
+    }
+
+    /// Set the name of this chaos layer instance.
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    /// Set the latency injection rate (0.0 - 1.0).
+    pub fn latency_rate(mut self, rate: f64) -> Self {
+        self.latency_rate = rate.clamp(0.0, 1.0);
+        self
+    }
+
+    /// Set the minimum latency to inject.
+    pub fn min_latency(mut self, duration: Duration) -> Self {
+        self.min_latency = duration;
+        self
+    }
+
+    /// Set the maximum latency to inject.
+    pub fn max_latency(mut self, duration: Duration) -> Self {
+        self.max_latency = duration;
+        self
+    }
+
+    /// Set a seed for deterministic chaos injection.
+    pub fn seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
+    }
+
+    /// Add a listener for error injection events.
+    pub fn on_error_injected<F>(mut self, f: F) -> Self
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        self.event_listeners.add(FnListener::new(move |event| {
+            if matches!(event, ChaosEvent::ErrorInjected { .. }) {
+                f();
+            }
+        }));
+        self
+    }
+
+    /// Add a listener for latency injection events.
+    pub fn on_latency_injected<F>(mut self, f: F) -> Self
+    where
+        F: Fn(Duration) + Send + Sync + 'static,
+    {
+        self.event_listeners.add(FnListener::new(move |event| {
+            if let ChaosEvent::LatencyInjected { delay, .. } = event {
+                f(*delay);
+            }
+        }));
+        self
+    }
+
+    /// Add a listener for pass-through events.
+    pub fn on_passed_through<F>(mut self, f: F) -> Self
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        self.event_listeners.add(FnListener::new(move |event| {
+            if matches!(event, ChaosEvent::PassedThrough { .. }) {
+                f();
+            }
+        }));
+        self
     }
 }

--- a/crates/tower-resilience-chaos/src/layer.rs
+++ b/crates/tower-resilience-chaos/src/layer.rs
@@ -1,12 +1,16 @@
 //! Tower layer for chaos engineering.
 
-use crate::config::{ChaosConfig, ChaosConfigBuilder};
+use crate::config::{ChaosConfig, ChaosConfigBuilder, NoErrorInjection};
 use crate::service::Chaos;
 use tower_layer::Layer;
 
 /// A Tower layer that wraps services with chaos engineering capabilities.
 ///
-/// # Example
+/// The type parameter `E` is the error injector type:
+/// - `ChaosLayer<NoErrorInjection>` - latency-only chaos (works with any types)
+/// - `ChaosLayer<CustomErrorFn<F>>` - custom error injection
+///
+/// # Latency-Only Chaos (no type parameters needed)
 ///
 /// ```rust
 /// use tower::ServiceBuilder;
@@ -14,12 +18,8 @@ use tower_layer::Layer;
 /// use std::time::Duration;
 ///
 /// # async fn example() {
-/// let chaos = ChaosLayer::<(), std::io::Error>::builder()
-///     .name("test-chaos")
-///     .error_rate(0.1)  // 10% of requests fail
-///     .error_fn(|_req| {
-///         std::io::Error::new(std::io::ErrorKind::Other, "chaos!")
-///     })
+/// // No type parameters needed for latency-only chaos!
+/// let chaos = ChaosLayer::builder()
 ///     .latency_rate(0.2)  // 20% of requests delayed
 ///     .min_latency(Duration::from_millis(50))
 ///     .max_latency(Duration::from_millis(200))
@@ -27,32 +27,88 @@ use tower_layer::Layer;
 ///
 /// let service = ServiceBuilder::new()
 ///     .layer(chaos)
-///     .service_fn(|req: ()| async { Ok::<_, std::io::Error>(()) });
+///     .service_fn(|req: String| async { Ok::<_, std::io::Error>(req) });
+/// # }
+/// ```
+///
+/// # Error Injection (types inferred from closure)
+///
+/// ```rust
+/// use tower::ServiceBuilder;
+/// use tower_resilience_chaos::ChaosLayer;
+///
+/// # async fn example() {
+/// let chaos = ChaosLayer::builder()
+///     .error_rate(0.1)  // 10% of requests fail
+///     .error_fn(|_req: &String| std::io::Error::other("chaos!"))
+///     .build();
+///
+/// let service = ServiceBuilder::new()
+///     .layer(chaos)
+///     .service_fn(|req: String| async { Ok::<_, std::io::Error>(req) });
 /// # }
 /// ```
 #[derive(Clone)]
-pub struct ChaosLayer<Req, Err> {
-    config: ChaosConfig<Req, Err>,
+pub struct ChaosLayer<E = NoErrorInjection> {
+    config: ChaosConfig<E>,
 }
 
-impl<Req, Err> ChaosLayer<Req, Err> {
-    /// Create a new builder for chaos layer configuration.
-    pub fn builder() -> ChaosConfigBuilder<Req, Err> {
-        ChaosConfigBuilder::new()
-    }
-
+impl<E> ChaosLayer<E> {
     /// Create a new chaos layer from configuration.
-    pub fn new(config: ChaosConfig<Req, Err>) -> Self {
+    pub fn new(config: ChaosConfig<E>) -> Self {
         Self { config }
     }
 }
 
-impl<S, Req, Err> Layer<S> for ChaosLayer<Req, Err>
+impl ChaosLayer<NoErrorInjection> {
+    /// Create a new builder for chaos layer configuration.
+    ///
+    /// # Example
+    ///
+    /// ## Latency-only chaos (no type parameters)
+    ///
+    /// ```rust
+    /// use tower_resilience_chaos::ChaosLayer;
+    /// use std::time::Duration;
+    ///
+    /// // No type parameters needed!
+    /// let layer = ChaosLayer::builder()
+    ///     .latency_rate(0.2)
+    ///     .min_latency(Duration::from_millis(50))
+    ///     .max_latency(Duration::from_millis(200))
+    ///     .build();
+    /// ```
+    ///
+    /// ## Error injection (types inferred from closure)
+    ///
+    /// ```rust
+    /// use tower_resilience_chaos::ChaosLayer;
+    ///
+    /// let layer = ChaosLayer::builder()
+    ///     .error_rate(0.1)
+    ///     .error_fn(|_req: &String| std::io::Error::other("chaos!"))
+    ///     .build();
+    /// ```
+    pub fn builder() -> ChaosConfigBuilder<NoErrorInjection> {
+        ChaosConfigBuilder::new()
+    }
+}
+
+// Implement Layer<S> for NoErrorInjection - works with any service
+impl<S> Layer<S> for ChaosLayer<NoErrorInjection> {
+    type Service = Chaos<S, NoErrorInjection>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Chaos::new(inner, self.config.clone())
+    }
+}
+
+// Implement Layer<S> for CustomErrorFn - the closure determines compatible services
+impl<S, F> Layer<S> for ChaosLayer<crate::config::CustomErrorFn<F>>
 where
-    Req: 'static,
-    Err: 'static,
+    F: 'static,
 {
-    type Service = Chaos<S, Req, Err>;
+    type Service = Chaos<S, crate::config::CustomErrorFn<F>>;
 
     fn layer(&self, inner: S) -> Self::Service {
         Chaos::new(inner, self.config.clone())

--- a/crates/tower-resilience-healthcheck/tests/http_integration.rs
+++ b/crates/tower-resilience-healthcheck/tests/http_integration.rs
@@ -399,9 +399,10 @@ async fn test_chaos_injection_with_health_check() {
     );
 
     // Now wrap the endpoint's get_data call with chaos layer
-    let chaos_layer = ChaosLayer::<(), String>::builder()
+    // Types inferred from closure signature
+    let chaos_layer = ChaosLayer::builder()
         .error_rate(0.5) // 50% failure rate
-        .error_fn(|_req| "chaos error".to_string())
+        .error_fn(|_req: &()| "chaos error".to_string())
         .build();
 
     // Create a service from the endpoint

--- a/crates/tower-resilience-hedge/src/layer.rs
+++ b/crates/tower-resilience-hedge/src/layer.rs
@@ -2,18 +2,33 @@
 
 use crate::config::{HedgeConfig, HedgeConfigBuilder};
 use crate::Hedge;
-use std::marker::PhantomData;
 use std::time::Duration;
 use tower_layer::Layer;
 
 /// A Tower [`Layer`] that applies hedging to a service.
 ///
+/// No type parameters needed - types are inferred from the service.
+///
 /// See the [crate-level documentation](crate) for more details.
-pub struct HedgeLayer<Req, Res, E> {
-    config: HedgeConfig<Req, Res, E>,
+///
+/// # Example
+///
+/// ```rust
+/// use tower_resilience_hedge::HedgeLayer;
+/// use std::time::Duration;
+///
+/// // No type parameters needed!
+/// let layer = HedgeLayer::builder()
+///     .delay(Duration::from_millis(100))
+///     .max_hedged_attempts(3)
+///     .build();
+/// ```
+#[derive(Clone)]
+pub struct HedgeLayer {
+    config: HedgeConfig,
 }
 
-impl<Req, Res, E> HedgeLayer<Req, Res, E> {
+impl HedgeLayer {
     /// Create a new `HedgeLayer` with the given delay.
     ///
     /// This creates a layer that will fire a single hedge request
@@ -25,9 +40,8 @@ impl<Req, Res, E> HedgeLayer<Req, Res, E> {
     /// use tower_resilience_hedge::HedgeLayer;
     /// use std::time::Duration;
     ///
-    /// let layer = HedgeLayer::<(), String, std::io::Error>::new(
-    ///     Duration::from_millis(100)
-    /// );
+    /// // No type parameters needed!
+    /// let layer = HedgeLayer::new(Duration::from_millis(100));
     /// ```
     pub fn new(delay: Duration) -> Self {
         Self::builder().delay(delay).build()
@@ -41,53 +55,26 @@ impl<Req, Res, E> HedgeLayer<Req, Res, E> {
     /// use tower_resilience_hedge::HedgeLayer;
     /// use std::time::Duration;
     ///
-    /// let layer = HedgeLayer::<(), String, std::io::Error>::builder()
+    /// // No type parameters needed!
+    /// let layer = HedgeLayer::builder()
     ///     .delay(Duration::from_millis(100))
     ///     .max_hedged_attempts(3)
     ///     .build();
     /// ```
-    pub fn builder() -> HedgeConfigBuilder<Req, Res, E> {
+    pub fn builder() -> HedgeConfigBuilder {
         HedgeConfigBuilder::new()
     }
 
     /// Create a `HedgeLayer` from a configuration.
-    pub(crate) fn from_config(config: HedgeConfig<Req, Res, E>) -> Self {
+    pub(crate) fn from_config(config: HedgeConfig) -> Self {
         Self { config }
     }
 }
 
-impl<Req, Res, E> Clone for HedgeLayer<Req, Res, E> {
-    fn clone(&self) -> Self {
-        Self {
-            config: HedgeConfig {
-                name: self.config.name.clone(),
-                max_hedged_attempts: self.config.max_hedged_attempts,
-                delay: self.config.delay.clone(),
-                listeners: self.config.listeners.clone(),
-                _phantom: PhantomData,
-            },
-        }
-    }
-}
-
-impl<S, Req, Res, E> Layer<S> for HedgeLayer<Req, Res, E>
-where
-    Req: Clone,
-    Res: Clone,
-    E: Clone,
-{
-    type Service = Hedge<S, Req, Res, E>;
+impl<S> Layer<S> for HedgeLayer {
+    type Service = Hedge<S>;
 
     fn layer(&self, service: S) -> Self::Service {
-        Hedge::new(
-            service,
-            HedgeConfig {
-                name: self.config.name.clone(),
-                max_hedged_attempts: self.config.max_hedged_attempts,
-                delay: self.config.delay.clone(),
-                listeners: self.config.listeners.clone(),
-                _phantom: PhantomData,
-            },
-        )
+        Hedge::new(service, self.config.clone())
     }
 }

--- a/crates/tower-resilience/src/patterns.rs
+++ b/crates/tower-resilience/src/patterns.rs
@@ -1115,7 +1115,7 @@ pub mod hedge {
     //! # async fn example() {
     //! # let database_query = tower::service_fn(|_req: String| async { Ok::<String, DbError>(String::new()) });
     //! // Fire hedge after 50ms if primary hasn't responded
-    //! let hedge = HedgeLayer::<String, String, DbError>::builder()
+    //! let hedge = HedgeLayer::builder()
     //!     .name("db-query-hedge")
     //!     .delay(Duration::from_millis(50))
     //!     .max_hedged_attempts(2)
@@ -1143,7 +1143,7 @@ pub mod hedge {
     //! # async fn example() {
     //! # let multi_region_api = tower::service_fn(|_req: String| async { Ok::<String, ApiError>(String::new()) });
     //! // Fire all 3 requests immediately, return fastest
-    //! let hedge = HedgeLayer::<String, String, ApiError>::builder()
+    //! let hedge = HedgeLayer::builder()
     //!     .name("multi-region-hedge")
     //!     .no_delay()  // Parallel mode
     //!     .max_hedged_attempts(3)
@@ -1172,7 +1172,7 @@ pub mod hedge {
     //! # async fn example() {
     //! # let cache_lookup = tower::service_fn(|_req: String| async { Ok::<String, CacheError>(String::new()) });
     //! // Increasing delays: 10ms, 40ms, 90ms...
-    //! let hedge = HedgeLayer::<String, String, CacheError>::builder()
+    //! let hedge = HedgeLayer::builder()
     //!     .name("cache-hedge")
     //!     .delay_fn(|attempt| Duration::from_millis(10 * (attempt as u64).pow(2)))
     //!     .max_hedged_attempts(3)
@@ -1201,7 +1201,7 @@ pub mod hedge {
     //! # impl std::error::Error for MyError {}
     //! # async fn example() {
     //! # let service_fn = tower::service_fn(|_req: String| async { Ok::<String, MyError>(String::new()) });
-    //! let hedge = HedgeLayer::<String, String, MyError>::builder()
+    //! let hedge = HedgeLayer::builder()
     //!     .name("monitored-hedge")
     //!     .delay(Duration::from_millis(50))
     //!     .max_hedged_attempts(2)

--- a/examples/chaos.rs
+++ b/examples/chaos.rs
@@ -13,11 +13,12 @@ async fn main() {
     println!("=========================\n");
 
     // Create a chaos layer that injects failures and latency
-    let chaos = ChaosLayer::<String, std::io::Error>::builder()
+    // Types are inferred from the error_fn closure signature
+    let chaos = ChaosLayer::builder()
         .name("test-chaos")
         .error_rate(0.3) // 30% of requests fail
-        .error_fn(|_req| std::io::Error::other("chaos error!"))
-        .latency_rate(0.2) // 20% of requests delayed
+        .error_fn(|_req: &String| std::io::Error::other("chaos error!"))
+        .latency_rate(0.2) // 20% of remaining requests delayed
         .min_latency(Duration::from_millis(50))
         .max_latency(Duration::from_millis(100))
         .on_error_injected(|| {
@@ -52,11 +53,11 @@ async fn main() {
             Ok(response) => {
                 successes += 1;
                 let elapsed = start.elapsed();
-                println!("✓ Request {}: {} ({:?})", i, response, elapsed);
+                println!("Request {}: {} ({:?})", i, response, elapsed);
             }
             Err(e) => {
                 failures += 1;
-                println!("✗ Request {}: {}", i, e);
+                println!("Request {}: {}", i, e);
             }
         }
     }

--- a/examples/hedge.rs
+++ b/examples/hedge.rs
@@ -144,7 +144,7 @@ async fn main() {
         }
     });
 
-    let layer2 = HedgeLayer::<String, String, MyError>::builder()
+    let layer2 = HedgeLayer::builder()
         .name("parallel-hedge")
         .no_delay() // Fire all immediately
         .max_hedged_attempts(3)

--- a/tests/composition_stacks/external_api.rs
+++ b/tests/composition_stacks/external_api.rs
@@ -161,7 +161,7 @@ async fn stack_with_hedging_compiles() {
         .timeout_duration(Duration::from_secs(10))
         .build();
 
-    let hedge = HedgeLayer::<ApiRequest, ApiResponse, ApiError>::builder()
+    let hedge = HedgeLayer::builder()
         .delay(Duration::from_millis(50))
         .max_hedged_attempts(2)
         .build();

--- a/tests/composition_stacks/latency_critical.rs
+++ b/tests/composition_stacks/latency_critical.rs
@@ -55,7 +55,7 @@ fn mock_multi_region_client()
 /// Latency mode hedging: fire hedge after delay
 #[tokio::test]
 async fn latency_mode_hedging_compiles() {
-    let hedge = HedgeLayer::<LatencyCacheKey, LatencyCacheValue, LatencyCacheError>::builder()
+    let hedge = HedgeLayer::builder()
         .delay(Duration::from_millis(10)) // Fire hedge after 10ms
         .max_hedged_attempts(2)
         .build();
@@ -74,7 +74,7 @@ async fn latency_mode_hedging_compiles() {
 /// Parallel mode hedging: fire all requests immediately
 #[tokio::test]
 async fn parallel_mode_hedging_compiles() {
-    let hedge = HedgeLayer::<LatencyCacheKey, LatencyCacheValue, LatencyCacheError>::builder()
+    let hedge = HedgeLayer::builder()
         .no_delay() // Fire all requests immediately
         .max_hedged_attempts(3)
         .build();
@@ -93,7 +93,7 @@ async fn parallel_mode_hedging_compiles() {
 /// Dynamic delay hedging
 #[tokio::test]
 async fn dynamic_delay_hedging_compiles() {
-    let hedge = HedgeLayer::<LatencyCacheKey, LatencyCacheValue, LatencyCacheError>::builder()
+    let hedge = HedgeLayer::builder()
         .delay_fn(|attempt| Duration::from_millis(10 * (attempt as u64).pow(2)))
         .max_hedged_attempts(3)
         .build();

--- a/tests/hedge/concurrency.rs
+++ b/tests/hedge/concurrency.rs
@@ -111,7 +111,7 @@ async fn test_parallel_mode_concurrent() {
         }
     });
 
-    let layer = HedgeLayer::<String, String, TestError>::builder()
+    let layer = HedgeLayer::builder()
         .no_delay()
         .max_hedged_attempts(3)
         .build();
@@ -214,7 +214,7 @@ async fn test_mixed_success_failure_concurrent() {
         }
     });
 
-    let layer = HedgeLayer::<String, String, TestError>::builder()
+    let layer = HedgeLayer::builder()
         .no_delay()
         .max_hedged_attempts(2)
         .build();

--- a/tests/hedge/delay_modes.rs
+++ b/tests/hedge/delay_modes.rs
@@ -41,7 +41,7 @@ async fn test_parallel_mode_fires_all_immediately() {
         }
     });
 
-    let layer = HedgeLayer::<String, String, TestError>::builder()
+    let layer = HedgeLayer::builder()
         .no_delay() // Parallel mode
         .max_hedged_attempts(3)
         .build();

--- a/tests/hedge/events.rs
+++ b/tests/hedge/events.rs
@@ -136,7 +136,7 @@ async fn test_all_failed_event() {
     let service =
         service_fn(|_req: String| async move { Err::<String, _>(TestError::new("failed")) });
 
-    let layer = HedgeLayer::<String, String, TestError>::builder()
+    let layer = HedgeLayer::builder()
         .no_delay()
         .max_hedged_attempts(3)
         .on_event(FnListener::new(move |e: &HedgeEvent| {

--- a/tests/hedge/integration.rs
+++ b/tests/hedge/integration.rs
@@ -104,7 +104,7 @@ async fn test_all_attempts_fail() {
         }
     });
 
-    let layer = HedgeLayer::<String, String, TestError>::builder()
+    let layer = HedgeLayer::builder()
         .no_delay()
         .max_hedged_attempts(3)
         .build();
@@ -260,7 +260,7 @@ async fn test_error_preserved_in_all_failed() {
         Err::<String, _>(TestError::new("original error message"))
     });
 
-    let layer = HedgeLayer::<String, String, TestError>::builder()
+    let layer = HedgeLayer::builder()
         .no_delay()
         .max_hedged_attempts(2)
         .build();

--- a/tests/metrics_regression/chaos.rs
+++ b/tests/metrics_regression/chaos.rs
@@ -11,10 +11,11 @@ use tower_resilience_chaos::ChaosLayer;
 async fn chaos_error_injection_metrics() {
     init_recorder();
 
-    let layer = ChaosLayer::<u64, &'static str>::builder()
+    // Types inferred from closure signature
+    let layer = ChaosLayer::builder()
         .name("error_chaos")
         .error_rate(1.0)
-        .error_fn(|_req| "injected_error")
+        .error_fn(|_req: &u64| "injected_error")
         .build();
 
     let service = tower::service_fn(|_: u64| async { Ok::<_, &'static str>("success") });
@@ -34,7 +35,8 @@ async fn chaos_error_injection_metrics() {
 async fn chaos_latency_injection_metrics() {
     init_recorder();
 
-    let layer = ChaosLayer::<u64, &'static str>::builder()
+    // Latency-only chaos - no type parameters needed!
+    let layer = ChaosLayer::builder()
         .name("latency_chaos")
         .latency_rate(1.0)
         .min_latency(Duration::from_millis(10))
@@ -61,10 +63,10 @@ async fn chaos_latency_injection_metrics() {
 async fn chaos_passthrough_metrics() {
     init_recorder();
 
-    let layer = ChaosLayer::<u64, &'static str>::builder()
+    // Latency-only chaos with 0% rate - all pass through
+    let layer = ChaosLayer::builder()
         .name("passthrough_chaos")
-        .error_rate(0.0)
-        .error_fn(|_req| "error")
+        .latency_rate(0.0)
         .build();
 
     let service = tower::service_fn(|_: u64| async { Ok::<_, &'static str>("success") });

--- a/tests/stress/hedge.rs
+++ b/tests/stress/hedge.rs
@@ -82,7 +82,7 @@ async fn stress_parallel_mode_high_volume() {
         }
     });
 
-    let layer = HedgeLayer::<u32, String, TestError>::builder()
+    let layer = HedgeLayer::builder()
         .no_delay()
         .max_hedged_attempts(3)
         .build();
@@ -232,7 +232,7 @@ async fn stress_all_attempts_fail() {
         }
     });
 
-    let layer = HedgeLayer::<u32, String, TestError>::builder()
+    let layer = HedgeLayer::builder()
         .no_delay()
         .max_hedged_attempts(3)
         .build();


### PR DESCRIPTION
## Summary

Closes #203

This PR reduces type parameter verbosity for two more layers, following the successful pattern established for `TimeLimiterLayer` in #212:

### ChaosLayer
- **Before**: `ChaosLayer::<String, MyError>::builder()`
- **After (latency-only)**: `ChaosLayer::builder().latency_rate(0.2).build()` - no type params!
- **After (error injection)**: `ChaosLayer::builder().error_rate(0.1).error_fn(|_req: &String| MyError).build()` - types inferred from closure

### HedgeLayer  
- **Before**: `HedgeLayer::<String, String, MyError>::builder()`
- **After**: `HedgeLayer::builder().delay(Duration::from_millis(100)).build()` - no type params!

Both layers now follow the same pattern as `RateLimiterLayer` where types are derived from the inner service or inferred from closure signatures.

## Breaking Changes

- `ChaosLayer` no longer accepts type parameters - use closures for type inference
- `HedgeLayer` no longer accepts type parameters - types derived from inner service

Migration is straightforward: remove explicit type annotations and ensure closure signatures include type annotations if needed.

## Test plan

- [x] All lib tests pass
- [x] All doc tests pass  
- [x] All integration tests pass
- [x] `cargo clippy` passes
- [x] `cargo fmt` applied