### PR TITLE
docs: add feature flag documentation and standardize imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ let service = ServiceBuilder::new()
 Every pattern includes **preset configurations** with sensible defaults. Start immediately without tuning parameters - customize later when you need to:
 
 ```rust
-use tower_resilience_retry::RetryLayer;
-use tower_resilience_circuitbreaker::CircuitBreakerLayer;
-use tower_resilience_ratelimiter::RateLimiterLayer;
-use tower_resilience_bulkhead::BulkheadLayer;
+use tower_resilience::retry::RetryLayer;
+use tower_resilience::circuitbreaker::CircuitBreakerLayer;
+use tower_resilience::ratelimiter::RateLimiterLayer;
+use tower_resilience::bulkhead::BulkheadLayer;
 
 // Retry with exponential backoff (3 attempts, 100ms base)
 let retry = RetryLayer::<(), MyError>::exponential_backoff().build();
@@ -110,7 +110,7 @@ Prevent cascading failures by opening the circuit when error rate exceeds thresh
 
 ```rust
 use tower::Layer;
-use tower_resilience_circuitbreaker::CircuitBreakerLayer;
+use tower_resilience::circuitbreaker::CircuitBreakerLayer;
 use std::time::Duration;
 
 let layer = CircuitBreakerLayer::builder()
@@ -133,7 +133,7 @@ let service = layer.layer(my_service);
 Limit concurrent requests to prevent resource exhaustion:
 
 ```rust
-use tower_resilience_bulkhead::BulkheadLayer;
+use tower_resilience::bulkhead::BulkheadLayer;
 use std::time::Duration;
 
 let layer = BulkheadLayer::builder()
@@ -158,7 +158,7 @@ let service = layer.layer(my_service);
 Enforce timeouts on operations with configurable cancellation:
 
 ```rust
-use tower_resilience_timelimiter::TimeLimiterLayer;
+use tower_resilience::timelimiter::TimeLimiterLayer;
 use std::time::Duration;
 
 let layer = TimeLimiterLayer::builder()
@@ -179,7 +179,7 @@ let service = layer.layer(my_service);
 Retry failed requests with exponential backoff and jitter:
 
 ```rust
-use tower_resilience_retry::RetryLayer;
+use tower_resilience::retry::RetryLayer;
 use std::time::Duration;
 
 let layer = RetryLayer::<(), MyError>::builder()
@@ -203,7 +203,7 @@ let service = layer.layer(my_service);
 Control request rate to protect downstream services:
 
 ```rust
-use tower_resilience_ratelimiter::RateLimiterLayer;
+use tower_resilience::ratelimiter::RateLimiterLayer;
 use std::time::Duration;
 
 let layer = RateLimiterLayer::builder()
@@ -225,7 +225,7 @@ let service = layer.layer(my_service);
 Cache responses to reduce load on expensive operations:
 
 ```rust
-use tower_resilience_cache::{CacheLayer, EvictionPolicy};
+use tower_resilience::cache::{CacheLayer, EvictionPolicy};
 use std::time::Duration;
 
 let layer = CacheLayer::builder()
@@ -247,7 +247,7 @@ let service = layer.layer(my_service);
 Provide fallback responses when the primary service fails:
 
 ```rust
-use tower_resilience_fallback::FallbackLayer;
+use tower_resilience::fallback::FallbackLayer;
 
 // Return a static fallback value on error
 let layer = FallbackLayer::<Request, Response, MyError>::value(
@@ -272,7 +272,7 @@ let service = layer.layer(primary_service);
 Reduce tail latency by firing backup requests after a delay:
 
 ```rust
-use tower_resilience_hedge::HedgeLayer;
+use tower_resilience::hedge::HedgeLayer;
 use std::time::Duration;
 
 // Fire a hedge request if primary takes > 100ms
@@ -299,7 +299,7 @@ let service = layer.layer(my_service);
 Automatically reconnect on connection failures with configurable backoff:
 
 ```rust
-use tower_resilience_reconnect::{ReconnectLayer, ReconnectConfig, ReconnectPolicy};
+use tower_resilience::reconnect::{ReconnectLayer, ReconnectConfig, ReconnectPolicy};
 use std::time::Duration;
 
 let layer = ReconnectLayer::new(
@@ -327,7 +327,7 @@ let service = layer.layer(my_service);
 Proactive health monitoring with intelligent resource selection:
 
 ```rust
-use tower_resilience_healthcheck::{HealthCheckWrapper, HealthStatus, SelectionStrategy};
+use tower_resilience::healthcheck::{HealthCheckWrapper, HealthStatus, SelectionStrategy};
 use std::time::Duration;
 
 // Create wrapper with multiple resources
@@ -362,7 +362,7 @@ if let Some(db) = wrapper.get_healthy().await {
 Deduplicate concurrent identical requests (singleflight pattern):
 
 ```rust
-use tower_resilience_coalesce::CoalesceLayer;
+use tower_resilience::coalesce::CoalesceLayer;
 use tower::ServiceBuilder;
 
 // Coalesce by request ID - concurrent requests for same ID share one execution
@@ -391,7 +391,7 @@ Use cases:
 Delegate request processing to dedicated executors for parallel execution:
 
 ```rust
-use tower_resilience_executor::ExecutorLayer;
+use tower_resilience::executor::ExecutorLayer;
 use tower::ServiceBuilder;
 
 // Use a dedicated runtime for CPU-heavy work
@@ -421,7 +421,7 @@ Use cases:
 Dynamically adjust concurrency limits based on observed latency and error rates:
 
 ```rust
-use tower_resilience_adaptive::{AdaptiveLimiterLayer, Aimd, Vegas};
+use tower_resilience::adaptive::{AdaptiveLimiterLayer, Aimd, Vegas};
 use tower::ServiceBuilder;
 use std::time::Duration;
 
@@ -464,7 +464,7 @@ Use cases:
 Inject failures and latency to test your resilience patterns:
 
 ```rust
-use tower_resilience_chaos::ChaosLayer;
+use tower_resilience::chaos::ChaosLayer;
 use std::time::Duration;
 
 // Types inferred from closure signature - no type parameters needed!
@@ -508,7 +508,7 @@ impl From<TimeLimiterError> for ServiceError { /* ... */ }
 Use `ResilienceError<E>` as your service error type - all layer errors automatically convert:
 
 ```rust
-use tower_resilience_core::ResilienceError;
+use tower_resilience::core::ResilienceError;
 
 // Your application error
 #[derive(Debug, Clone)]
@@ -526,7 +526,7 @@ type ServiceError = ResilienceError<AppError>;
 Handle different failure modes explicitly:
 
 ```rust
-use tower_resilience_core::ResilienceError;
+use tower_resilience::core::ResilienceError;
 
 fn handle_error<E: std::fmt::Display>(error: ResilienceError<E>) {
     match error {

--- a/crates/tower-resilience-adaptive/Cargo.toml
+++ b/crates/tower-resilience-adaptive/Cargo.toml
@@ -28,5 +28,7 @@ tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time
 
 [features]
 default = []
+# Enable distributed tracing via the tracing crate
 tracing = ["dep:tracing"]
+# Enable Prometheus metrics (concurrency limit changes, RTT measurements)
 metrics = ["dep:metrics"]

--- a/crates/tower-resilience-bulkhead/Cargo.toml
+++ b/crates/tower-resilience-bulkhead/Cargo.toml
@@ -29,5 +29,7 @@ tokio = { workspace = true, features = ["rt", "macros", "rt-multi-thread"] }
 
 [features]
 default = []
+# Enable distributed tracing via the tracing crate
 tracing = ["dep:tracing"]
+# Enable Prometheus metrics (concurrent calls, rejections, wait times)
 metrics = ["dep:metrics"]

--- a/crates/tower-resilience-cache/Cargo.toml
+++ b/crates/tower-resilience-cache/Cargo.toml
@@ -28,5 +28,7 @@ tower = { workspace = true, features = ["util"] }
 
 [features]
 default = []
+# Enable Prometheus metrics (hit/miss rates, cache size, evictions)
 metrics = ["dep:metrics", "tower-resilience-core/metrics"]
+# Enable distributed tracing via the tracing crate
 tracing = ["dep:tracing", "tower-resilience-core/tracing"]

--- a/crates/tower-resilience-chaos/Cargo.toml
+++ b/crates/tower-resilience-chaos/Cargo.toml
@@ -27,5 +27,7 @@ tokio = { workspace = true, features = ["rt", "macros", "rt-multi-thread"] }
 
 [features]
 default = []
+# Enable distributed tracing via the tracing crate
 tracing = ["dep:tracing"]
+# Enable Prometheus metrics (injected errors, latency additions)
 metrics = ["dep:metrics"]

--- a/crates/tower-resilience-circuitbreaker/Cargo.toml
+++ b/crates/tower-resilience-circuitbreaker/Cargo.toml
@@ -25,9 +25,13 @@ serde = { workspace = true, optional = true }
 
 [features]
 default = []
+# Enable Prometheus metrics (state transitions, call counts, latency histograms)
 metrics = ["dep:metrics", "dep:metrics-util"]
+# Enable distributed tracing via the tracing crate
 tracing = ["dep:tracing"]
+# Enable serde serialization for circuit breaker state
 serde = ["dep:serde"]
+# Allow health checks to control circuit state (used with healthcheck crate)
 health-integration = ["tower-resilience-core/health-integration"]
 
 [dev-dependencies]

--- a/crates/tower-resilience-coalesce/Cargo.toml
+++ b/crates/tower-resilience-coalesce/Cargo.toml
@@ -29,5 +29,7 @@ tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time
 
 [features]
 default = []
+# Enable distributed tracing via the tracing crate
 tracing = ["dep:tracing"]
+# Enable Prometheus metrics (coalesced requests, in-flight counts)
 metrics = ["dep:metrics"]

--- a/crates/tower-resilience-core/Cargo.toml
+++ b/crates/tower-resilience-core/Cargo.toml
@@ -19,8 +19,11 @@ metrics = { workspace = true, optional = true }
 
 [features]
 default = []
+# Enable distributed tracing via the tracing crate
 tracing = ["dep:tracing"]
+# Enable Prometheus metrics support
 metrics = ["dep:metrics"]
+# Enable HealthTriggerable trait for health-based pattern control
 health-integration = []
 
 [dev-dependencies]

--- a/crates/tower-resilience-executor/Cargo.toml
+++ b/crates/tower-resilience-executor/Cargo.toml
@@ -27,5 +27,7 @@ tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time
 
 [features]
 default = []
+# Enable distributed tracing via the tracing crate
 tracing = ["dep:tracing"]
+# Enable Prometheus metrics (spawned tasks, completion times)
 metrics = ["dep:metrics"]

--- a/crates/tower-resilience-fallback/Cargo.toml
+++ b/crates/tower-resilience-fallback/Cargo.toml
@@ -12,7 +12,9 @@ categories = ["asynchronous", "network-programming"]
 
 [features]
 default = []
+# Enable Prometheus metrics (fallback invocations, success/failure counts)
 metrics = ["dep:metrics"]
+# Enable distributed tracing via the tracing crate
 tracing = ["dep:tracing"]
 
 [dependencies]

--- a/crates/tower-resilience-healthcheck/Cargo.toml
+++ b/crates/tower-resilience-healthcheck/Cargo.toml
@@ -22,7 +22,11 @@ tower-layer = "0.3"
 
 [features]
 default = []
+# Enable random selection strategy for load balancing across healthy resources
 random = ["dep:rand"]
+# Enable distributed tracing support (placeholder for future implementation)
 tracing = []
+# Enable health-triggered control of other patterns (e.g., circuit breakers)
 triggers = ["dep:tower-resilience-core", "tower-resilience-core/health-integration"]
+# Enable all optional features
 full = ["random", "tracing"]

--- a/crates/tower-resilience-hedge/Cargo.toml
+++ b/crates/tower-resilience-hedge/Cargo.toml
@@ -12,7 +12,9 @@ categories = ["asynchronous", "network-programming"]
 
 [features]
 default = []
+# Enable Prometheus metrics (hedge attempts, winner source, latency)
 metrics = ["dep:metrics"]
+# Enable distributed tracing via the tracing crate
 tracing = ["dep:tracing"]
 
 [dependencies]

--- a/crates/tower-resilience-ratelimiter/Cargo.toml
+++ b/crates/tower-resilience-ratelimiter/Cargo.toml
@@ -26,5 +26,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [features]
 default = []
+# Enable Prometheus metrics (permits acquired/rejected, wait times)
 metrics = ["dep:metrics", "tower-resilience-core/metrics"]
+# Enable distributed tracing via the tracing crate
 tracing = ["dep:tracing", "tower-resilience-core/tracing"]

--- a/crates/tower-resilience-reconnect/Cargo.toml
+++ b/crates/tower-resilience-reconnect/Cargo.toml
@@ -30,5 +30,7 @@ tokio-test = "0.4"
 
 [features]
 default = []
+# Enable Prometheus metrics (reconnection attempts, state transitions)
 metrics = ["dep:metrics", "tower-resilience-core/metrics"]
+# Enable distributed tracing via the tracing crate
 tracing = ["dep:tracing", "tower-resilience-core/tracing"]

--- a/crates/tower-resilience-retry/Cargo.toml
+++ b/crates/tower-resilience-retry/Cargo.toml
@@ -27,5 +27,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [features]
 default = []
+# Enable Prometheus metrics (retry attempts, successes, exhausted retries)
 metrics = ["dep:metrics", "tower-resilience-core/metrics"]
+# Enable distributed tracing via the tracing crate
 tracing = ["dep:tracing", "tower-resilience-core/tracing"]

--- a/crates/tower-resilience-timelimiter/Cargo.toml
+++ b/crates/tower-resilience-timelimiter/Cargo.toml
@@ -27,5 +27,7 @@ tower = { workspace = true, features = ["util"] }
 
 [features]
 default = []
+# Enable Prometheus metrics (timeouts, successful completions, latency)
 metrics = ["dep:metrics", "tower-resilience-core/metrics"]
+# Enable distributed tracing via the tracing crate
 tracing = ["dep:tracing", "tower-resilience-core/tracing"]

--- a/crates/tower-resilience/Cargo.toml
+++ b/crates/tower-resilience/Cargo.toml
@@ -32,23 +32,39 @@ tower-resilience-coalesce = { version = "0.7.0", path = "../tower-resilience-coa
 
 [features]
 default = []
-# Individual patterns
+
+# Resilience patterns - enable the ones you need
+# Circuit breaker: prevent cascading failures by stopping calls to failing services
 circuitbreaker = ["dep:tower-resilience-circuitbreaker"]
+# Bulkhead: isolate resources with concurrency limits
 bulkhead = ["dep:tower-resilience-bulkhead"]
+# Time limiter: enforce timeouts with cancellation support
 timelimiter = ["dep:tower-resilience-timelimiter"]
+# Cache: response memoization to reduce load
 cache = ["dep:tower-resilience-cache"]
+# Retry: automatic retries with exponential backoff and jitter
 retry = ["dep:tower-resilience-retry"]
+# Rate limiter: control request rate with fixed or sliding windows
 ratelimiter = ["dep:tower-resilience-ratelimiter"]
+# Reconnect: automatic reconnection with configurable backoff
 reconnect = ["dep:tower-resilience-reconnect"]
+# Health check: proactive health monitoring with resource selection
 healthcheck = ["dep:tower-resilience-healthcheck"]
+# Fallback: provide alternative responses when services fail
 fallback = ["dep:tower-resilience-fallback"]
+# Hedge: reduce tail latency by racing parallel requests
 hedge = ["dep:tower-resilience-hedge"]
+# Executor: delegate processing to dedicated thread pools
 executor = ["dep:tower-resilience-executor"]
+# Adaptive: dynamic concurrency limiting (AIMD/Vegas algorithms)
 adaptive = ["dep:tower-resilience-adaptive"]
+# Coalesce: deduplicate concurrent identical requests (singleflight)
 coalesce = ["dep:tower-resilience-coalesce"]
-# Enable all patterns
+
+# Enable all patterns at once
 full = ["circuitbreaker", "bulkhead", "timelimiter", "cache", "retry", "ratelimiter", "reconnect", "healthcheck", "fallback", "hedge", "executor", "adaptive", "coalesce"]
-# Health check and circuit breaker integration
+
+# Integration: health checks can proactively open/close circuit breakers
 health-circuitbreaker = [
     "healthcheck",
     "circuitbreaker",


### PR DESCRIPTION
## Summary

Addresses two documentation issues before release:

### Feature Flag Documentation (#219)

Added inline comments to all `[features]` sections across 16 crates explaining what each feature enables:

```toml
[features]
default = []
# Enable Prometheus metrics (state transitions, call counts, latency histograms)
metrics = ["dep:metrics", "dep:metrics-util"]
# Enable distributed tracing via the tracing crate
tracing = ["dep:tracing"]
```

### Standardize Imports (#222)

Updated all README examples to use top-level crate imports instead of individual crate imports:

```rust
// Before
use tower_resilience_circuitbreaker::CircuitBreakerLayer;

// After
use tower_resilience::circuitbreaker::CircuitBreakerLayer;
```

This encourages users to depend on the umbrella crate with features:
```toml
tower-resilience = { version = "0.7", features = ["circuitbreaker", "retry"] }
```

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features --workspace`

Closes #219
Closes #222