### PR TITLE
feat(bulkhead,circuitbreaker): add opt-in backpressure mode

### DIFF
--- a/crates/tower-resilience-bulkhead/src/config.rs
+++ b/crates/tower-resilience-bulkhead/src/config.rs
@@ -11,6 +11,8 @@ pub struct BulkheadConfig {
     pub(crate) max_concurrent_calls: usize,
     /// Maximum time to wait for a permit.
     pub(crate) max_wait_duration: Option<Duration>,
+    /// Whether backpressure mode is enabled.
+    pub(crate) backpressure: bool,
     /// Name of this bulkhead instance.
     pub(crate) name: String,
     /// Event listeners.
@@ -21,6 +23,7 @@ pub struct BulkheadConfig {
 pub struct BulkheadConfigBuilder {
     max_concurrent_calls: usize,
     max_wait_duration: Option<Duration>,
+    backpressure: bool,
     name: String,
     event_listeners: EventListeners<BulkheadEvent>,
 }
@@ -31,6 +34,7 @@ impl BulkheadConfigBuilder {
         Self {
             max_concurrent_calls: 25,
             max_wait_duration: None,
+            backpressure: false,
             name: "bulkhead".to_string(),
             event_listeners: EventListeners::new(),
         }
@@ -88,6 +92,37 @@ impl BulkheadConfigBuilder {
     /// where users want a concurrency limiter that rejects rather than queues.
     pub fn reject_when_full(mut self) -> Self {
         self.max_wait_duration = Some(Duration::ZERO);
+        self
+    }
+
+    /// Enables backpressure mode.
+    ///
+    /// In backpressure mode, the bulkhead acquires a semaphore permit in `poll_ready()`
+    /// rather than in `call()`. When all permits are in use, `poll_ready()` returns
+    /// `Poll::Pending` instead of allowing the request through and returning a
+    /// `BulkheadFull` or `Timeout` error.
+    ///
+    /// This integrates with Tower's load balancing, buffer layers, and the standard
+    /// `service.ready().await` pattern.
+    ///
+    /// When backpressure mode is enabled:
+    /// - `max_wait_duration` is ignored (the service waits indefinitely; callers control
+    ///   timeout externally)
+    /// - `BulkheadError::BulkheadFull` and `BulkheadError::Timeout` are never returned
+    ///
+    /// Default: `false` (rejection mode)
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use tower_resilience_bulkhead::BulkheadLayer;
+    ///
+    /// let layer = BulkheadLayer::builder()
+    ///     .max_concurrent_calls(10)
+    ///     .backpressure()
+    ///     .build();
+    /// ```
+    pub fn backpressure(mut self) -> Self {
+        self.backpressure = true;
         self
     }
 
@@ -264,6 +299,7 @@ impl BulkheadConfigBuilder {
         let config = BulkheadConfig {
             max_concurrent_calls: self.max_concurrent_calls,
             max_wait_duration: self.max_wait_duration,
+            backpressure: self.backpressure,
             name: self.name,
             event_listeners: self.event_listeners,
         };

--- a/crates/tower-resilience-bulkhead/src/lib.rs
+++ b/crates/tower-resilience-bulkhead/src/lib.rs
@@ -271,6 +271,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
+    use tower::{Service, ServiceExt};
 
     #[test]
     fn test_config_builder_defaults() {
@@ -364,5 +365,126 @@ mod tests {
             .max_wait_duration(Duration::from_secs(5))
             .name("custom")
             .build();
+    }
+
+    #[tokio::test]
+    async fn test_backpressure_allows_requests_within_limit() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let cc = Arc::clone(&call_count);
+
+        let service = tower::service_fn(move |req: String| {
+            let cc = Arc::clone(&cc);
+            async move {
+                cc.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, std::io::Error>(format!("Response: {}", req))
+            }
+        });
+
+        let layer = BulkheadLayer::builder()
+            .max_concurrent_calls(5)
+            .backpressure()
+            .build();
+
+        let mut service = tower::ServiceBuilder::new().layer(layer).service(service);
+
+        for i in 0..5 {
+            let result = service
+                .ready()
+                .await
+                .unwrap()
+                .call(format!("req-{}", i))
+                .await;
+            assert!(result.is_ok());
+        }
+
+        assert_eq!(call_count.load(Ordering::SeqCst), 5);
+    }
+
+    #[tokio::test]
+    async fn test_backpressure_waits_instead_of_rejecting() {
+        let service = tower::service_fn(|_req: String| async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            Ok::<_, std::io::Error>("ok".to_string())
+        });
+
+        let layer = BulkheadLayer::builder()
+            .max_concurrent_calls(1)
+            .backpressure()
+            .build();
+
+        let mut service = tower::ServiceBuilder::new().layer(layer).service(service);
+
+        // First request: acquire permit via ready(), then call
+        let mut svc = service.ready().await.unwrap().clone();
+        let handle = tokio::spawn(async move { svc.call("1".to_string()).await });
+
+        // Give the first call time to start
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        // Second request should wait in poll_ready (not error)
+        let start = std::time::Instant::now();
+        let result = service.ready().await.unwrap().call("2".to_string()).await;
+        let elapsed = start.elapsed();
+
+        assert!(result.is_ok());
+        // Should have waited for the first call to release its permit
+        assert!(elapsed >= Duration::from_millis(30));
+
+        let _ = handle.await;
+    }
+
+    #[tokio::test]
+    async fn test_backpressure_never_returns_bulkhead_full() {
+        let service =
+            tower::service_fn(
+                |_req: String| async move { Ok::<_, std::io::Error>("ok".to_string()) },
+            );
+
+        let layer = BulkheadLayer::builder()
+            .max_concurrent_calls(1)
+            .backpressure()
+            .build();
+
+        let mut service = tower::ServiceBuilder::new().layer(layer).service(service);
+
+        // Make several requests; none should return BulkheadFull or Timeout
+        for _ in 0..5 {
+            let result = service.ready().await.unwrap().call("x".to_string()).await;
+            assert!(result.is_ok());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_backpressure_events_fire_call_permitted() {
+        let permitted_count = Arc::new(AtomicUsize::new(0));
+        let rejected_count = Arc::new(AtomicUsize::new(0));
+
+        let pc = Arc::clone(&permitted_count);
+        let rc = Arc::clone(&rejected_count);
+
+        let service =
+            tower::service_fn(
+                |_req: String| async move { Ok::<_, std::io::Error>("ok".to_string()) },
+            );
+
+        let layer = BulkheadLayer::builder()
+            .max_concurrent_calls(5)
+            .backpressure()
+            .on_call_permitted(move |_| {
+                pc.fetch_add(1, Ordering::SeqCst);
+            })
+            .on_call_rejected(move |_| {
+                rc.fetch_add(1, Ordering::SeqCst);
+            })
+            .build();
+
+        let mut service = tower::ServiceBuilder::new().layer(layer).service(service);
+
+        for _ in 0..3 {
+            let _ = service.ready().await.unwrap().call("x".to_string()).await;
+        }
+
+        assert_eq!(permitted_count.load(Ordering::SeqCst), 3);
+        assert_eq!(rejected_count.load(Ordering::SeqCst), 0);
     }
 }

--- a/crates/tower-resilience-bulkhead/src/service.rs
+++ b/crates/tower-resilience-bulkhead/src/service.rs
@@ -4,21 +4,41 @@ use crate::config::BulkheadConfig;
 use crate::error::{BulkheadError, BulkheadServiceError};
 use crate::events::BulkheadEvent;
 use futures::future::BoxFuture;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Instant;
-use tokio::sync::Semaphore;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tower::Service;
 
 #[cfg(feature = "metrics")]
 use metrics::{counter, gauge, histogram};
 
+type AcquireFuture =
+    Pin<Box<dyn Future<Output = Result<OwnedSemaphorePermit, tokio::sync::AcquireError>> + Send>>;
+
 /// Bulkhead service that limits concurrent calls.
-#[derive(Clone)]
 pub struct Bulkhead<S> {
     inner: S,
     semaphore: Arc<Semaphore>,
     config: Arc<BulkheadConfig>,
+    /// Permit reserved in `poll_ready` (backpressure mode only).
+    permit: Option<OwnedSemaphorePermit>,
+    /// In-flight semaphore acquire future (backpressure mode only).
+    acquire_future: Option<AcquireFuture>,
+}
+
+impl<S: Clone> Clone for Bulkhead<S> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            semaphore: Arc::clone(&self.semaphore),
+            config: Arc::clone(&self.config),
+            permit: None,
+            acquire_future: None,
+        }
+    }
 }
 
 impl<S> Bulkhead<S> {
@@ -29,6 +49,8 @@ impl<S> Bulkhead<S> {
             inner,
             semaphore,
             config: Arc::new(config),
+            permit: None,
+            acquire_future: None,
         }
     }
 }
@@ -46,12 +68,124 @@ where
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner
-            .poll_ready(cx)
-            .map_err(BulkheadServiceError::Inner)
+        // Check inner service readiness first
+        match self.inner.poll_ready(cx) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(Err(e)) => return Poll::Ready(Err(BulkheadServiceError::Inner(e))),
+            Poll::Ready(Ok(())) => {}
+        }
+
+        if !self.config.backpressure {
+            return Poll::Ready(Ok(()));
+        }
+
+        // Backpressure mode: acquire permit in poll_ready
+        if self.permit.is_some() {
+            return Poll::Ready(Ok(()));
+        }
+
+        // Create or poll the acquire future
+        let fut = self.acquire_future.get_or_insert_with(|| {
+            let sem = Arc::clone(&self.semaphore);
+            Box::pin(async move { sem.acquire_owned().await })
+        });
+
+        match fut.as_mut().poll(cx) {
+            Poll::Ready(Ok(permit)) => {
+                self.acquire_future = None;
+                self.permit = Some(permit);
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Err(_)) => {
+                // Semaphore closed -- should not happen in normal operation
+                self.acquire_future = None;
+                Poll::Ready(Ok(()))
+            }
+            Poll::Pending => Poll::Pending,
+        }
     }
 
     fn call(&mut self, request: Request) -> Self::Future {
+        if let Some(permit) = self.permit.take() {
+            // Backpressure mode: permit already acquired in poll_ready
+            let semaphore_for_check = Arc::clone(&self.semaphore);
+            let config = Arc::clone(&self.config);
+            let mut inner = self.inner.clone();
+            let start_time = Instant::now();
+
+            // Emit call permitted event
+            let concurrent_calls =
+                config.max_concurrent_calls - semaphore_for_check.available_permits();
+            let event = BulkheadEvent::CallPermitted {
+                pattern_name: config.name.clone(),
+                timestamp: Instant::now(),
+                concurrent_calls,
+            };
+            config.event_listeners.emit(&event);
+
+            #[cfg(feature = "metrics")]
+            {
+                counter!("bulkhead_calls_permitted_total", "bulkhead" => config.name.clone())
+                    .increment(1);
+                gauge!("bulkhead_concurrent_calls", "bulkhead" => config.name.clone())
+                    .set(concurrent_calls as f64);
+                histogram!("bulkhead_wait_duration_seconds", "bulkhead" => config.name.clone())
+                    .record(0.0);
+            }
+
+            return Box::pin(async move {
+                let result = inner.call(request).await;
+                drop(permit);
+                let duration = start_time.elapsed();
+
+                match &result {
+                    Ok(_) => {
+                        let event = BulkheadEvent::CallFinished {
+                            pattern_name: config.name.clone(),
+                            timestamp: Instant::now(),
+                            duration,
+                        };
+                        config.event_listeners.emit(&event);
+
+                        #[cfg(feature = "metrics")]
+                        {
+                            counter!("bulkhead_calls_finished_total", "bulkhead" => config.name.clone())
+                                .increment(1);
+                            histogram!("bulkhead_call_duration_seconds", "bulkhead" => config.name.clone())
+                                .record(duration.as_secs_f64());
+                        }
+                    }
+                    Err(_) => {
+                        let event = BulkheadEvent::CallFailed {
+                            pattern_name: config.name.clone(),
+                            timestamp: Instant::now(),
+                            duration,
+                        };
+                        config.event_listeners.emit(&event);
+
+                        #[cfg(feature = "metrics")]
+                        {
+                            counter!("bulkhead_calls_failed_total", "bulkhead" => config.name.clone())
+                                .increment(1);
+                            histogram!("bulkhead_call_duration_seconds", "bulkhead" => config.name.clone())
+                                .record(duration.as_secs_f64());
+                        }
+                    }
+                }
+
+                #[cfg(feature = "metrics")]
+                {
+                    let new_concurrent =
+                        config.max_concurrent_calls - semaphore_for_check.available_permits();
+                    gauge!("bulkhead_concurrent_calls", "bulkhead" => config.name.clone())
+                        .set(new_concurrent as f64);
+                }
+
+                result.map_err(BulkheadServiceError::Inner)
+            });
+        }
+
+        // Rejection mode: acquire permit in call
         let semaphore = Arc::clone(&self.semaphore);
         let semaphore_for_check = Arc::clone(&self.semaphore);
         let config = Arc::clone(&self.config);

--- a/crates/tower-resilience-circuitbreaker/src/circuit.rs
+++ b/crates/tower-resilience-circuitbreaker/src/circuit.rs
@@ -391,6 +391,35 @@ impl Circuit {
         }
     }
 
+    /// Read-only check of whether a call would be permitted.
+    ///
+    /// Returns `Ok(())` if a call would likely succeed, or `Err(duration)` with
+    /// the suggested wait time before retrying.
+    ///
+    /// Unlike `try_acquire`, this does not mutate state or emit events.
+    pub fn check_permitted<C>(&self, config: &CircuitBreakerConfig<C>) -> Result<(), Duration> {
+        match self.state {
+            CircuitState::Closed => Ok(()),
+            CircuitState::Open => {
+                let elapsed = self.last_state_change.elapsed();
+                if elapsed >= config.wait_duration_in_open {
+                    // Wait has elapsed; try_acquire will transition to HalfOpen
+                    Ok(())
+                } else {
+                    Err(config.wait_duration_in_open - elapsed)
+                }
+            }
+            CircuitState::HalfOpen => {
+                if self.success_count + self.failure_count < config.permitted_calls_in_half_open {
+                    Ok(())
+                } else {
+                    // Half-open slots full; wait for resolution
+                    Err(config.wait_duration_in_open)
+                }
+            }
+        }
+    }
+
     pub fn force_open<C>(&mut self, config: &CircuitBreakerConfig<C>) {
         self.transition_to(CircuitState::Open, config);
     }

--- a/crates/tower-resilience-circuitbreaker/src/config.rs
+++ b/crates/tower-resilience-circuitbreaker/src/config.rs
@@ -32,6 +32,7 @@ pub struct CircuitBreakerConfig<C> {
     pub(crate) slow_call_rate_threshold: f64,
     pub(crate) event_listeners: EventListeners<CircuitBreakerEvent>,
     pub(crate) name: String,
+    pub(crate) backpressure: bool,
 }
 
 /// Builder for configuring and constructing a circuit breaker.
@@ -81,6 +82,7 @@ pub struct CircuitBreakerConfigBuilder<C = DefaultClassifier> {
     slow_call_rate_threshold: f64,
     event_listeners: EventListeners<CircuitBreakerEvent>,
     name: String,
+    backpressure: bool,
 }
 
 impl Default for CircuitBreakerConfigBuilder<DefaultClassifier> {
@@ -108,6 +110,7 @@ impl CircuitBreakerConfigBuilder<DefaultClassifier> {
             slow_call_rate_threshold: 1.0,
             event_listeners: EventListeners::new(),
             name: String::from("<unnamed>"),
+            backpressure: false,
         }
     }
 }
@@ -204,6 +207,36 @@ impl<C> CircuitBreakerConfigBuilder<C> {
         self
     }
 
+    /// Enables backpressure mode.
+    ///
+    /// In backpressure mode, the circuit breaker checks circuit state in `poll_ready()`
+    /// rather than in `call()`. When the circuit is open, `poll_ready()` returns
+    /// `Poll::Pending` and wakes the caller after `wait_duration_in_open` elapses,
+    /// instead of returning `CircuitBreakerError::OpenCircuit`.
+    ///
+    /// This integrates with Tower's load balancing, buffer layers, and the standard
+    /// `service.ready().await` pattern.
+    ///
+    /// When backpressure mode is enabled:
+    /// - `CircuitBreakerError::OpenCircuit` is never returned
+    /// - Callers naturally wait for the circuit to transition to half-open
+    ///
+    /// Default: `false` (rejection mode)
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use tower_resilience_circuitbreaker::CircuitBreakerLayer;
+    ///
+    /// let layer = CircuitBreakerLayer::builder()
+    ///     .failure_rate_threshold(0.5)
+    ///     .backpressure()
+    ///     .build();
+    /// ```
+    pub fn backpressure(mut self) -> Self {
+        self.backpressure = true;
+        self
+    }
+
     /// Sets a custom failure classifier function.
     ///
     /// The classifier determines which results should be counted as failures
@@ -274,6 +307,7 @@ impl<C> CircuitBreakerConfigBuilder<C> {
             slow_call_rate_threshold: self.slow_call_rate_threshold,
             event_listeners: self.event_listeners,
             name: self.name,
+            backpressure: self.backpressure,
         }
     }
 
@@ -609,6 +643,7 @@ impl<C> CircuitBreakerConfigBuilder<C> {
             slow_call_rate_threshold: self.slow_call_rate_threshold,
             event_listeners: self.event_listeners,
             name: self.name,
+            backpressure: self.backpressure,
         };
 
         crate::layer::CircuitBreakerLayer::new(config)

--- a/crates/tower-resilience-circuitbreaker/src/health_integration.rs
+++ b/crates/tower-resilience-circuitbreaker/src/health_integration.rs
@@ -87,6 +87,7 @@ mod tests {
             slow_call_rate_threshold: 1.0,
             event_listeners: EventListeners::new(),
             name: "test".into(),
+            backpressure: false,
         }
     }
 

--- a/crates/tower-resilience-circuitbreaker/src/lib.rs
+++ b/crates/tower-resilience-circuitbreaker/src/lib.rs
@@ -291,6 +291,7 @@
 use crate::circuit::Circuit;
 use crate::classifier::FailureClassifier;
 use futures::future::BoxFuture;
+use futures::Future;
 #[cfg(feature = "metrics")]
 use metrics::{counter, describe_counter, describe_gauge, describe_histogram};
 use std::sync::Arc;
@@ -389,6 +390,8 @@ pub struct CircuitBreaker<S, C> {
     pub(crate) circuit: Arc<Mutex<Circuit>>,
     state_atomic: Arc<std::sync::atomic::AtomicU8>,
     pub(crate) config: Arc<CircuitBreakerConfig<C>>,
+    /// Sleep future for backpressure mode wake-ups.
+    sleep: Option<std::pin::Pin<Box<tokio::time::Sleep>>>,
 }
 
 impl<S, C> CircuitBreaker<S, C> {
@@ -402,6 +405,7 @@ impl<S, C> CircuitBreaker<S, C> {
             )))),
             state_atomic,
             config,
+            sleep: None,
         }
     }
 
@@ -450,6 +454,7 @@ impl<S, C> CircuitBreaker<S, C> {
             config: self.config,
             fallback: Arc::new(fallback),
             _phantom: std::marker::PhantomData,
+            sleep: None,
         }
     }
 
@@ -533,6 +538,7 @@ where
             circuit: Arc::clone(&self.circuit),
             state_atomic: Arc::clone(&self.state_atomic),
             config: Arc::clone(&self.config),
+            sleep: None,
         }
     }
 }
@@ -551,9 +557,53 @@ where
     type Future = BoxFuture<'static, Result<S::Response, Self::Error>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner
-            .poll_ready(cx)
-            .map_err(CircuitBreakerError::Inner)
+        // Check inner service readiness first
+        match self.inner.poll_ready(cx) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(Err(e)) => return Poll::Ready(Err(CircuitBreakerError::Inner(e))),
+            Poll::Ready(Ok(())) => {}
+        }
+
+        if !self.config.backpressure {
+            return Poll::Ready(Ok(()));
+        }
+
+        // Backpressure mode: check circuit state in poll_ready
+
+        // If we have a pending sleep, poll it first
+        if let Some(sleep) = self.sleep.as_mut() {
+            match sleep.as_mut().poll(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(()) => {
+                    self.sleep = None;
+                    // Fall through to re-check circuit state
+                }
+            }
+        }
+
+        // Try to lock the circuit mutex synchronously
+        let circuit = match self.circuit.try_lock() {
+            Ok(guard) => guard,
+            Err(_) => {
+                // Mutex contended; set a short sleep and return Pending
+                let sleep = tokio::time::sleep(std::time::Duration::from_millis(1));
+                let mut pinned = Box::pin(sleep);
+                let _ = pinned.as_mut().poll(cx);
+                self.sleep = Some(pinned);
+                return Poll::Pending;
+            }
+        };
+
+        match circuit.check_permitted(&self.config) {
+            Ok(()) => Poll::Ready(Ok(())),
+            Err(wait) => {
+                let sleep = tokio::time::sleep(wait);
+                let mut pinned = Box::pin(sleep);
+                let _ = pinned.as_mut().poll(cx);
+                self.sleep = Some(pinned);
+                Poll::Pending
+            }
+        }
     }
 
     fn call(&mut self, req: Req) -> Self::Future {
@@ -625,6 +675,8 @@ pub struct CircuitBreakerWithFallback<S, C, Req, Res, Err> {
     pub(crate) config: Arc<CircuitBreakerConfig<C>>,
     fallback: SharedFallback<Req, Res, Err>,
     _phantom: std::marker::PhantomData<(Req, Res, Err)>,
+    /// Sleep future for backpressure mode wake-ups.
+    sleep: Option<std::pin::Pin<Box<tokio::time::Sleep>>>,
 }
 
 impl<S, C, Req, Res, Err> CircuitBreakerWithFallback<S, C, Req, Res, Err> {
@@ -699,6 +751,7 @@ where
             config: Arc::clone(&self.config),
             fallback: Arc::clone(&self.fallback),
             _phantom: std::marker::PhantomData,
+            sleep: None,
         }
     }
 }
@@ -717,9 +770,48 @@ where
     type Future = BoxFuture<'static, Result<Res, Self::Error>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner
-            .poll_ready(cx)
-            .map_err(CircuitBreakerError::Inner)
+        // Check inner service readiness first
+        match self.inner.poll_ready(cx) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(Err(e)) => return Poll::Ready(Err(CircuitBreakerError::Inner(e))),
+            Poll::Ready(Ok(())) => {}
+        }
+
+        if !self.config.backpressure {
+            return Poll::Ready(Ok(()));
+        }
+
+        // Backpressure mode: check circuit state in poll_ready
+        if let Some(sleep) = self.sleep.as_mut() {
+            match sleep.as_mut().poll(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(()) => {
+                    self.sleep = None;
+                }
+            }
+        }
+
+        let circuit = match self.circuit.try_lock() {
+            Ok(guard) => guard,
+            Err(_) => {
+                let sleep = tokio::time::sleep(std::time::Duration::from_millis(1));
+                let mut pinned = Box::pin(sleep);
+                let _ = pinned.as_mut().poll(cx);
+                self.sleep = Some(pinned);
+                return Poll::Pending;
+            }
+        };
+
+        match circuit.check_permitted(&self.config) {
+            Ok(()) => Poll::Ready(Ok(())),
+            Err(wait) => {
+                let sleep = tokio::time::sleep(wait);
+                let mut pinned = Box::pin(sleep);
+                let _ = pinned.as_mut().poll(cx);
+                self.sleep = Some(pinned);
+                Poll::Pending
+            }
+        }
     }
 
     fn call(&mut self, req: Req) -> Self::Future {
@@ -808,6 +900,7 @@ mod tests {
             slow_call_rate_threshold: 1.0,
             event_listeners: EventListeners::new(),
             name: "test".into(),
+            backpressure: false,
         }
     }
 
@@ -917,6 +1010,7 @@ mod tests {
                 listeners
             },
             name: "test".into(),
+            backpressure: false,
         };
 
         let mut circuit = Circuit::new();
@@ -970,6 +1064,7 @@ mod tests {
                 listeners
             },
             name: "test".into(),
+            backpressure: false,
         };
 
         let mut circuit = Circuit::new();
@@ -1085,5 +1180,121 @@ mod tests {
             .name("my-service")
             .failure_rate_threshold(0.6)
             .build();
+    }
+
+    #[tokio::test]
+    async fn test_backpressure_allows_requests_when_closed() {
+        use tower::{Service, ServiceExt};
+
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let cc = Arc::clone(&call_count);
+
+        let service = tower::service_fn(move |req: String| {
+            let cc = Arc::clone(&cc);
+            async move {
+                cc.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok::<_, std::io::Error>(format!("Response: {}", req))
+            }
+        });
+
+        let layer = CircuitBreakerLayer::builder()
+            .failure_rate_threshold(0.5)
+            .sliding_window_size(10)
+            .minimum_number_of_calls(10)
+            .backpressure()
+            .build();
+
+        let mut service = tower::ServiceBuilder::new().layer(layer).service(service);
+
+        for i in 0..5 {
+            let result = service
+                .ready()
+                .await
+                .unwrap()
+                .call(format!("req-{}", i))
+                .await;
+            assert!(result.is_ok());
+        }
+
+        assert_eq!(call_count.load(std::sync::atomic::Ordering::SeqCst), 5);
+    }
+
+    #[tokio::test]
+    async fn test_backpressure_waits_when_open() {
+        use tower::{Service, ServiceExt};
+
+        let service =
+            tower::service_fn(|_req: String| async move { Ok::<_, String>("ok".to_string()) });
+
+        let layer = CircuitBreakerLayer::builder()
+            .failure_rate_threshold(0.5)
+            .sliding_window_size(2)
+            .minimum_number_of_calls(2)
+            .wait_duration_in_open(Duration::from_millis(100))
+            .permitted_calls_in_half_open(1)
+            .backpressure()
+            .build();
+
+        let mut service = layer.layer_fn(service);
+
+        // Record 2 failures to open the circuit
+        {
+            let mut circuit = service.circuit.lock().await;
+            circuit.record_failure(&service.config, Duration::from_millis(10));
+            circuit.record_failure(&service.config, Duration::from_millis(10));
+        }
+
+        assert_eq!(service.state().await, CircuitState::Open);
+
+        // In backpressure mode, ready() should wait until the circuit transitions
+        let start = std::time::Instant::now();
+        let result = service
+            .ready()
+            .await
+            .unwrap()
+            .call("test".to_string())
+            .await;
+        let elapsed = start.elapsed();
+
+        // Should have waited for the open duration
+        assert!(elapsed >= Duration::from_millis(90));
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_backpressure_events_still_fire() {
+        use tower::{Service, ServiceExt};
+
+        let permitted_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let rejected_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let pc = Arc::clone(&permitted_count);
+        let rc = Arc::clone(&rejected_count);
+
+        let service =
+            tower::service_fn(
+                |_req: String| async move { Ok::<_, std::io::Error>("ok".to_string()) },
+            );
+
+        let layer = CircuitBreakerLayer::builder()
+            .failure_rate_threshold(0.5)
+            .sliding_window_size(100)
+            .backpressure()
+            .on_call_permitted(move |_state| {
+                pc.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            })
+            .on_call_rejected(move || {
+                rc.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            })
+            .build();
+
+        let mut service = tower::ServiceBuilder::new().layer(layer).service(service);
+
+        for _ in 0..3 {
+            let _ = service.ready().await.unwrap().call("x".to_string()).await;
+        }
+
+        assert_eq!(permitted_count.load(std::sync::atomic::Ordering::SeqCst), 3);
+        assert_eq!(rejected_count.load(std::sync::atomic::Ordering::SeqCst), 0);
     }
 }


### PR DESCRIPTION
## Summary

- Add opt-in backpressure mode to **bulkhead** and **circuit breaker**, following the pattern from #230 (rate limiter)
- When enabled via `.backpressure()`, limits are applied in `poll_ready()` instead of `call()`, returning `Poll::Pending` rather than errors
- Integrates with Tower's load balancing, buffer layers, and `service.ready().await`

### Bulkhead
- Acquires semaphore permits in `poll_ready()` via a stored acquire future
- Permits are consumed in `call()` without re-acquiring
- `BulkheadError::BulkheadFull` and `Timeout` are never returned in this mode

### Circuit Breaker
- Adds read-only `check_permitted()` to `Circuit` for state checks without side effects
- `poll_ready()` checks circuit state and sleeps until open wait duration elapses
- `CircuitBreakerError::OpenCircuit` is never returned in this mode
- Applied to both `CircuitBreaker` and `CircuitBreakerWithFallback`

## Test plan

- [x] Bulkhead: requests within limit succeed immediately
- [x] Bulkhead: requests over limit wait and eventually succeed (never `BulkheadFull`/`Timeout`)
- [x] Bulkhead: events fire `CallPermitted` (never `CallRejected`)
- [x] Circuit breaker: requests succeed when circuit closed
- [x] Circuit breaker: requests wait when circuit open, succeed after wait duration
- [x] Circuit breaker: events still fire correctly
- [x] `cargo fmt`, `cargo clippy`, all lib/integration/doc tests pass

Closes #231, closes #232