### PR TITLE
feat(retry,fallback): add response-based predicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ use tower_resilience::ratelimiter::RateLimiterLayer;
 use tower_resilience::bulkhead::BulkheadLayer;
 
 // Retry with exponential backoff (3 attempts, 100ms base)
-let retry = RetryLayer::<(), MyError>::exponential_backoff().build();
+let retry = RetryLayer::<(), (), MyError>::exponential_backoff().build();
 
 // Circuit breaker with balanced defaults
 let breaker = CircuitBreakerLayer::standard().build();
@@ -182,7 +182,7 @@ Retry failed requests with exponential backoff and jitter:
 use tower_resilience::retry::RetryLayer;
 use std::time::Duration;
 
-let layer = RetryLayer::<(), MyError>::builder()
+let layer = RetryLayer::<(), (), MyError>::builder()
     .max_attempts(5)
     .exponential_backoff(Duration::from_millis(100))
     .on_retry(|attempt, delay| {

--- a/benches/comprehensive_benchmarks.rs
+++ b/benches/comprehensive_benchmarks.rs
@@ -309,7 +309,7 @@ fn bench_retry_exhausted(c: &mut Criterion) {
 
     c.bench_function("worst_case_retry_exhausted", |b| {
         b.to_async(&runtime).iter(|| async {
-            let layer = RetryLayer::<TestRequest, TestError>::builder()
+            let layer = RetryLayer::<TestRequest, TestResponse, TestError>::builder()
                 .max_attempts(1) // No retries
                 .fixed_backoff(Duration::from_millis(1))
                 .build();

--- a/benches/happy_path_overhead.rs
+++ b/benches/happy_path_overhead.rs
@@ -116,7 +116,7 @@ fn bench_retry(c: &mut Criterion) {
 
     c.bench_function("retry_no_retries_needed", |b| {
         b.to_async(&runtime).iter(|| async {
-            let layer = RetryLayer::<TestRequest, TestError>::builder()
+            let layer = RetryLayer::<TestRequest, TestResponse, TestError>::builder()
                 .max_attempts(3)
                 .fixed_backoff(Duration::from_millis(100))
                 .build();

--- a/crates/tower-resilience-fallback/src/config.rs
+++ b/crates/tower-resilience-fallback/src/config.rs
@@ -1,6 +1,6 @@
 //! Configuration for the fallback service.
 
-use crate::{FallbackEvent, FallbackStrategy, HandlePredicate};
+use crate::{FallbackEvent, FallbackStrategy, HandlePredicate, HandleResponsePredicate};
 use tower_resilience_core::{EventListeners, FnListener};
 
 /// Configuration for the fallback service.
@@ -8,6 +8,7 @@ pub struct FallbackConfig<Req, Res, E> {
     pub(crate) name: String,
     pub(crate) strategy: FallbackStrategy<Req, Res, E>,
     pub(crate) handle_predicate: Option<HandlePredicate<E>>,
+    pub(crate) handle_response_predicate: Option<HandleResponsePredicate<Res>>,
     pub(crate) event_listeners: EventListeners<FallbackEvent>,
 }
 
@@ -16,6 +17,7 @@ pub struct FallbackConfigBuilder<Req, Res, E> {
     name: String,
     strategy: Option<FallbackStrategy<Req, Res, E>>,
     handle_predicate: Option<HandlePredicate<E>>,
+    handle_response_predicate: Option<HandleResponsePredicate<Res>>,
     event_listeners: EventListeners<FallbackEvent>,
 }
 
@@ -32,6 +34,7 @@ impl<Req, Res, E> FallbackConfigBuilder<Req, Res, E> {
             name: "fallback".to_string(),
             strategy: None,
             handle_predicate: None,
+            handle_response_predicate: None,
             event_listeners: EventListeners::new(),
         }
     }
@@ -129,6 +132,42 @@ impl<Req, Res, E> FallbackConfigBuilder<Req, Res, E> {
         self
     }
 
+    /// Trigger fallback for successful responses matching this predicate.
+    ///
+    /// When this predicate returns `true` for a response, the fallback strategy
+    /// is applied as if the service had returned an error. This is useful when
+    /// errors are encoded inside successful responses, such as:
+    /// - JSON-RPC error codes in the response body
+    /// - HTTP 200 responses containing error payloads
+    /// - Responses indicating degraded or stale data
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_resilience_fallback::FallbackLayer;
+    ///
+    /// #[derive(Debug, Clone)]
+    /// struct MyError;
+    ///
+    /// #[derive(Clone)]
+    /// struct ApiResponse {
+    ///     is_stale: bool,
+    ///     data: String,
+    /// }
+    ///
+    /// let layer: FallbackLayer<String, ApiResponse, MyError> = FallbackLayer::builder()
+    ///     .value_fn(|| ApiResponse { is_stale: false, data: "default".to_string() })
+    ///     .handle_response(|resp: &ApiResponse| resp.is_stale)
+    ///     .build();
+    /// ```
+    pub fn handle_response<F>(mut self, predicate: F) -> Self
+    where
+        F: Fn(&Res) -> bool + Send + Sync + 'static,
+    {
+        self.handle_response_predicate = Some(std::sync::Arc::new(predicate));
+        self
+    }
+
     /// Adds an event listener.
     pub fn on_event<F>(mut self, listener: F) -> Self
     where
@@ -148,6 +187,7 @@ impl<Req, Res, E> FallbackConfigBuilder<Req, Res, E> {
             name: self.name,
             strategy: self.strategy.expect("fallback strategy must be set"),
             handle_predicate: self.handle_predicate,
+            handle_response_predicate: self.handle_response_predicate,
             event_listeners: self.event_listeners,
         };
         crate::FallbackLayer::new(config)

--- a/crates/tower-resilience-fallback/src/lib.rs
+++ b/crates/tower-resilience-fallback/src/lib.rs
@@ -219,6 +219,12 @@ where
 /// Predicate to determine if an error should trigger the fallback.
 pub type HandlePredicate<E> = Arc<dyn Fn(&E) -> bool + Send + Sync>;
 
+/// Predicate to determine if a successful response should trigger the fallback.
+///
+/// When this predicate returns `true`, the response is treated as if the service
+/// had failed, and the fallback strategy is applied.
+pub type HandleResponsePredicate<Res> = Arc<dyn Fn(&Res) -> bool + Send + Sync>;
+
 /// A Tower service that provides fallback responses when the inner service fails.
 ///
 /// See the [module-level documentation](crate) for usage examples.
@@ -284,6 +290,130 @@ where
 
             match result {
                 Ok(response) => {
+                    // Check if the response should trigger fallback
+                    let should_handle_response = config
+                        .handle_response_predicate
+                        .as_ref()
+                        .map(|p| p(&response))
+                        .unwrap_or(false);
+
+                    if should_handle_response {
+                        #[cfg(feature = "tracing")]
+                        tracing::debug!(
+                            fallback = %config.name,
+                            "Response matches predicate, applying fallback"
+                        );
+
+                        // Emit failed attempt event
+                        let event = FallbackEvent::FailedAttempt {
+                            pattern_name: config.name.clone(),
+                            timestamp: Instant::now(),
+                        };
+                        config.event_listeners.emit(&event);
+
+                        // Apply fallback strategy (only strategies that don't need an error)
+                        match &config.strategy {
+                            FallbackStrategy::Value(v) => {
+                                #[cfg(feature = "metrics")]
+                                counter!(
+                                    "fallback_calls_total",
+                                    "fallback" => config.name.clone(),
+                                    "result" => "applied",
+                                    "strategy" => "value"
+                                )
+                                .increment(1);
+
+                                let event = FallbackEvent::Applied {
+                                    pattern_name: config.name.clone(),
+                                    timestamp: Instant::now(),
+                                    strategy: "value",
+                                };
+                                config.event_listeners.emit(&event);
+
+                                return Ok(v.clone());
+                            }
+
+                            FallbackStrategy::ValueFn(f) => {
+                                let fallback_response = f();
+
+                                #[cfg(feature = "metrics")]
+                                counter!(
+                                    "fallback_calls_total",
+                                    "fallback" => config.name.clone(),
+                                    "result" => "applied",
+                                    "strategy" => "value_fn"
+                                )
+                                .increment(1);
+
+                                let event = FallbackEvent::Applied {
+                                    pattern_name: config.name.clone(),
+                                    timestamp: Instant::now(),
+                                    strategy: "value_fn",
+                                };
+                                config.event_listeners.emit(&event);
+
+                                return Ok(fallback_response);
+                            }
+
+                            FallbackStrategy::Service(backup) => {
+                                #[cfg(feature = "tracing")]
+                                tracing::debug!(fallback = %config.name, "Calling backup service (response predicate)");
+
+                                match backup(req_clone).await {
+                                    Ok(backup_response) => {
+                                        #[cfg(feature = "metrics")]
+                                        counter!(
+                                            "fallback_calls_total",
+                                            "fallback" => config.name.clone(),
+                                            "result" => "applied",
+                                            "strategy" => "service"
+                                        )
+                                        .increment(1);
+
+                                        let event = FallbackEvent::Applied {
+                                            pattern_name: config.name.clone(),
+                                            timestamp: Instant::now(),
+                                            strategy: "service",
+                                        };
+                                        config.event_listeners.emit(&event);
+
+                                        return Ok(backup_response);
+                                    }
+                                    Err(backup_error) => {
+                                        #[cfg(feature = "tracing")]
+                                        tracing::warn!(
+                                            fallback = %config.name,
+                                            "Backup service failed (response predicate)"
+                                        );
+
+                                        #[cfg(feature = "metrics")]
+                                        counter!(
+                                            "fallback_calls_total",
+                                            "fallback" => config.name.clone(),
+                                            "result" => "failed",
+                                            "strategy" => "service"
+                                        )
+                                        .increment(1);
+
+                                        let event = FallbackEvent::Failed {
+                                            pattern_name: config.name.clone(),
+                                            timestamp: Instant::now(),
+                                        };
+                                        config.event_listeners.emit(&event);
+
+                                        return Err(FallbackError::FallbackFailed(backup_error));
+                                    }
+                                }
+                            }
+
+                            // FromError, FromRequestError, Exception need an error which we
+                            // don't have — return the original response unchanged.
+                            _ => {
+                                return Ok(response);
+                            }
+                        }
+                    }
+
                     #[cfg(feature = "tracing")]
                     tracing::debug!(fallback = %config.name, "Inner service succeeded");
 

--- a/crates/tower-resilience-retry/examples/retry_example.rs
+++ b/crates/tower-resilience-retry/examples/retry_example.rs
@@ -51,7 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    let retry_layer = RetryLayer::<String, TemporaryError>::builder()
+    let retry_layer = RetryLayer::<String, String, TemporaryError>::builder()
         .max_attempts(5)
         .fixed_backoff(Duration::from_millis(100))
         .on_retry(|attempt, delay| {
@@ -85,7 +85,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    let retry_layer = RetryLayer::<String, TemporaryError>::builder()
+    let retry_layer = RetryLayer::<String, String, TemporaryError>::builder()
         .max_attempts(5)
         .backoff(
             ExponentialBackoff::new(Duration::from_millis(50))
@@ -125,7 +125,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Err::<String, _>(PermanentError)
     });
 
-    let retry_layer = RetryLayer::<String, PermanentError>::builder()
+    let retry_layer = RetryLayer::<String, String, PermanentError>::builder()
         .max_attempts(5)
         .fixed_backoff(Duration::from_millis(50))
         .retry_on(|_: &PermanentError| false) // Never retry permanent errors
@@ -153,7 +153,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    let retry_layer = RetryLayer::<String, TemporaryError>::builder()
+    let retry_layer = RetryLayer::<String, String, TemporaryError>::builder()
         .max_attempts(3)
         .fixed_backoff(Duration::from_millis(50))
         .on_retry(|attempt, _| {

--- a/crates/tower-resilience-retry/src/config.rs
+++ b/crates/tower-resilience-retry/src/config.rs
@@ -1,7 +1,7 @@
 use crate::backoff::{ExponentialBackoff, FixedInterval, IntervalFunction};
 use crate::budget::RetryBudget;
 use crate::events::RetryEvent;
-use crate::policy::{RetryPolicy, RetryPredicate};
+use crate::policy::{ResponsePredicate, RetryPolicy, RetryPredicate};
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
@@ -39,8 +39,8 @@ impl<Req> Default for MaxAttemptsSource<Req> {
 }
 
 /// Configuration for the retry middleware.
-pub struct RetryConfig<Req, E> {
-    pub(crate) policy: RetryPolicy<E>,
+pub struct RetryConfig<Req, Res, E> {
+    pub(crate) policy: RetryPolicy<Res, E>,
     pub(crate) max_attempts_source: MaxAttemptsSource<Req>,
     pub(crate) event_listeners: EventListeners<RetryEvent>,
     pub(crate) name: String,
@@ -48,23 +48,24 @@ pub struct RetryConfig<Req, E> {
 }
 
 /// Builder for [`RetryConfig`].
-pub struct RetryConfigBuilder<Req, E> {
+pub struct RetryConfigBuilder<Req, Res, E> {
     max_attempts_source: MaxAttemptsSource<Req>,
     interval_fn: Option<Arc<dyn IntervalFunction>>,
     retry_predicate: Option<RetryPredicate<E>>,
+    response_predicate: Option<ResponsePredicate<Res>>,
     event_listeners: EventListeners<RetryEvent>,
     name: String,
     budget: Option<Arc<dyn RetryBudget>>,
-    _phantom: PhantomData<Req>,
+    _phantom: PhantomData<(Req, Res)>,
 }
 
-impl<Req, E> Default for RetryConfigBuilder<Req, E> {
+impl<Req, Res, E> Default for RetryConfigBuilder<Req, Res, E> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<Req, E> RetryConfigBuilder<Req, E> {
+impl<Req, Res, E> RetryConfigBuilder<Req, Res, E> {
     /// Creates a new builder with defaults.
     ///
     /// Defaults:
@@ -77,6 +78,7 @@ impl<Req, E> RetryConfigBuilder<Req, E> {
             max_attempts_source: MaxAttemptsSource::default(),
             interval_fn: None,
             retry_predicate: None,
+            response_predicate: None,
             event_listeners: EventListeners::new(),
             name: "<unnamed>".to_string(),
             budget: None,
@@ -120,7 +122,7 @@ impl<Req, E> RetryConfigBuilder<Req, E> {
     /// #[derive(Debug, Clone)]
     /// struct MyError;
     ///
-    /// let layer = RetryLayer::<MyRequest, MyError>::builder()
+    /// let layer = RetryLayer::<MyRequest, (), MyError>::builder()
     ///     .max_attempts_fn(|req: &MyRequest| {
     ///         if req.is_idempotent { 5 } else { 1 }
     ///     })
@@ -165,6 +167,49 @@ impl<Req, E> RetryConfigBuilder<Req, E> {
         self
     }
 
+    /// Sets a predicate to determine which successful responses should be retried.
+    ///
+    /// When this predicate returns `true` for a response, the response is treated
+    /// as a retryable failure — consuming a budget token, applying backoff, and
+    /// re-sending the request.
+    ///
+    /// This is useful when errors are encoded inside successful responses, such as:
+    /// - JSON-RPC error codes in the response body
+    /// - gRPC status codes in the response
+    /// - HTTP 200 responses containing error payloads
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_resilience_retry::RetryLayer;
+    /// use std::time::Duration;
+    ///
+    /// #[derive(Clone)]
+    /// struct JsonRpcResponse {
+    ///     error_code: Option<i32>,
+    ///     // ... other fields
+    /// }
+    ///
+    /// #[derive(Debug, Clone)]
+    /// struct MyError;
+    ///
+    /// let layer = RetryLayer::<String, JsonRpcResponse, MyError>::builder()
+    ///     .max_attempts(3)
+    ///     .exponential_backoff(Duration::from_millis(100))
+    ///     .retry_on_response(|resp: &JsonRpcResponse| {
+    ///         // Retry on transient JSON-RPC errors
+    ///         matches!(resp.error_code, Some(code) if (-32099..=-32000).contains(&code))
+    ///     })
+    ///     .build();
+    /// ```
+    pub fn retry_on_response<F>(mut self, predicate: F) -> Self
+    where
+        F: Fn(&Res) -> bool + Send + Sync + 'static,
+    {
+        self.response_predicate = Some(Arc::new(predicate));
+        self
+    }
+
     /// Sets the name for this retry instance (used in events).
     pub fn name<S: Into<String>>(mut self, name: S) -> Self {
         self.name = name.into();
@@ -190,7 +235,7 @@ impl<Req, E> RetryConfigBuilder<Req, E> {
     ///     .max_tokens(100)
     ///     .build();
     ///
-    /// let layer = RetryLayer::<(), std::io::Error>::builder()
+    /// let layer = RetryLayer::<(), (), std::io::Error>::builder()
     ///     .max_attempts(5)
     ///     .exponential_backoff(Duration::from_millis(100))
     ///     .budget(budget)
@@ -216,7 +261,7 @@ impl<Req, E> RetryConfigBuilder<Req, E> {
     /// use tower_resilience_retry::RetryLayer;
     /// use std::time::Duration;
     ///
-    /// let layer = RetryLayer::<(), std::io::Error>::builder()
+    /// let layer = RetryLayer::<(), (), std::io::Error>::builder()
     ///     .max_attempts(5)
     ///     .on_budget_exhausted(|attempt| {
     ///         println!("Retry {} skipped - budget exhausted", attempt);
@@ -251,7 +296,7 @@ impl<Req, E> RetryConfigBuilder<Req, E> {
     /// use tower_resilience_retry::RetryLayer;
     /// use std::time::Duration;
     ///
-    /// let layer = RetryLayer::<(), std::io::Error>::builder()
+    /// let layer = RetryLayer::<(), (), std::io::Error>::builder()
     ///     .max_attempts(5)
     ///     .exponential_backoff(Duration::from_millis(100))
     ///     .on_retry(|attempt, delay| {
@@ -290,7 +335,7 @@ impl<Req, E> RetryConfigBuilder<Req, E> {
     /// use tower_resilience_retry::RetryLayer;
     /// use std::time::Duration;
     ///
-    /// let layer = RetryLayer::<(), std::io::Error>::builder()
+    /// let layer = RetryLayer::<(), (), std::io::Error>::builder()
     ///     .max_attempts(3)
     ///     .on_success(|attempts| {
     ///         if attempts == 1 {
@@ -333,7 +378,7 @@ impl<Req, E> RetryConfigBuilder<Req, E> {
     /// let failure_count = Arc::new(AtomicUsize::new(0));
     /// let counter = Arc::clone(&failure_count);
     ///
-    /// let layer = RetryLayer::<(), std::io::Error>::builder()
+    /// let layer = RetryLayer::<(), (), std::io::Error>::builder()
     ///     .max_attempts(3)
     ///     .on_error(move |attempts| {
     ///         let count = counter.fetch_add(1, Ordering::SeqCst);
@@ -370,7 +415,7 @@ impl<Req, E> RetryConfigBuilder<Req, E> {
     /// use std::time::Duration;
     /// use std::io::{Error, ErrorKind};
     ///
-    /// let layer = RetryLayer::<(), Error>::builder()
+    /// let layer = RetryLayer::<(), (), Error>::builder()
     ///     .max_attempts(3)
     ///     .retry_on(|err| {
     ///         // Only retry transient errors
@@ -394,7 +439,7 @@ impl<Req, E> RetryConfigBuilder<Req, E> {
     }
 
     /// Builds the retry layer.
-    pub fn build(self) -> crate::RetryLayer<Req, E> {
+    pub fn build(self) -> crate::RetryLayer<Req, Res, E> {
         let interval_fn = self
             .interval_fn
             .unwrap_or_else(|| Arc::new(ExponentialBackoff::new(Duration::from_millis(100))));
@@ -402,6 +447,9 @@ impl<Req, E> RetryConfigBuilder<Req, E> {
         let mut policy = RetryPolicy::new(interval_fn);
         if let Some(predicate) = self.retry_predicate {
             policy.retry_predicate = Some(predicate);
+        }
+        if let Some(predicate) = self.response_predicate {
+            policy.response_predicate = Some(predicate);
         }
 
         let config = RetryConfig {
@@ -423,12 +471,12 @@ mod tests {
 
     #[test]
     fn test_builder_defaults() {
-        let _layer = RetryLayer::<(), std::io::Error>::builder().build();
+        let _layer = RetryLayer::<(), (), std::io::Error>::builder().build();
     }
 
     #[test]
     fn test_builder_custom_values() {
-        let _layer = RetryLayer::<(), std::io::Error>::builder()
+        let _layer = RetryLayer::<(), (), std::io::Error>::builder()
             .max_attempts(5)
             .fixed_backoff(Duration::from_secs(2))
             .name("test-retry")
@@ -437,7 +485,7 @@ mod tests {
 
     #[test]
     fn test_event_listeners() {
-        let _layer = RetryLayer::<(), std::io::Error>::builder()
+        let _layer = RetryLayer::<(), (), std::io::Error>::builder()
             .on_retry(|_, _| {})
             .on_success(|_| {})
             .build();
@@ -450,7 +498,7 @@ mod tests {
             is_idempotent: bool,
         }
 
-        let _layer = RetryLayer::<MyRequest, std::io::Error>::builder()
+        let _layer = RetryLayer::<MyRequest, (), std::io::Error>::builder()
             .max_attempts_fn(|req: &MyRequest| if req.is_idempotent { 5 } else { 1 })
             .build();
     }
@@ -476,23 +524,23 @@ mod tests {
 
     #[test]
     fn test_preset_exponential_backoff() {
-        let _layer = RetryLayer::<(), std::io::Error>::exponential_backoff().build();
+        let _layer = RetryLayer::<(), (), std::io::Error>::exponential_backoff().build();
     }
 
     #[test]
     fn test_preset_aggressive() {
-        let _layer = RetryLayer::<(), std::io::Error>::aggressive().build();
+        let _layer = RetryLayer::<(), (), std::io::Error>::aggressive().build();
     }
 
     #[test]
     fn test_preset_conservative() {
-        let _layer = RetryLayer::<(), std::io::Error>::conservative().build();
+        let _layer = RetryLayer::<(), (), std::io::Error>::conservative().build();
     }
 
     #[test]
     fn test_preset_with_customization() {
         // Verify presets can be further customized
-        let _layer = RetryLayer::<(), std::io::Error>::exponential_backoff()
+        let _layer = RetryLayer::<(), (), std::io::Error>::exponential_backoff()
             .max_attempts(10)
             .name("custom")
             .build();

--- a/crates/tower-resilience-retry/src/layer.rs
+++ b/crates/tower-resilience-retry/src/layer.rs
@@ -20,7 +20,7 @@ use tower::Layer;
 /// # #[derive(Debug, Clone)]
 /// # struct MyError;
 /// # async fn example() {
-/// let retry_layer = RetryLayer::<String, MyError>::builder()
+/// let retry_layer = RetryLayer::<String, String, MyError>::builder()
 ///     .max_attempts(5)
 ///     .exponential_backoff(Duration::from_millis(100))
 ///     .build();
@@ -51,7 +51,7 @@ use tower::Layer;
 /// # struct MyError;
 /// # async fn example() {
 /// // Idempotent requests can retry more, non-idempotent get 1 attempt
-/// let retry_layer = RetryLayer::<MyRequest, MyError>::builder()
+/// let retry_layer = RetryLayer::<MyRequest, String, MyError>::builder()
 ///     .max_attempts_fn(|req: &MyRequest| {
 ///         if req.is_idempotent { 5 } else { 1 }
 ///     })
@@ -60,13 +60,13 @@ use tower::Layer;
 /// # }
 /// ```
 #[derive(Clone)]
-pub struct RetryLayer<Req, E> {
-    config: Arc<RetryConfig<Req, E>>,
+pub struct RetryLayer<Req, Res, E> {
+    config: Arc<RetryConfig<Req, Res, E>>,
 }
 
-impl<Req, E> RetryLayer<Req, E> {
+impl<Req, Res, E> RetryLayer<Req, Res, E> {
     /// Creates a new `RetryLayer` with the given configuration.
-    pub fn new(config: RetryConfig<Req, E>) -> Self {
+    pub fn new(config: RetryConfig<Req, Res, E>) -> Self {
         Self {
             config: Arc::new(config),
         }
@@ -82,12 +82,12 @@ impl<Req, E> RetryLayer<Req, E> {
     ///
     /// # #[derive(Debug, Clone)]
     /// # struct MyError;
-    /// let layer = RetryLayer::<(), MyError>::builder()
+    /// let layer = RetryLayer::<(), (), MyError>::builder()
     ///     .max_attempts(5)
     ///     .exponential_backoff(Duration::from_millis(100))
     ///     .build();
     /// ```
-    pub fn builder() -> crate::RetryConfigBuilder<Req, E> {
+    pub fn builder() -> crate::RetryConfigBuilder<Req, Res, E> {
         crate::RetryConfigBuilder::new()
     }
 
@@ -111,14 +111,14 @@ impl<Req, E> RetryLayer<Req, E> {
     /// # #[derive(Debug, Clone)]
     /// # struct MyError;
     /// // Use as-is
-    /// let layer = RetryLayer::<(), MyError>::exponential_backoff().build();
+    /// let layer = RetryLayer::<(), (), MyError>::exponential_backoff().build();
     ///
     /// // Or customize further
-    /// let layer = RetryLayer::<(), MyError>::exponential_backoff()
+    /// let layer = RetryLayer::<(), (), MyError>::exponential_backoff()
     ///     .max_attempts(5)  // Override default
     ///     .build();
     /// ```
-    pub fn exponential_backoff() -> crate::RetryConfigBuilder<Req, E> {
+    pub fn exponential_backoff() -> crate::RetryConfigBuilder<Req, Res, E> {
         use std::time::Duration;
         Self::builder()
             .max_attempts(3)
@@ -141,9 +141,9 @@ impl<Req, E> RetryLayer<Req, E> {
     ///
     /// # #[derive(Debug, Clone)]
     /// # struct MyError;
-    /// let layer = RetryLayer::<(), MyError>::aggressive().build();
+    /// let layer = RetryLayer::<(), (), MyError>::aggressive().build();
     /// ```
-    pub fn aggressive() -> crate::RetryConfigBuilder<Req, E> {
+    pub fn aggressive() -> crate::RetryConfigBuilder<Req, Res, E> {
         use std::time::Duration;
         Self::builder()
             .max_attempts(5)
@@ -166,9 +166,9 @@ impl<Req, E> RetryLayer<Req, E> {
     ///
     /// # #[derive(Debug, Clone)]
     /// # struct MyError;
-    /// let layer = RetryLayer::<(), MyError>::conservative().build();
+    /// let layer = RetryLayer::<(), (), MyError>::conservative().build();
     /// ```
-    pub fn conservative() -> crate::RetryConfigBuilder<Req, E> {
+    pub fn conservative() -> crate::RetryConfigBuilder<Req, Res, E> {
         use std::time::Duration;
         Self::builder()
             .max_attempts(2)
@@ -176,12 +176,8 @@ impl<Req, E> RetryLayer<Req, E> {
     }
 }
 
-impl<S, Req, E> Layer<S> for RetryLayer<Req, E>
-where
-    E: Clone,
-    Req: 'static,
-{
-    type Service = Retry<S, Req, E>;
+impl<S, Req, Res, E> Layer<S> for RetryLayer<Req, Res, E> {
+    type Service = Retry<S, Req, Res, E>;
 
     fn layer(&self, service: S) -> Self::Service {
         Retry::new(service, Arc::clone(&self.config), PhantomData)

--- a/crates/tower-resilience-retry/src/lib.rs
+++ b/crates/tower-resilience-retry/src/lib.rs
@@ -28,7 +28,7 @@
 //! # struct MyError;
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! // Create retry layer with exponential backoff
-//! let retry_layer = RetryLayer::<String, MyError>::builder()
+//! let retry_layer = RetryLayer::<String, String, MyError>::builder()
 //!     .max_attempts(5)
 //!     .exponential_backoff(Duration::from_millis(100))
 //!     .on_retry(|attempt, delay| {
@@ -65,7 +65,7 @@
 //! # struct MyError;
 //! # async fn example() {
 //! // Idempotent requests can retry more aggressively
-//! let retry_layer = RetryLayer::<MyRequest, MyError>::builder()
+//! let retry_layer = RetryLayer::<MyRequest, (), MyError>::builder()
 //!     .max_attempts_fn(|req: &MyRequest| {
 //!         if req.is_idempotent { 5 } else { 1 }
 //!     })
@@ -92,7 +92,7 @@
 //! # }
 //! # impl std::error::Error for MyError {}
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! let retry_layer = RetryLayer::<String, MyError>::builder()
+//! let retry_layer = RetryLayer::<String, String, MyError>::builder()
 //!     .max_attempts(3)
 //!     .exponential_backoff(Duration::from_millis(100))
 //!     .build();
@@ -131,7 +131,7 @@
 //! let cache = Arc::new(std::sync::RwLock::new(HashMap::new()));
 //! cache.write().unwrap().insert("key", "cached value");
 //!
-//! let retry_layer = RetryLayer::<String, MyError>::builder()
+//! let retry_layer = RetryLayer::<String, String, MyError>::builder()
 //!     .max_attempts(3)
 //!     .exponential_backoff(Duration::from_millis(50))
 //!     .build();
@@ -168,7 +168,7 @@ pub use budget::{AimdBudget, RetryBudget, RetryBudgetBuilder, TokenBucketBudget}
 pub use config::{MaxAttemptsSource, RetryConfig, RetryConfigBuilder};
 pub use events::RetryEvent;
 pub use layer::RetryLayer;
-pub use policy::{RetryPolicy, RetryPredicate};
+pub use policy::{ResponsePredicate, RetryPolicy, RetryPredicate};
 
 use futures::future::BoxFuture;
 use std::marker::PhantomData;
@@ -187,15 +187,19 @@ use tracing::{debug, info, warn};
 ///
 /// This service wraps an inner service and automatically retries requests
 /// that fail, according to the configured retry policy and backoff strategy.
-pub struct Retry<S, Req, E> {
+pub struct Retry<S, Req, Res, E> {
     inner: S,
-    config: Arc<RetryConfig<Req, E>>,
+    config: Arc<RetryConfig<Req, Res, E>>,
     _phantom: PhantomData<Req>,
 }
 
-impl<S, Req, E> Retry<S, Req, E> {
+impl<S, Req, Res, E> Retry<S, Req, Res, E> {
     /// Creates a new `Retry` service wrapping the given service.
-    pub fn new(inner: S, config: Arc<RetryConfig<Req, E>>, _phantom: PhantomData<Req>) -> Self {
+    pub fn new(
+        inner: S,
+        config: Arc<RetryConfig<Req, Res, E>>,
+        _phantom: PhantomData<Req>,
+    ) -> Self {
         #[cfg(feature = "metrics")]
         {
             describe_counter!(
@@ -217,7 +221,7 @@ impl<S, Req, E> Retry<S, Req, E> {
     }
 }
 
-impl<S, Req, E> Clone for Retry<S, Req, E>
+impl<S, Req, Res, E> Clone for Retry<S, Req, Res, E>
 where
     S: Clone,
 {
@@ -230,15 +234,15 @@ where
     }
 }
 
-impl<S, Req, E> Service<Req> for Retry<S, Req, E>
+impl<S, Req, Res, E> Service<Req> for Retry<S, Req, Res, E>
 where
-    S: Service<Req, Error = E> + Clone + Send + 'static,
+    S: Service<Req, Response = Res, Error = E> + Clone + Send + 'static,
     S::Future: Send + 'static,
     Req: Clone + Send + 'static,
+    Res: Send + 'static,
     E: Clone + Send + 'static,
-    S::Response: Send + 'static,
 {
-    type Response = S::Response;
+    type Response = Res;
     type Error = E;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
@@ -261,6 +265,73 @@ where
 
                 match result {
                     Ok(response) => {
+                        // Check if the response should be retried
+                        if config.policy.should_retry_response(&response) {
+                            // Treat as a retryable failure
+                            if attempt + 1 >= max_attempts {
+                                #[cfg(feature = "metrics")]
+                                {
+                                    counter!("retry_calls_total", "retry" => config.name.clone(), "result" => "exhausted").increment(1);
+                                }
+
+                                #[cfg(feature = "tracing")]
+                                warn!(retry = %config.name, attempts = attempt + 1, max_attempts = max_attempts, "Retry attempts exhausted (response predicate)");
+
+                                let event = RetryEvent::Error {
+                                    pattern_name: config.name.clone(),
+                                    timestamp: Instant::now(),
+                                    attempts: attempt + 1,
+                                };
+                                config.event_listeners.emit(&event);
+                                return Ok(response);
+                            }
+
+                            // Check retry budget if configured
+                            if let Some(ref budget) = config.budget {
+                                if !budget.try_withdraw() {
+                                    #[cfg(feature = "metrics")]
+                                    {
+                                        counter!("retry_calls_total", "retry" => config.name.clone(), "result" => "budget_exhausted").increment(1);
+                                    }
+
+                                    #[cfg(feature = "tracing")]
+                                    warn!(retry = %config.name, attempt = attempt + 1, "Retry budget exhausted (response predicate)");
+
+                                    let event = RetryEvent::BudgetExhausted {
+                                        pattern_name: config.name.clone(),
+                                        timestamp: Instant::now(),
+                                        attempt: attempt + 1,
+                                    };
+                                    config.event_listeners.emit(&event);
+                                    return Ok(response);
+                                }
+                            }
+
+                            // Calculate backoff and retry
+                            let delay = config.policy.next_backoff(attempt);
+
+                            #[cfg(feature = "metrics")]
+                            {
+                                counter!("retry_attempts_total", "retry" => config.name.clone())
+                                    .increment(1);
+                            }
+
+                            #[cfg(feature = "tracing")]
+                            debug!(retry = %config.name, attempt = attempt + 1, delay_ms = delay.as_millis(), "Retrying after response predicate match");
+
+                            let event = RetryEvent::Retry {
+                                pattern_name: config.name.clone(),
+                                timestamp: Instant::now(),
+                                attempt,
+                                delay,
+                            };
+                            config.event_listeners.emit(&event);
+
+                            tokio::time::sleep(delay).await;
+                            attempt += 1;
+                            continue;
+                        }
+
                         // Success - deposit to budget if configured
                         if let Some(ref budget) = config.budget {
                             budget.deposit();
@@ -408,7 +479,7 @@ mod tests {
             }
         });
 
-        let layer = RetryLayer::<String, TestError>::builder()
+        let layer = RetryLayer::<String, String, TestError>::builder()
             .max_attempts(3)
             .fixed_backoff(Duration::from_millis(10))
             .build();
@@ -444,7 +515,7 @@ mod tests {
             }
         });
 
-        let layer = RetryLayer::<String, TestError>::builder()
+        let layer = RetryLayer::<String, String, TestError>::builder()
             .max_attempts(3)
             .fixed_backoff(Duration::from_millis(10))
             .build();
@@ -476,7 +547,7 @@ mod tests {
             }
         });
 
-        let layer = RetryLayer::<String, TestError>::builder()
+        let layer = RetryLayer::<String, String, TestError>::builder()
             .max_attempts(3)
             .fixed_backoff(Duration::from_millis(10))
             .build();
@@ -507,7 +578,7 @@ mod tests {
             }
         });
 
-        let layer = RetryLayer::<String, TestError>::builder()
+        let layer = RetryLayer::<String, String, TestError>::builder()
             .max_attempts(3)
             .fixed_backoff(Duration::from_millis(10))
             .retry_on(|_: &TestError| false) // Never retry
@@ -549,7 +620,7 @@ mod tests {
             }
         });
 
-        let layer = RetryLayer::<String, TestError>::builder()
+        let layer = RetryLayer::<String, String, TestError>::builder()
             .max_attempts(3)
             .fixed_backoff(Duration::from_millis(10))
             .on_retry(move |_, _| {
@@ -596,7 +667,7 @@ mod tests {
             }
         });
 
-        let layer = RetryLayer::<String, TestError>::builder()
+        let layer = RetryLayer::<String, String, TestError>::builder()
             .max_attempts(5)
             .fixed_backoff(Duration::from_millis(1))
             .budget(budget)
@@ -660,7 +731,7 @@ mod tests {
             }
         });
 
-        let layer = RetryLayer::<Request, TestError>::builder()
+        let layer = RetryLayer::<Request, String, TestError>::builder()
             .max_attempts_fn(|req: &Request| if req.is_idempotent { 5 } else { 1 })
             .fixed_backoff(Duration::from_millis(1))
             .build();
@@ -715,7 +786,7 @@ mod tests {
             }
         });
 
-        let layer = RetryLayer::<Request, TestError>::builder()
+        let layer = RetryLayer::<Request, String, TestError>::builder()
             .max_attempts_fn(|req: &Request| req.max_retries)
             .fixed_backoff(Duration::from_millis(1))
             .build();

--- a/crates/tower-resilience-retry/src/policy.rs
+++ b/crates/tower-resilience-retry/src/policy.rs
@@ -5,22 +5,31 @@ use std::time::Duration;
 /// Determines whether an error should be retried.
 pub type RetryPredicate<E> = Arc<dyn Fn(&E) -> bool + Send + Sync>;
 
+/// Determines whether a successful response should be retried.
+///
+/// When this predicate returns `true`, the response is treated as a
+/// retryable failure — consuming a budget token, applying backoff,
+/// and re-sending the request.
+pub type ResponsePredicate<R> = Arc<dyn Fn(&R) -> bool + Send + Sync>;
+
 /// Policy for retry behavior.
 ///
 /// This policy combines the interval function (backoff strategy)
-/// and retry predicate (which errors to retry). Maximum attempts
+/// and retry predicates (which errors/responses to retry). Maximum attempts
 /// are configured separately via `MaxAttemptsSource` in the config.
-pub struct RetryPolicy<E> {
+pub struct RetryPolicy<R, E> {
     pub(crate) interval_fn: Arc<dyn IntervalFunction>,
     pub(crate) retry_predicate: Option<RetryPredicate<E>>,
+    pub(crate) response_predicate: Option<ResponsePredicate<R>>,
 }
 
-impl<E> RetryPolicy<E> {
+impl<R, E> RetryPolicy<R, E> {
     /// Creates a new retry policy.
     pub fn new(interval_fn: Arc<dyn IntervalFunction>) -> Self {
         Self {
             interval_fn,
             retry_predicate: None,
+            response_predicate: None,
         }
     }
 
@@ -42,6 +51,18 @@ impl<E> RetryPolicy<E> {
         }
     }
 
+    /// Checks if the given response should be retried.
+    ///
+    /// Returns `true` if a response predicate is set and it matches.
+    /// Returns `false` if no response predicate is set (default behavior).
+    pub fn should_retry_response(&self, response: &R) -> bool {
+        if let Some(predicate) = &self.response_predicate {
+            predicate(response)
+        } else {
+            false // Never retry responses by default
+        }
+    }
+
     /// Computes the delay before the next retry attempt.
     pub fn next_backoff(&self, attempt: usize) -> Duration {
         self.interval_fn.next_interval(attempt)
@@ -58,9 +79,15 @@ mod tests {
         retryable: bool,
     }
 
+    #[derive(Debug)]
+    struct TestResponse {
+        has_error: bool,
+    }
+
     #[test]
     fn test_retry_all_by_default() {
-        let policy = RetryPolicy::new(Arc::new(FixedInterval::new(Duration::from_secs(1))));
+        let policy: RetryPolicy<TestResponse, TestError> =
+            RetryPolicy::new(Arc::new(FixedInterval::new(Duration::from_secs(1))));
 
         let error = TestError { retryable: false };
         assert!(policy.should_retry(&error));
@@ -68,16 +95,35 @@ mod tests {
 
     #[test]
     fn test_retry_predicate() {
-        let policy = RetryPolicy::new(Arc::new(FixedInterval::new(Duration::from_secs(1))))
-            .with_retry_predicate(|e: &TestError| e.retryable);
+        let policy: RetryPolicy<TestResponse, TestError> =
+            RetryPolicy::new(Arc::new(FixedInterval::new(Duration::from_secs(1))))
+                .with_retry_predicate(|e: &TestError| e.retryable);
 
         assert!(policy.should_retry(&TestError { retryable: true }));
         assert!(!policy.should_retry(&TestError { retryable: false }));
     }
 
     #[test]
+    fn test_no_response_retry_by_default() {
+        let policy: RetryPolicy<TestResponse, TestError> =
+            RetryPolicy::new(Arc::new(FixedInterval::new(Duration::from_secs(1))));
+
+        assert!(!policy.should_retry_response(&TestResponse { has_error: true }));
+    }
+
+    #[test]
+    fn test_response_predicate() {
+        let mut policy: RetryPolicy<TestResponse, TestError> =
+            RetryPolicy::new(Arc::new(FixedInterval::new(Duration::from_secs(1))));
+        policy.response_predicate = Some(Arc::new(|r: &TestResponse| r.has_error));
+
+        assert!(policy.should_retry_response(&TestResponse { has_error: true }));
+        assert!(!policy.should_retry_response(&TestResponse { has_error: false }));
+    }
+
+    #[test]
     fn test_backoff_computation() {
-        let policy: RetryPolicy<TestError> =
+        let policy: RetryPolicy<TestResponse, TestError> =
             RetryPolicy::new(Arc::new(FixedInterval::new(Duration::from_secs(2))));
 
         assert_eq!(policy.next_backoff(0), Duration::from_secs(2));

--- a/crates/tower-resilience/src/composition.rs
+++ b/crates/tower-resilience/src/composition.rs
@@ -833,7 +833,7 @@ pub mod error_types {
     //! // impl From<BulkheadError> for ServiceError { /* ... */ }
     //! // impl From<CircuitBreakerError> for ServiceError { /* ... */ }
     //!
-    //! let retry = RetryLayer::<(), ServiceError>::builder()
+    //! let retry = RetryLayer::<(), (), ServiceError>::builder()
     //!     .max_attempts(3)
     //!     .retry_on(|err| matches!(err, ServiceError::Network(_)))
     //!     .build();
@@ -867,7 +867,7 @@ pub mod error_types {
     //! # async fn example() {
     //! # let db_service = tower::service_fn(|_req: ()| async { Ok::<_, DatabaseError>(()) });
     //! let service = ServiceBuilder::new()
-    //!     .layer(RetryLayer::<(), AppError>::builder()
+    //!     .layer(RetryLayer::<(), (), AppError>::builder()
     //!         .max_attempts(3)
     //!         .build())
     //!     .map_err(|err: DatabaseError| AppError::from(err))
@@ -907,7 +907,7 @@ pub mod advanced {
     //!     .layer(TimeLimiterLayer::builder()
     //!         .timeout_duration(Duration::from_secs(5))
     //!         .build())
-    //!     .layer(RetryLayer::<(), MyError>::builder()
+    //!     .layer(RetryLayer::<(), (), MyError>::builder()
     //!         .max_attempts(3)
     //!         .exponential_backoff(Duration::from_millis(100))
     //!         .build())
@@ -961,7 +961,7 @@ pub mod advanced {
     //! # async fn example() {
     //! # let base_service = tower::service_fn(|req: Request| async { Ok::<_, MyError>(req) });
     //! // Build layers inside-out manually
-    //! let with_retry = RetryLayer::<Request, MyError>::builder()
+    //! let with_retry = RetryLayer::<Request, Request, MyError>::builder()
     //!     .max_attempts(3)
     //!     .build()
     //!     .layer(base_service);
@@ -1005,7 +1005,7 @@ pub mod advanced {
     //!     .layer(TimeLimiterLayer::builder()
     //!         .timeout_duration(Duration::from_secs(5))
     //!         .build())
-    //!     .layer(RetryLayer::<Request, MyError>::builder()
+    //!     .layer(RetryLayer::<Request, Request, MyError>::builder()
     //!         .max_attempts(3)
     //!         .build())
     //!     .service(base_service);
@@ -1038,7 +1038,7 @@ pub mod advanced {
     //! # async fn example() {
     //! # let base_service = tower::service_fn(|_req: ()| async { Ok::<_, MyError>(()) });
     //! // Build retry layer first
-    //! let retry_layer = RetryLayer::<(), MyError>::builder()
+    //! let retry_layer = RetryLayer::<(), (), MyError>::builder()
     //!     .max_attempts(3)
     //!     .build();
     //!

--- a/crates/tower-resilience/src/lib.rs
+++ b/crates/tower-resilience/src/lib.rs
@@ -27,7 +27,7 @@
 //! # #[derive(Debug, Clone)]
 //! # struct MyError;
 //! // Retry: 3 attempts with 100ms exponential backoff
-//! let retry = RetryLayer::<(), MyError>::exponential_backoff().build();
+//! let retry = RetryLayer::<(), (), MyError>::exponential_backoff().build();
 //!
 //! // Circuit breaker: balanced defaults (50% threshold, 100 call window)
 //! let breaker = CircuitBreakerLayer::standard().build();
@@ -149,7 +149,7 @@
 //!     .sliding_window_size(100)
 //!     .build();
 //!
-//! let retry = RetryLayer::<(), MyError>::builder()
+//! let retry = RetryLayer::<(), (), MyError>::builder()
 //!     .name("api-retry")
 //!     .max_attempts(3)
 //!     .exponential_backoff(Duration::from_millis(100))

--- a/crates/tower-resilience/src/patterns.rs
+++ b/crates/tower-resilience/src/patterns.rs
@@ -564,7 +564,7 @@ pub mod retry {
     //! # struct MyError;
     //! # async fn example() {
     //! # let http_client = tower::service_fn(|_req: ()| async { Ok::<_, MyError>(()) });
-    //! let retry = RetryLayer::<(), MyError>::builder()
+    //! let retry = RetryLayer::<(), (), MyError>::builder()
     //!     .max_attempts(3)
     //!     .exponential_backoff(Duration::from_millis(100))
     //!     .retry_on(|err: &MyError| {

--- a/examples/composition_outbound.rs
+++ b/examples/composition_outbound.rs
@@ -175,7 +175,7 @@ async fn scenario_retry_timeout() {
                 .build(),
         )
         .layer(
-            RetryLayer::<Request, ClientError>::builder()
+            RetryLayer::<Request, Response, ClientError>::builder()
                 .max_attempts(5)
                 .exponential_backoff(Duration::from_millis(100))
                 .retry_on(|err| {
@@ -353,7 +353,7 @@ async fn scenario_full_stack() {
         .layer(circuit_breaker_layer)
         // 3. Retry - Handle transient failures
         .layer(
-            RetryLayer::<Request, ClientError>::builder()
+            RetryLayer::<Request, Response, ClientError>::builder()
                 .max_attempts(3)
                 .exponential_backoff(Duration::from_millis(100))
                 .retry_on(|err| matches!(err, ClientError::Network(_)))

--- a/examples/database_client.rs
+++ b/examples/database_client.rs
@@ -122,7 +122,7 @@ async fn scenario_retry_transient_errors() {
     });
 
     // Configure retry: retry transient errors with exponential backoff
-    let retry_layer = RetryLayer::<DbQuery, DbError>::builder()
+    let retry_layer = RetryLayer::<DbQuery, Vec<String>, DbError>::builder()
         .max_attempts(5)
         .exponential_backoff(Duration::from_millis(100))
         .retry_on(|err: &DbError| {
@@ -224,7 +224,7 @@ async fn scenario_full_stack() {
 
     // Combine circuit breaker with retry
     // Apply retry first (innermost layer), then circuit breaker
-    let retry_layer = RetryLayer::<DbQuery, DbError>::builder()
+    let retry_layer = RetryLayer::<DbQuery, Vec<String>, DbError>::builder()
         .max_attempts(3)
         .exponential_backoff(Duration::from_millis(50))
         .retry_on(|err| matches!(err, DbError::Transient(_)))

--- a/examples/message_queue_worker.rs
+++ b/examples/message_queue_worker.rs
@@ -175,7 +175,7 @@ async fn scenario_retry_transient() {
     });
 
     // Configure retry with exponential backoff
-    let retry_layer = RetryLayer::<Message, ProcessingError>::builder()
+    let retry_layer = RetryLayer::<Message, ProcessingResult, ProcessingError>::builder()
         .max_attempts(5)
         .exponential_backoff(Duration::from_millis(100))
         .retry_on(|err| {
@@ -337,7 +337,7 @@ async fn scenario_full_worker_stack() {
         )
         // 2. Retry - handle transient failures
         .layer(
-            RetryLayer::<Message, ProcessingError>::builder()
+            RetryLayer::<Message, ProcessingResult, ProcessingError>::builder()
                 .max_attempts(3)
                 .exponential_backoff(Duration::from_millis(100))
                 .retry_on(|err| {

--- a/examples/observability_metrics.rs
+++ b/examples/observability_metrics.rs
@@ -171,7 +171,7 @@ async fn demo_retry() {
         }
     });
 
-    let service = RetryLayer::<(), AppError>::builder()
+    let service = RetryLayer::<(), String, AppError>::builder()
         .name("api-retry") // ← Named instance for metrics
         .max_attempts(5)
         .build()

--- a/tests/circuitbreaker/integration.rs
+++ b/tests/circuitbreaker/integration.rs
@@ -452,7 +452,7 @@ async fn multi_layer_composition_with_retry() {
         .wait_duration_in_open(Duration::from_secs(10))
         .build();
 
-    let retry_layer = RetryLayer::<(), &'static str>::builder()
+    let retry_layer = RetryLayer::<(), &'static str, &'static str>::builder()
         .max_attempts(3)
         .fixed_backoff(Duration::from_millis(10))
         .build();

--- a/tests/composition_stacks/database.rs
+++ b/tests/composition_stacks/database.rs
@@ -70,7 +70,7 @@ async fn standard_database_stack_compiles() {
         .max_concurrent_calls(20) // Match connection pool size
         .build();
 
-    let retry = RetryLayer::<Query, DbError>::builder()
+    let retry = RetryLayer::<Query, QueryResult, DbError>::builder()
         .max_attempts(2)
         .retry_on(|e: &DbError| e.is_transient())
         .build();
@@ -116,7 +116,7 @@ async fn two_layer_servicebuilder_compiles() {
         .timeout_duration(Duration::from_secs(5))
         .build();
 
-    let retry = RetryLayer::<Query, DbError>::builder()
+    let retry = RetryLayer::<Query, QueryResult, DbError>::builder()
         .max_attempts(2)
         .build();
 

--- a/tests/composition_stacks/external_api.rs
+++ b/tests/composition_stacks/external_api.rs
@@ -64,7 +64,7 @@ fn mock_http_client() -> impl Service<ApiRequest, Response = ApiResponse, Error 
 /// Minimal stack: Timeout + Retry
 #[tokio::test]
 async fn minimal_stack_compiles() {
-    let retry = RetryLayer::<ApiRequest, ApiError>::builder()
+    let retry = RetryLayer::<ApiRequest, ApiResponse, ApiError>::builder()
         .max_attempts(3)
         .exponential_backoff(Duration::from_millis(100))
         .build();
@@ -93,7 +93,7 @@ async fn standard_stack_compiles() {
         .failure_rate_threshold(0.5)
         .build();
 
-    let retry = RetryLayer::<ApiRequest, ApiError>::builder()
+    let retry = RetryLayer::<ApiRequest, ApiResponse, ApiError>::builder()
         .max_attempts(3)
         .exponential_backoff(Duration::from_millis(100))
         .build();
@@ -127,7 +127,7 @@ async fn full_stack_with_fallback_compiles() {
         .wait_duration_in_open(Duration::from_secs(30))
         .build();
 
-    let retry = RetryLayer::<ApiRequest, ApiError>::builder()
+    let retry = RetryLayer::<ApiRequest, ApiResponse, ApiError>::builder()
         .max_attempts(3)
         .exponential_backoff(Duration::from_millis(100))
         .build();
@@ -170,7 +170,7 @@ async fn stack_with_hedging_compiles() {
         .failure_rate_threshold(0.5)
         .build();
 
-    let retry = RetryLayer::<ApiRequest, ApiError>::builder()
+    let retry = RetryLayer::<ApiRequest, ApiResponse, ApiError>::builder()
         .max_attempts(3)
         .exponential_backoff(Duration::from_millis(100))
         .build();

--- a/tests/composition_stacks/message_queues.rs
+++ b/tests/composition_stacks/message_queues.rs
@@ -84,7 +84,7 @@ async fn consumer_stack_compiles() {
         .wait_duration_in_open(Duration::from_secs(60))
         .build();
 
-    let retry = RetryLayer::<Message, MessageError>::builder()
+    let retry = RetryLayer::<Message, ProcessResult, MessageError>::builder()
         .max_attempts(5)
         .exponential_backoff(Duration::from_secs(1))
         .build();
@@ -106,7 +106,7 @@ async fn consumer_stack_compiles() {
 async fn producer_stack_compiles() {
     let bulkhead = BulkheadLayer::builder().max_concurrent_calls(50).build();
 
-    let retry = RetryLayer::<PublishRequest, MessageError>::builder()
+    let retry = RetryLayer::<PublishRequest, PublishResult, MessageError>::builder()
         .max_attempts(3)
         .exponential_backoff(Duration::from_millis(100))
         .build();
@@ -126,7 +126,7 @@ async fn producer_stack_compiles() {
 /// Consumer with retry predicate
 #[tokio::test]
 async fn consumer_with_retry_predicate_compiles() {
-    let retry = RetryLayer::<Message, MessageError>::builder()
+    let retry = RetryLayer::<Message, ProcessResult, MessageError>::builder()
         .max_attempts(3)
         .retry_on(|e: &MessageError| e.retriable)
         .exponential_backoff(Duration::from_secs(1))

--- a/tests/composition_stacks/microservices.rs
+++ b/tests/composition_stacks/microservices.rs
@@ -57,7 +57,7 @@ async fn standard_microservices_stack_compiles() {
         .slow_call_duration_threshold(Duration::from_secs(2))
         .build();
 
-    let retry = RetryLayer::<GrpcRequest, ServiceError>::builder()
+    let retry = RetryLayer::<GrpcRequest, GrpcResponse, ServiceError>::builder()
         .max_attempts(2)
         .fixed_backoff(Duration::from_millis(50))
         .build();
@@ -77,7 +77,7 @@ async fn standard_microservices_stack_compiles() {
 /// Microservices stack with adaptive concurrency
 #[tokio::test]
 async fn microservices_with_adaptive_concurrency_compiles() {
-    let retry = RetryLayer::<GrpcRequest, ServiceError>::builder()
+    let retry = RetryLayer::<GrpcRequest, GrpcResponse, ServiceError>::builder()
         .max_attempts(2)
         .build();
 
@@ -102,7 +102,7 @@ async fn two_layer_servicebuilder_compiles() {
         .timeout_duration(Duration::from_secs(5))
         .build();
 
-    let retry = RetryLayer::<GrpcRequest, ServiceError>::builder()
+    let retry = RetryLayer::<GrpcRequest, GrpcResponse, ServiceError>::builder()
         .max_attempts(2)
         .build();
 

--- a/tests/composition_stacks/order_verification.rs
+++ b/tests/composition_stacks/order_verification.rs
@@ -32,7 +32,7 @@ async fn total_timeout_bounds_all_retries() {
         }
     });
 
-    let retry = RetryLayer::<ApiRequest, ApiError>::builder()
+    let retry = RetryLayer::<ApiRequest, ApiResponse, ApiError>::builder()
         .max_attempts(10) // Would take 5s+ without total timeout
         .build();
 
@@ -79,7 +79,7 @@ async fn without_timeout_retries_continue() {
         }
     });
 
-    let retry = RetryLayer::<ApiRequest, ApiError>::builder()
+    let retry = RetryLayer::<ApiRequest, ApiResponse, ApiError>::builder()
         .max_attempts(5)
         .build();
 
@@ -116,7 +116,7 @@ async fn retry_recovers_from_transient_failures() {
         }
     });
 
-    let retry = RetryLayer::<ApiRequest, ApiError>::builder()
+    let retry = RetryLayer::<ApiRequest, ApiResponse, ApiError>::builder()
         .max_attempts(5)
         .build();
 

--- a/tests/property/retry.rs
+++ b/tests/property/retry.rs
@@ -52,7 +52,7 @@ proptest! {
                 }
             });
 
-            let layer = RetryLayer::<(), TestError>::builder()
+            let layer = RetryLayer::<(), (), TestError>::builder()
                 .max_attempts(max_attempts)
                 .fixed_backoff(Duration::from_millis(1))
                 .build();
@@ -103,7 +103,7 @@ proptest! {
                 }
             });
 
-            let layer = RetryLayer::<(), TestError>::builder()
+            let layer = RetryLayer::<(), (), TestError>::builder()
                 .max_attempts(max_attempts)
                 .fixed_backoff(Duration::from_millis(1))
                 .build();
@@ -143,7 +143,7 @@ proptest! {
                 }
             });
 
-            let layer = RetryLayer::<(), TestError>::builder()
+            let layer = RetryLayer::<(), (), TestError>::builder()
                 .max_attempts(max_attempts)
                 .fixed_backoff(Duration::from_millis(1))
                 .retry_on(|err: &TestError| {
@@ -199,7 +199,7 @@ proptest! {
                 }
             });
 
-            let layer = RetryLayer::<usize, TestError>::builder()
+            let layer = RetryLayer::<usize, usize, TestError>::builder()
                 .max_attempts(max_attempts)
                 .fixed_backoff(Duration::from_millis(1))
                 .build();
@@ -249,7 +249,7 @@ proptest! {
                 }
             });
 
-            let layer = RetryLayer::<(), TestError>::builder()
+            let layer = RetryLayer::<(), (), TestError>::builder()
                 .max_attempts(max_attempts)
                 .fixed_backoff(Duration::from_millis(1))
                 .build();

--- a/tests/retry/retry_config.rs
+++ b/tests/retry/retry_config.rs
@@ -551,12 +551,12 @@ async fn different_configs_different_services() {
         }
     });
 
-    let layer1 = RetryLayer::<String, TestError>::builder()
+    let layer1 = RetryLayer::<String, String, TestError>::builder()
         .max_attempts(2)
         .fixed_backoff(Duration::from_millis(10))
         .build();
 
-    let layer2 = RetryLayer::<String, TestError>::builder()
+    let layer2 = RetryLayer::<String, String, TestError>::builder()
         .max_attempts(5)
         .fixed_backoff(Duration::from_millis(10))
         .build();

--- a/tests/retry/retry_predicates.rs
+++ b/tests/retry/retry_predicates.rs
@@ -404,14 +404,14 @@ async fn different_predicates_different_services() {
     });
 
     // Service 1: retry transient errors
-    let layer1 = RetryLayer::<String, TestError>::builder()
+    let layer1 = RetryLayer::<String, String, TestError>::builder()
         .max_attempts(3)
         .fixed_backoff(std::time::Duration::from_millis(10))
         .retry_on(|e| matches!(e, TestError::Transient))
         .build();
 
     // Service 2: don't retry transient errors
-    let layer2 = RetryLayer::<String, TestError>::builder()
+    let layer2 = RetryLayer::<String, String, TestError>::builder()
         .max_attempts(3)
         .fixed_backoff(std::time::Duration::from_millis(10))
         .retry_on(|e| matches!(e, TestError::Permanent))

--- a/tests/stress/retry.rs
+++ b/tests/stress/retry.rs
@@ -21,7 +21,7 @@ async fn stress_one_million_calls_no_retries() {
         async { Ok::<_, String>(()) }
     });
 
-    let layer = RetryLayer::<u32, String>::builder()
+    let layer = RetryLayer::<u32, (), String>::builder()
         .max_attempts(3)
         .fixed_backoff(Duration::from_millis(10))
         .build();
@@ -71,7 +71,7 @@ async fn stress_high_volume_with_retries() {
         }
     });
 
-    let layer = RetryLayer::<u32, String>::builder()
+    let layer = RetryLayer::<u32, (), String>::builder()
         .max_attempts(5)
         .fixed_backoff(Duration::from_micros(100))
         .build();
@@ -120,7 +120,7 @@ async fn stress_exponential_backoff_timing() {
         }
     });
 
-    let layer = RetryLayer::<u32, String>::builder()
+    let layer = RetryLayer::<u32, (), String>::builder()
         .max_attempts(5)
         .exponential_backoff(Duration::from_millis(1))
         .build();
@@ -172,7 +172,7 @@ async fn stress_high_concurrency_with_retries() {
         }
     });
 
-    let layer = RetryLayer::<u32, String>::builder()
+    let layer = RetryLayer::<u32, (), String>::builder()
         .max_attempts(3)
         .fixed_backoff(Duration::from_millis(1))
         .build();
@@ -228,7 +228,7 @@ async fn stress_retry_exhaustion() {
         }
     });
 
-    let layer = RetryLayer::<u32, String>::builder()
+    let layer = RetryLayer::<u32, (), String>::builder()
         .max_attempts(3)
         .fixed_backoff(Duration::from_micros(100))
         .build();
@@ -284,7 +284,7 @@ async fn stress_memory_stability() {
         }
     });
 
-    let layer = RetryLayer::<u32, String>::builder()
+    let layer = RetryLayer::<u32, (), String>::builder()
         .max_attempts(5)
         .fixed_backoff(Duration::from_micros(100))
         .build();
@@ -357,7 +357,7 @@ async fn stress_custom_retry_predicate() {
     let retryable = Arc::clone(&retryable_failures);
     let permanent = Arc::clone(&permanent_failures);
 
-    let layer = RetryLayer::<u32, String>::builder()
+    let layer = RetryLayer::<u32, (), String>::builder()
         .max_attempts(3)
         .fixed_backoff(Duration::from_micros(100))
         .retry_on(move |err: &String| {


### PR DESCRIPTION
## Summary

- Add `.retry_on_response(|resp: &R| -> bool)` to `RetryLayer` builder (#236)
- Add `.handle_response(|resp: &Res| -> bool)` to `FallbackLayer` builder (#237)
- Update `RetryLayer<Req, E>` -> `RetryLayer<Req, Res, E>` to support response inspection

Enables retry and fallback for services where errors are encoded inside successful responses (JSON-RPC error codes, HTTP 200 with error payloads, gRPC status in response body, etc).

### Retry

When `retry_on_response` predicate returns `true`, the response is treated as a retryable failure with the same budget/backoff/event semantics as error-based retry.

```rust
let layer = RetryLayer::<String, JsonRpcResponse, MyError>::builder()
    .max_attempts(3)
    .exponential_backoff(Duration::from_millis(100))
    .retry_on_response(|resp: &JsonRpcResponse| {
        matches!(resp.error_code, Some(code) if (-32099..=-32000).contains(&code))
    })
    .build();
```

### Fallback

When `handle_response` predicate matches, fallback strategies that don't require an error (Value, ValueFn, Service) are applied. Error-dependent strategies gracefully return the original response.

```rust
let layer: FallbackLayer<String, ApiResponse, MyError> = FallbackLayer::builder()
    .value_fn(|| ApiResponse { is_stale: false, data: "default".to_string() })
    .handle_response(|resp: &ApiResponse| resp.is_stale)
    .build();
```

### Breaking Change

`RetryLayer` now requires 3 type parameters: `RetryLayer<Req, Res, E>` (was `RetryLayer<Req, E>`).

## Test plan

- [x] All existing tests pass with updated type signatures
- [x] New unit tests for `ResponsePredicate` and `should_retry_response`
- [x] Doc tests for `retry_on_response` and `handle_response`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo doc --no-deps --all-features` clean

Closes #236
Closes #237