### PR TITLE
feat(ratelimiter): add opt-in backpressure mode

### DIFF
--- a/crates/tower-resilience-ratelimiter/src/config.rs
+++ b/crates/tower-resilience-ratelimiter/src/config.rs
@@ -59,6 +59,7 @@ pub struct RateLimiterConfig {
     pub(crate) refresh_period: Duration,
     pub(crate) timeout_duration: Duration,
     pub(crate) window_type: WindowType,
+    pub(crate) backpressure: bool,
     pub(crate) event_listeners: EventListeners<RateLimiterEvent>,
     pub(crate) name: String,
 }
@@ -69,6 +70,7 @@ pub struct RateLimiterConfigBuilder {
     refresh_period: Duration,
     timeout_duration: Duration,
     window_type: WindowType,
+    backpressure: bool,
     event_listeners: EventListeners<RateLimiterEvent>,
     name: String,
 }
@@ -94,6 +96,7 @@ impl RateLimiterConfigBuilder {
             refresh_period: Duration::from_secs(1),
             timeout_duration: Duration::from_millis(100),
             window_type: WindowType::default(),
+            backpressure: false,
             event_listeners: EventListeners::new(),
             name: "<unnamed>".to_string(),
         }
@@ -129,6 +132,40 @@ impl RateLimiterConfigBuilder {
     /// Sets the name for this rate limiter instance (used in events).
     pub fn name<S: Into<String>>(mut self, name: S) -> Self {
         self.name = name.into();
+        self
+    }
+
+    /// Enables backpressure mode.
+    ///
+    /// In backpressure mode, the rate limiter applies limits in `poll_ready()` rather
+    /// than in `call()`. When no permits are available, `poll_ready()` returns
+    /// `Poll::Pending` instead of allowing the request through and returning a
+    /// `RateLimited` error.
+    ///
+    /// This integrates with Tower's load balancing, buffer layers, and the standard
+    /// `service.ready().await` pattern -- making it ideal for client-side rate limiting
+    /// against external APIs.
+    ///
+    /// When backpressure mode is enabled:
+    /// - `timeout_duration` is ignored (the service waits indefinitely; callers control
+    ///   timeout externally)
+    /// - `RateLimiterServiceError::RateLimited` is never returned
+    ///
+    /// Default: `false` (rejection mode)
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use tower_resilience_ratelimiter::RateLimiterLayer;
+    /// use std::time::Duration;
+    ///
+    /// let limiter = RateLimiterLayer::builder()
+    ///     .limit_for_period(100)
+    ///     .refresh_period(Duration::from_secs(1))
+    ///     .backpressure()
+    ///     .build();
+    /// ```
+    pub fn backpressure(mut self) -> Self {
+        self.backpressure = true;
         self
     }
 
@@ -288,6 +325,7 @@ impl RateLimiterConfigBuilder {
             refresh_period: self.refresh_period,
             timeout_duration: self.timeout_duration,
             window_type: self.window_type,
+            backpressure: self.backpressure,
             event_listeners: self.event_listeners,
             name: self.name,
         };

--- a/crates/tower-resilience-ratelimiter/src/lib.rs
+++ b/crates/tower-resilience-ratelimiter/src/lib.rs
@@ -225,6 +225,8 @@ pub use layer::RateLimiterLayer;
 
 use crate::limiter::SharedRateLimiter;
 use futures::future::BoxFuture;
+use futures::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Instant;
@@ -240,10 +242,26 @@ use tracing::{debug, warn};
 ///
 /// This service wraps an inner service and limits the rate at which
 /// requests can be processed according to the configured policy.
+///
+/// # Backpressure mode
+///
+/// By default, the rate limiter applies limits in `call()` and returns
+/// `RateLimiterServiceError::RateLimited` when permits are exhausted (rejection mode).
+///
+/// When [backpressure mode](RateLimiterConfigBuilder::backpressure) is enabled,
+/// limits are applied in `poll_ready()` instead: the service returns `Poll::Pending`
+/// when no permits are available, causing callers to wait naturally via
+/// `service.ready().await`. This integrates with Tower's load balancing and buffer
+/// layers. In this mode, `RateLimiterServiceError::RateLimited` is never returned
+/// and `timeout_duration` is ignored.
 pub struct RateLimiter<S> {
     inner: S,
     config: Arc<RateLimiterConfig>,
     limiter: SharedRateLimiter,
+    /// Sleep future for backpressure mode wake-ups.
+    sleep: Option<Pin<Box<tokio::time::Sleep>>>,
+    /// Whether a permit has been acquired in `poll_ready` (backpressure mode only).
+    permit_acquired: bool,
 }
 
 impl<S> RateLimiter<S> {
@@ -272,6 +290,8 @@ impl<S> RateLimiter<S> {
             inner,
             config,
             limiter,
+            sleep: None,
+            permit_acquired: false,
         }
     }
 }
@@ -285,6 +305,8 @@ where
             inner: self.inner.clone(),
             config: Arc::clone(&self.config),
             limiter: self.limiter.clone(),
+            sleep: None,
+            permit_acquired: false,
         }
     }
 }
@@ -301,21 +323,89 @@ where
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner
-            .poll_ready(cx)
-            .map_err(RateLimiterServiceError::Inner)
+        // Check inner service readiness first
+        match self.inner.poll_ready(cx) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(Err(e)) => return Poll::Ready(Err(RateLimiterServiceError::Inner(e))),
+            Poll::Ready(Ok(())) => {}
+        }
+
+        if !self.config.backpressure {
+            return Poll::Ready(Ok(()));
+        }
+
+        // Backpressure mode: acquire permit in poll_ready
+        if self.permit_acquired {
+            return Poll::Ready(Ok(()));
+        }
+
+        // If we have a pending sleep, poll it first
+        if let Some(sleep) = self.sleep.as_mut() {
+            match sleep.as_mut().poll(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(()) => {
+                    self.sleep = None;
+                    // Fall through to retry acquire
+                }
+            }
+        }
+
+        match self.limiter.try_acquire_now() {
+            Ok(()) => {
+                self.permit_acquired = true;
+                Poll::Ready(Ok(()))
+            }
+            Err(wait_duration) => {
+                let sleep = tokio::time::sleep(wait_duration);
+                let mut pinned = Box::pin(sleep);
+                // Register the waker so we get polled again when the sleep completes
+                let _ = pinned.as_mut().poll(cx);
+                self.sleep = Some(pinned);
+                Poll::Pending
+            }
+        }
     }
 
     fn call(&mut self, req: Req) -> Self::Future {
+        if self.permit_acquired {
+            // Backpressure mode: permit already acquired in poll_ready
+            self.permit_acquired = false;
+            let config = Arc::clone(&self.config);
+            let mut inner = self.inner.clone();
+
+            let event = RateLimiterEvent::PermitAcquired {
+                pattern_name: config.name.clone(),
+                timestamp: Instant::now(),
+                wait_duration: std::time::Duration::ZERO,
+            };
+            config.event_listeners.emit(&event);
+
+            #[cfg(feature = "metrics")]
+            {
+                counter!("ratelimiter_calls_total", "ratelimiter" => config.name.clone(), "result" => "permitted").increment(1);
+                histogram!("ratelimiter_wait_duration_seconds", "ratelimiter" => config.name.clone())
+                    .record(0.0);
+            }
+
+            #[cfg(feature = "tracing")]
+            debug!(ratelimiter = %config.name, "Permit acquired via backpressure");
+
+            return Box::pin(async move {
+                inner
+                    .call(req)
+                    .await
+                    .map_err(RateLimiterServiceError::Inner)
+            });
+        }
+
+        // Rejection mode: acquire permit in call
         let limiter = self.limiter.clone();
         let config = Arc::clone(&self.config);
         let mut inner = self.inner.clone();
 
         Box::pin(async move {
-            // Try to acquire a permit
             match limiter.acquire().await {
                 Ok(wait_duration) => {
-                    // Permit acquired
                     let event = RateLimiterEvent::PermitAcquired {
                         pattern_name: config.name.clone(),
                         timestamp: Instant::now(),
@@ -343,14 +433,12 @@ where
                         }
                     }
 
-                    // Process the request
                     inner
                         .call(req)
                         .await
                         .map_err(RateLimiterServiceError::Inner)
                 }
                 Err(()) => {
-                    // Rate limited
                     let event = RateLimiterEvent::PermitRejected {
                         pattern_name: config.name.clone(),
                         timestamp: Instant::now(),
@@ -574,5 +662,165 @@ mod tests {
 
         assert!(result.is_ok());
         assert!(elapsed >= Duration::from_millis(45)); // Should have waited
+    }
+
+    // ==================== Backpressure Mode Tests ====================
+
+    #[tokio::test]
+    async fn test_backpressure_allows_requests_within_limit() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let cc = Arc::clone(&call_count);
+
+        let service = service_fn(move |req: String| {
+            let cc = Arc::clone(&cc);
+            async move {
+                cc.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, std::io::Error>(format!("Response: {}", req))
+            }
+        });
+
+        let layer = RateLimiterLayer::builder()
+            .limit_for_period(10)
+            .refresh_period(Duration::from_secs(1))
+            .backpressure()
+            .build();
+
+        let mut service = layer.layer(service);
+
+        for _ in 0..10 {
+            let result = service
+                .ready()
+                .await
+                .unwrap()
+                .call("test".to_string())
+                .await;
+            assert!(result.is_ok());
+        }
+
+        assert_eq!(call_count.load(Ordering::SeqCst), 10);
+    }
+
+    #[tokio::test]
+    async fn test_backpressure_waits_instead_of_rejecting() {
+        let service =
+            service_fn(|_req: String| async move { Ok::<_, std::io::Error>("ok".to_string()) });
+
+        let layer = RateLimiterLayer::builder()
+            .limit_for_period(1)
+            .refresh_period(Duration::from_millis(50))
+            .backpressure()
+            .build();
+
+        let mut service = layer.layer(service);
+
+        // First request succeeds immediately
+        assert!(service
+            .ready()
+            .await
+            .unwrap()
+            .call("1".to_string())
+            .await
+            .is_ok());
+
+        // Second request should wait (not error) and eventually succeed
+        let start = std::time::Instant::now();
+        let result = service.ready().await.unwrap().call("2".to_string()).await;
+        let elapsed = start.elapsed();
+
+        assert!(result.is_ok());
+        assert!(elapsed >= Duration::from_millis(40));
+    }
+
+    #[tokio::test]
+    async fn test_backpressure_never_returns_rate_limited() {
+        let service =
+            service_fn(|_req: String| async move { Ok::<_, std::io::Error>("ok".to_string()) });
+
+        let layer = RateLimiterLayer::builder()
+            .limit_for_period(1)
+            .refresh_period(Duration::from_millis(50))
+            .backpressure()
+            .build();
+
+        let mut service = layer.layer(service);
+
+        // Make several requests; none should return RateLimited
+        for _ in 0..5 {
+            let result = service.ready().await.unwrap().call("x".to_string()).await;
+            assert!(result.is_ok());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_backpressure_events_fire_permit_acquired() {
+        let acquired_count = Arc::new(AtomicUsize::new(0));
+        let rejected_count = Arc::new(AtomicUsize::new(0));
+
+        let ac = Arc::clone(&acquired_count);
+        let rc = Arc::clone(&rejected_count);
+
+        let service =
+            service_fn(|_req: String| async move { Ok::<_, std::io::Error>("ok".to_string()) });
+
+        let layer = RateLimiterLayer::builder()
+            .limit_for_period(1)
+            .refresh_period(Duration::from_millis(50))
+            .backpressure()
+            .on_permit_acquired(move |_| {
+                ac.fetch_add(1, Ordering::SeqCst);
+            })
+            .on_permit_rejected(move |_| {
+                rc.fetch_add(1, Ordering::SeqCst);
+            })
+            .build();
+
+        let mut service = layer.layer(service);
+
+        for _ in 0..3 {
+            let _ = service.ready().await.unwrap().call("x".to_string()).await;
+        }
+
+        assert_eq!(acquired_count.load(Ordering::SeqCst), 3);
+        assert_eq!(rejected_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn test_backpressure_with_sliding_log() {
+        let service =
+            service_fn(|_req: String| async move { Ok::<_, std::io::Error>("ok".to_string()) });
+
+        let layer = RateLimiterLayer::builder()
+            .limit_for_period(2)
+            .refresh_period(Duration::from_millis(50))
+            .window_type(WindowType::SlidingLog)
+            .backpressure()
+            .build();
+
+        let mut service = layer.layer(service);
+
+        for _ in 0..4 {
+            let result = service.ready().await.unwrap().call("x".to_string()).await;
+            assert!(result.is_ok());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_backpressure_with_sliding_counter() {
+        let service =
+            service_fn(|_req: String| async move { Ok::<_, std::io::Error>("ok".to_string()) });
+
+        let layer = RateLimiterLayer::builder()
+            .limit_for_period(2)
+            .refresh_period(Duration::from_millis(50))
+            .window_type(WindowType::SlidingCounter)
+            .backpressure()
+            .build();
+
+        let mut service = layer.layer(service);
+
+        for _ in 0..4 {
+            let result = service.ready().await.unwrap().call("x".to_string()).await;
+            assert!(result.is_ok());
+        }
     }
 }

--- a/crates/tower-resilience-ratelimiter/src/limiter.rs
+++ b/crates/tower-resilience-ratelimiter/src/limiter.rs
@@ -59,6 +59,26 @@ impl FixedWindowState {
         }
     }
 
+    /// Attempts to acquire a permit without timeout enforcement.
+    ///
+    /// Returns `Duration::ZERO` if a permit was consumed, or the wait duration
+    /// until a permit will be available.
+    fn try_acquire_no_timeout(&mut self) -> Duration {
+        let now = Instant::now();
+
+        if now.duration_since(self.period_start) >= self.refresh_period {
+            self.refresh(now);
+        }
+
+        if self.available_permits > 0 {
+            self.available_permits -= 1;
+            return Duration::ZERO;
+        }
+
+        self.refresh_period
+            .saturating_sub(now.duration_since(self.period_start))
+    }
+
     fn refresh(&mut self, now: Instant) {
         self.available_permits = self.limit_for_period;
         self.period_start = now;
@@ -128,6 +148,33 @@ impl SlidingLogState {
         }
     }
 
+    /// Attempts to acquire a permit without timeout enforcement.
+    fn try_acquire_no_timeout(&mut self) -> Duration {
+        let now = Instant::now();
+
+        while let Some(&timestamp) = self.request_log.front() {
+            if now.duration_since(timestamp) >= self.window_duration {
+                self.request_log.pop_front();
+            } else {
+                break;
+            }
+        }
+
+        if self.request_log.len() < self.limit_for_period {
+            self.request_log.push_back(now);
+            return Duration::ZERO;
+        }
+
+        if let Some(&oldest) = self.request_log.front() {
+            oldest
+                .checked_add(self.window_duration)
+                .map(|expiry| expiry.saturating_duration_since(now))
+                .unwrap_or(Duration::ZERO)
+        } else {
+            Duration::ZERO
+        }
+    }
+
     fn available_permits(&self) -> usize {
         self.limit_for_period.saturating_sub(self.request_log.len())
     }
@@ -190,6 +237,27 @@ impl SlidingCounterState {
         } else {
             Ok(time_until_slot)
         }
+    }
+
+    /// Attempts to acquire a permit without timeout enforcement.
+    fn try_acquire_no_timeout(&mut self) -> Duration {
+        let now = Instant::now();
+        self.maybe_rotate_bucket(now);
+
+        let elapsed = now.duration_since(self.bucket_start);
+        let elapsed_ratio = elapsed.as_secs_f64() / self.bucket_duration.as_secs_f64();
+        let elapsed_ratio = elapsed_ratio.clamp(0.0, 1.0);
+
+        let previous_weight = 1.0 - elapsed_ratio;
+        let weighted_count =
+            (self.previous_count as f64 * previous_weight) + self.current_count as f64;
+
+        if weighted_count < self.limit_for_period as f64 {
+            self.current_count += 1;
+            return Duration::ZERO;
+        }
+
+        self.estimate_wait_time(elapsed_ratio)
     }
 
     fn maybe_rotate_bucket(&mut self, now: Instant) {
@@ -305,6 +373,14 @@ impl RateLimiterStateInner {
         }
     }
 
+    fn try_acquire_no_timeout(&mut self) -> Duration {
+        match self {
+            Self::Fixed(state) => state.try_acquire_no_timeout(),
+            Self::SlidingLog(state) => state.try_acquire_no_timeout(),
+            Self::SlidingCounter(state) => state.try_acquire_no_timeout(),
+        }
+    }
+
     fn available_permits(&self) -> usize {
         match self {
             Self::Fixed(state) => state.available_permits(),
@@ -365,6 +441,20 @@ impl SharedRateLimiter {
                 // Timeout would be exceeded
                 Err(())
             }
+        }
+    }
+
+    /// Attempts to acquire a permit immediately without waiting or timeout.
+    ///
+    /// Returns `Ok(())` if a permit was consumed, or `Err(wait_duration)` indicating
+    /// how long to wait before retrying.
+    pub(crate) fn try_acquire_now(&self) -> Result<(), Duration> {
+        let mut state = self.state.lock().unwrap();
+        let wait = state.try_acquire_no_timeout();
+        if wait == Duration::ZERO {
+            Ok(())
+        } else {
+            Err(wait)
         }
     }
 
@@ -604,5 +694,84 @@ mod tests {
 
         assert!(limiter.acquire().await.is_ok());
         assert_eq!(limiter.available_permits(), 0);
+    }
+
+    // ==================== try_acquire_no_timeout Tests ====================
+
+    #[test]
+    fn test_fixed_try_acquire_no_timeout_returns_zero_when_available() {
+        let mut state =
+            FixedWindowState::new(2, Duration::from_secs(1), Duration::from_millis(100));
+        assert_eq!(state.try_acquire_no_timeout(), Duration::ZERO);
+        assert_eq!(state.available_permits(), 1);
+    }
+
+    #[test]
+    fn test_fixed_try_acquire_no_timeout_returns_wait_when_exhausted() {
+        let mut state =
+            FixedWindowState::new(1, Duration::from_secs(1), Duration::from_millis(100));
+        assert_eq!(state.try_acquire_no_timeout(), Duration::ZERO);
+        let wait = state.try_acquire_no_timeout();
+        assert!(wait > Duration::ZERO);
+    }
+
+    #[test]
+    fn test_sliding_log_try_acquire_no_timeout_returns_zero_when_available() {
+        let mut state = SlidingLogState::new(2, Duration::from_secs(1), Duration::from_millis(100));
+        assert_eq!(state.try_acquire_no_timeout(), Duration::ZERO);
+        assert_eq!(state.available_permits(), 1);
+    }
+
+    #[test]
+    fn test_sliding_log_try_acquire_no_timeout_returns_wait_when_exhausted() {
+        let mut state = SlidingLogState::new(1, Duration::from_secs(1), Duration::from_millis(100));
+        assert_eq!(state.try_acquire_no_timeout(), Duration::ZERO);
+        let wait = state.try_acquire_no_timeout();
+        assert!(wait > Duration::ZERO);
+    }
+
+    #[test]
+    fn test_sliding_counter_try_acquire_no_timeout_returns_zero_when_available() {
+        let mut state =
+            SlidingCounterState::new(2, Duration::from_secs(1), Duration::from_millis(100));
+        assert_eq!(state.try_acquire_no_timeout(), Duration::ZERO);
+        assert_eq!(state.available_permits(), 1);
+    }
+
+    #[test]
+    fn test_sliding_counter_try_acquire_no_timeout_returns_wait_when_exhausted() {
+        let mut state =
+            SlidingCounterState::new(1, Duration::from_secs(1), Duration::from_millis(100));
+        assert_eq!(state.try_acquire_no_timeout(), Duration::ZERO);
+        let wait = state.try_acquire_no_timeout();
+        assert!(wait > Duration::ZERO);
+    }
+
+    // ==================== try_acquire_now Tests ====================
+
+    #[test]
+    fn test_try_acquire_now_ok_when_available() {
+        let limiter = SharedRateLimiter::new(
+            WindowType::Fixed,
+            2,
+            Duration::from_secs(1),
+            Duration::from_millis(100),
+        );
+        assert!(limiter.try_acquire_now().is_ok());
+        assert_eq!(limiter.available_permits(), 1);
+    }
+
+    #[test]
+    fn test_try_acquire_now_err_when_exhausted() {
+        let limiter = SharedRateLimiter::new(
+            WindowType::Fixed,
+            1,
+            Duration::from_secs(1),
+            Duration::from_millis(100),
+        );
+        assert!(limiter.try_acquire_now().is_ok());
+        let result = limiter.try_acquire_now();
+        assert!(result.is_err());
+        assert!(result.unwrap_err() > Duration::ZERO);
     }
 }


### PR DESCRIPTION
## Summary

- Add `.backpressure()` builder method that switches the rate limiter from rejection mode (errors in `call()`) to backpressure mode (limits in `poll_ready()` via `Poll::Pending`)
- When enabled, integrates with Tower's load balancing, buffer layers, and `service.ready().await` pattern for client-side rate limiting against external APIs
- Default behavior (rejection mode) is unchanged -- no breaking changes

Ref: tower-rs/tower#842

## Changes

- **config.rs**: Add `backpressure: bool` field and `.backpressure()` builder method
- **limiter.rs**: Add `try_acquire_no_timeout()` (returns wait duration, never errors on timeout) and `try_acquire_now()` (non-async instant permit check)
- **lib.rs**: Add `sleep`/`permit_acquired` fields to `RateLimiter<S>`, update `poll_ready()` to acquire permits when in backpressure mode, update `call()` to skip acquisition when permit already reserved

## Test plan

- [x] Requests within limit succeed immediately in backpressure mode
- [x] Requests over limit wait (not error) and eventually succeed
- [x] Backpressure mode never returns `RateLimited` error
- [x] Events fire `PermitAcquired` (never `PermitRejected`) in backpressure mode
- [x] Works with all three window types (Fixed, SlidingLog, SlidingCounter)
- [x] `try_acquire_no_timeout` returns wait duration when permits exhausted
- [x] `try_acquire_now` returns `Ok` / `Err(duration)` correctly
- [x] All existing tests pass unchanged
- [x] `cargo clippy --all-targets --all-features` clean
- [x] Doc tests pass