### PR TITLE
feat: add preset configurations for common use cases

### DIFF
--- a/crates/tower-resilience-bulkhead/src/layer.rs
+++ b/crates/tower-resilience-bulkhead/src/layer.rs
@@ -73,6 +73,74 @@ impl BulkheadLayer {
         }
         crate::BulkheadConfigBuilder::new()
     }
+
+    // =========================================================================
+    // Presets
+    // =========================================================================
+
+    /// Preset: Small bulkhead for limited concurrency.
+    ///
+    /// Configuration:
+    /// - 10 maximum concurrent calls
+    /// - No wait timeout (rejects immediately when full)
+    ///
+    /// Use this for protecting resources with limited capacity, such as
+    /// database connection pools or external API rate limits.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tower_resilience_bulkhead::BulkheadLayer;
+    ///
+    /// let layer = BulkheadLayer::small().build();
+    ///
+    /// // Or customize further
+    /// let layer = BulkheadLayer::small()
+    ///     .max_wait_duration(std::time::Duration::from_secs(5))
+    ///     .build();
+    /// ```
+    pub fn small() -> crate::BulkheadConfigBuilder {
+        Self::builder().max_concurrent_calls(10).reject_when_full()
+    }
+
+    /// Preset: Medium bulkhead for moderate concurrency.
+    ///
+    /// Configuration:
+    /// - 50 maximum concurrent calls
+    /// - No wait timeout (rejects immediately when full)
+    ///
+    /// A balanced configuration for typical service-to-service communication.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tower_resilience_bulkhead::BulkheadLayer;
+    ///
+    /// let layer = BulkheadLayer::medium().build();
+    /// ```
+    pub fn medium() -> crate::BulkheadConfigBuilder {
+        Self::builder().max_concurrent_calls(50).reject_when_full()
+    }
+
+    /// Preset: Large bulkhead for high concurrency.
+    ///
+    /// Configuration:
+    /// - 200 maximum concurrent calls
+    /// - No wait timeout (rejects immediately when full)
+    ///
+    /// Use this for high-throughput services that can handle many
+    /// concurrent requests.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tower_resilience_bulkhead::BulkheadLayer;
+    ///
+    /// let layer = BulkheadLayer::large().build();
+    /// ```
+    pub fn large() -> crate::BulkheadConfigBuilder {
+        Self::builder().max_concurrent_calls(200).reject_when_full()
+    }
 }
 
 impl<S> Layer<S> for BulkheadLayer {

--- a/crates/tower-resilience-bulkhead/src/lib.rs
+++ b/crates/tower-resilience-bulkhead/src/lib.rs
@@ -341,4 +341,28 @@ mod tests {
         };
         assert_eq!(event.event_type(), "call_failed");
     }
+
+    #[test]
+    fn test_preset_small() {
+        let _layer = BulkheadLayer::small().build();
+    }
+
+    #[test]
+    fn test_preset_medium() {
+        let _layer = BulkheadLayer::medium().build();
+    }
+
+    #[test]
+    fn test_preset_large() {
+        let _layer = BulkheadLayer::large().build();
+    }
+
+    #[test]
+    fn test_preset_with_customization() {
+        // Verify presets can be further customized
+        let _layer = BulkheadLayer::small()
+            .max_wait_duration(Duration::from_secs(5))
+            .name("custom")
+            .build();
+    }
 }

--- a/crates/tower-resilience-circuitbreaker/src/layer.rs
+++ b/crates/tower-resilience-circuitbreaker/src/layer.rs
@@ -120,6 +120,96 @@ impl CircuitBreakerLayer<DefaultClassifier> {
     pub fn builder() -> crate::CircuitBreakerConfigBuilder<DefaultClassifier> {
         crate::CircuitBreakerConfigBuilder::new()
     }
+
+    // =========================================================================
+    // Presets
+    // =========================================================================
+
+    /// Preset: Standard balanced circuit breaker configuration.
+    ///
+    /// Configuration:
+    /// - 50% failure rate threshold
+    /// - 100 call sliding window
+    /// - 30 second wait duration in open state
+    /// - 3 permitted calls in half-open state
+    ///
+    /// This is a balanced configuration suitable for most use cases.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tower_resilience_circuitbreaker::CircuitBreakerLayer;
+    ///
+    /// // Use as-is
+    /// let layer = CircuitBreakerLayer::standard().build();
+    ///
+    /// // Or customize further
+    /// let layer = CircuitBreakerLayer::standard()
+    ///     .name("my-service")
+    ///     .build();
+    /// ```
+    pub fn standard() -> crate::CircuitBreakerConfigBuilder<DefaultClassifier> {
+        use std::time::Duration;
+        Self::builder()
+            .failure_rate_threshold(0.5)
+            .sliding_window_size(100)
+            .wait_duration_in_open(Duration::from_secs(30))
+            .permitted_calls_in_half_open(3)
+    }
+
+    /// Preset: Fast-fail circuit breaker for latency-sensitive scenarios.
+    ///
+    /// Configuration:
+    /// - 25% failure rate threshold (opens quickly)
+    /// - 20 call sliding window (reacts faster to failures)
+    /// - 10 second wait duration in open state
+    /// - 1 permitted call in half-open state
+    ///
+    /// Use this when you want to fail fast and protect downstream services
+    /// from cascading failures. Good for latency-sensitive applications.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tower_resilience_circuitbreaker::CircuitBreakerLayer;
+    ///
+    /// let layer = CircuitBreakerLayer::fast_fail().build();
+    /// ```
+    pub fn fast_fail() -> crate::CircuitBreakerConfigBuilder<DefaultClassifier> {
+        use std::time::Duration;
+        Self::builder()
+            .failure_rate_threshold(0.25)
+            .sliding_window_size(20)
+            .wait_duration_in_open(Duration::from_secs(10))
+            .permitted_calls_in_half_open(1)
+    }
+
+    /// Preset: Tolerant circuit breaker for resilient scenarios.
+    ///
+    /// Configuration:
+    /// - 75% failure rate threshold (tolerates more failures)
+    /// - 200 call sliding window (smoother failure rate)
+    /// - 60 second wait duration in open state
+    /// - 5 permitted calls in half-open state
+    ///
+    /// Use this when you want to tolerate more failures before opening,
+    /// such as when calling services that occasionally have transient issues.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tower_resilience_circuitbreaker::CircuitBreakerLayer;
+    ///
+    /// let layer = CircuitBreakerLayer::tolerant().build();
+    /// ```
+    pub fn tolerant() -> crate::CircuitBreakerConfigBuilder<DefaultClassifier> {
+        use std::time::Duration;
+        Self::builder()
+            .failure_rate_threshold(0.75)
+            .sliding_window_size(200)
+            .wait_duration_in_open(Duration::from_secs(60))
+            .permitted_calls_in_half_open(5)
+    }
 }
 
 // Implement Layer<S> for DefaultClassifier - works with any service

--- a/crates/tower-resilience-circuitbreaker/src/lib.rs
+++ b/crates/tower-resilience-circuitbreaker/src/lib.rs
@@ -1062,4 +1062,28 @@ mod tests {
         assert_eq!(metrics.failure_count, 1);
         assert!((metrics.failure_rate - 0.333).abs() < 0.01);
     }
+
+    #[test]
+    fn test_preset_standard() {
+        let _layer = CircuitBreakerLayer::standard().build();
+    }
+
+    #[test]
+    fn test_preset_fast_fail() {
+        let _layer = CircuitBreakerLayer::fast_fail().build();
+    }
+
+    #[test]
+    fn test_preset_tolerant() {
+        let _layer = CircuitBreakerLayer::tolerant().build();
+    }
+
+    #[test]
+    fn test_preset_with_customization() {
+        // Verify presets can be further customized
+        let _layer = CircuitBreakerLayer::standard()
+            .name("my-service")
+            .failure_rate_threshold(0.6)
+            .build();
+    }
 }

--- a/crates/tower-resilience-ratelimiter/src/config.rs
+++ b/crates/tower-resilience-ratelimiter/src/config.rs
@@ -326,4 +326,28 @@ mod tests {
             .build();
         // If this compiles and doesn't panic, the event listener registration works
     }
+
+    #[test]
+    fn test_preset_per_second() {
+        let _layer = RateLimiterLayer::per_second(100).build();
+    }
+
+    #[test]
+    fn test_preset_per_minute() {
+        let _layer = RateLimiterLayer::per_minute(1000).build();
+    }
+
+    #[test]
+    fn test_preset_burst() {
+        let _layer = RateLimiterLayer::burst(100, 50).build();
+    }
+
+    #[test]
+    fn test_preset_with_customization() {
+        // Verify presets can be further customized
+        let _layer = RateLimiterLayer::per_second(100)
+            .timeout_duration(Duration::from_secs(2))
+            .name("custom")
+            .build();
+    }
 }

--- a/crates/tower-resilience-ratelimiter/src/layer.rs
+++ b/crates/tower-resilience-ratelimiter/src/layer.rs
@@ -58,6 +58,86 @@ impl RateLimiterLayer {
     pub fn builder() -> crate::RateLimiterConfigBuilder {
         crate::RateLimiterConfigBuilder::new()
     }
+
+    // =========================================================================
+    // Presets
+    // =========================================================================
+
+    /// Preset: Rate limit of N requests per second.
+    ///
+    /// Configuration:
+    /// - `limit` requests per 1 second period
+    /// - 100ms timeout waiting for permits
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tower_resilience_ratelimiter::RateLimiterLayer;
+    ///
+    /// // Allow 100 requests per second
+    /// let layer = RateLimiterLayer::per_second(100).build();
+    ///
+    /// // Customize further
+    /// let layer = RateLimiterLayer::per_second(100)
+    ///     .timeout_duration(std::time::Duration::from_millis(500))
+    ///     .build();
+    /// ```
+    pub fn per_second(limit: usize) -> crate::RateLimiterConfigBuilder {
+        use std::time::Duration;
+        Self::builder()
+            .limit_for_period(limit)
+            .refresh_period(Duration::from_secs(1))
+            .timeout_duration(Duration::from_millis(100))
+    }
+
+    /// Preset: Rate limit of N requests per minute.
+    ///
+    /// Configuration:
+    /// - `limit` requests per 60 second period
+    /// - 1 second timeout waiting for permits
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tower_resilience_ratelimiter::RateLimiterLayer;
+    ///
+    /// // Allow 1000 requests per minute
+    /// let layer = RateLimiterLayer::per_minute(1000).build();
+    /// ```
+    pub fn per_minute(limit: usize) -> crate::RateLimiterConfigBuilder {
+        use std::time::Duration;
+        Self::builder()
+            .limit_for_period(limit)
+            .refresh_period(Duration::from_secs(60))
+            .timeout_duration(Duration::from_secs(1))
+    }
+
+    /// Preset: Rate limit with burst capacity.
+    ///
+    /// Configuration:
+    /// - `rate_per_second` sustained requests per second
+    /// - `burst_size` additional burst capacity above the sustained rate
+    /// - 100ms timeout waiting for permits
+    ///
+    /// This uses a sliding window to smooth out the rate limiting while
+    /// allowing short bursts of traffic.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tower_resilience_ratelimiter::RateLimiterLayer;
+    ///
+    /// // Allow 100 requests/sec sustained with burst up to 150
+    /// let layer = RateLimiterLayer::burst(100, 50).build();
+    /// ```
+    pub fn burst(rate_per_second: usize, burst_size: usize) -> crate::RateLimiterConfigBuilder {
+        use std::time::Duration;
+        Self::builder()
+            .limit_for_period(rate_per_second + burst_size)
+            .refresh_period(Duration::from_secs(1))
+            .timeout_duration(Duration::from_millis(100))
+            .window_type(crate::WindowType::SlidingCounter)
+    }
 }
 
 impl<S> Layer<S> for RateLimiterLayer {

--- a/crates/tower-resilience-retry/src/config.rs
+++ b/crates/tower-resilience-retry/src/config.rs
@@ -473,4 +473,28 @@ mod tests {
         let req = Req { retries: 10 };
         assert_eq!(source.get_max_attempts(&req), 10);
     }
+
+    #[test]
+    fn test_preset_exponential_backoff() {
+        let _layer = RetryLayer::<(), std::io::Error>::exponential_backoff().build();
+    }
+
+    #[test]
+    fn test_preset_aggressive() {
+        let _layer = RetryLayer::<(), std::io::Error>::aggressive().build();
+    }
+
+    #[test]
+    fn test_preset_conservative() {
+        let _layer = RetryLayer::<(), std::io::Error>::conservative().build();
+    }
+
+    #[test]
+    fn test_preset_with_customization() {
+        // Verify presets can be further customized
+        let _layer = RetryLayer::<(), std::io::Error>::exponential_backoff()
+            .max_attempts(10)
+            .name("custom")
+            .build();
+    }
 }

--- a/crates/tower-resilience-retry/src/layer.rs
+++ b/crates/tower-resilience-retry/src/layer.rs
@@ -90,6 +90,90 @@ impl<Req, E> RetryLayer<Req, E> {
     pub fn builder() -> crate::RetryConfigBuilder<Req, E> {
         crate::RetryConfigBuilder::new()
     }
+
+    // =========================================================================
+    // Presets
+    // =========================================================================
+
+    /// Preset: Standard exponential backoff configuration.
+    ///
+    /// Configuration:
+    /// - 3 attempts (1 initial + 2 retries)
+    /// - 100ms initial backoff with exponential growth
+    ///
+    /// This is a balanced configuration suitable for most use cases.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tower_resilience_retry::RetryLayer;
+    ///
+    /// # #[derive(Debug, Clone)]
+    /// # struct MyError;
+    /// // Use as-is
+    /// let layer = RetryLayer::<(), MyError>::exponential_backoff().build();
+    ///
+    /// // Or customize further
+    /// let layer = RetryLayer::<(), MyError>::exponential_backoff()
+    ///     .max_attempts(5)  // Override default
+    ///     .build();
+    /// ```
+    pub fn exponential_backoff() -> crate::RetryConfigBuilder<Req, E> {
+        use std::time::Duration;
+        Self::builder()
+            .max_attempts(3)
+            .exponential_backoff(Duration::from_millis(100))
+    }
+
+    /// Preset: Aggressive retry configuration for latency-sensitive operations.
+    ///
+    /// Configuration:
+    /// - 5 attempts (1 initial + 4 retries)
+    /// - 50ms initial backoff with exponential growth
+    ///
+    /// Use this when quick recovery is important and the downstream service
+    /// can handle the additional load from retries.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tower_resilience_retry::RetryLayer;
+    ///
+    /// # #[derive(Debug, Clone)]
+    /// # struct MyError;
+    /// let layer = RetryLayer::<(), MyError>::aggressive().build();
+    /// ```
+    pub fn aggressive() -> crate::RetryConfigBuilder<Req, E> {
+        use std::time::Duration;
+        Self::builder()
+            .max_attempts(5)
+            .exponential_backoff(Duration::from_millis(50))
+    }
+
+    /// Preset: Conservative retry configuration for resource-constrained scenarios.
+    ///
+    /// Configuration:
+    /// - 2 attempts (1 initial + 1 retry)
+    /// - 500ms initial backoff with exponential growth
+    ///
+    /// Use this when you want to minimize retry overhead, such as when
+    /// calling services that are already under load or have strict rate limits.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tower_resilience_retry::RetryLayer;
+    ///
+    /// # #[derive(Debug, Clone)]
+    /// # struct MyError;
+    /// let layer = RetryLayer::<(), MyError>::conservative().build();
+    /// ```
+    pub fn conservative() -> crate::RetryConfigBuilder<Req, E> {
+        use std::time::Duration;
+        Self::builder()
+            .max_attempts(2)
+            .exponential_backoff(Duration::from_millis(500))
+    }
 }
 
 impl<S, Req, E> Layer<S> for RetryLayer<Req, E>


### PR DESCRIPTION
## Summary

Adds named preset constructors for better developer experience. Presets return builders, allowing further customization.

### Retry presets
- `exponential_backoff()`: 3 attempts, 100ms base backoff
- `aggressive()`: 5 attempts, 50ms base backoff
- `conservative()`: 2 attempts, 500ms base backoff

### CircuitBreaker presets
- `standard()`: 50% threshold, 100 call window, 30s open duration
- `fast_fail()`: 25% threshold, 20 call window, 10s open duration
- `tolerant()`: 75% threshold, 200 call window, 60s open duration

### RateLimiter presets
- `per_second(n)`: n requests per second
- `per_minute(n)`: n requests per minute
- `burst(rate, burst)`: sustained rate with burst capacity

### Bulkhead presets
- `small()`: 10 concurrent calls
- `medium()`: 50 concurrent calls
- `large()`: 200 concurrent calls

## Usage

```rust
// Simple usage with defaults
let layer = RetryLayer::<(), MyError>::aggressive().build();

// Customize a preset
let layer = CircuitBreakerLayer::fast_fail()
    .name("my-service")
    .failure_rate_threshold(0.3)  // Override default
    .build();
```

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features --workspace`
- [x] Added tests for all presets in each crate

Closes #206