### PR TITLE
docs: fix version references and example file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Resilience patterns for [Tower](https://docs.rs/tower) services, inspired by [Re
 
 ```toml
 [dependencies]
-tower-resilience = "0.4"
+tower-resilience = "0.5"
 tower = "0.5"
 ```
 
@@ -355,7 +355,7 @@ if let Some(db) = wrapper.get_healthy().await {
 
 **Note:** Health Check is not a Tower layer - it's a wrapper pattern for managing multiple resources with automatic failover.
 
-**Full examples:** [basic.rs](crates/tower-resilience-healthcheck/examples/basic.rs)
+**Full examples:** [healthcheck_basic.rs](crates/tower-resilience-healthcheck/examples/healthcheck_basic.rs)
 
 ### Coalesce
 

--- a/crates/tower-resilience/src/lib.rs
+++ b/crates/tower-resilience/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tower-resilience = { version = "0.4", features = ["circuitbreaker", "bulkhead"] }
+//! tower-resilience = { version = "0.5", features = ["circuitbreaker", "bulkhead"] }
 //! ```
 //!
 //! # Presets: Get Started Immediately


### PR DESCRIPTION
## Summary

Pre-release audit fixes:

- Update Quick Start version from `0.4` to `0.5` (matches current published crate)
- Fix healthcheck example reference: `basic.rs` -> `healthcheck_basic.rs`

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features --workspace`