### PR TITLE
feat!: add outlier detection middleware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ members = [
     "crates/tower-resilience-executor",
     "crates/tower-resilience-adaptive",
     "crates/tower-resilience-coalesce",
+    "crates/tower-resilience-outlier",
     "crates/tower-resilience",
     "examples/axum-resilient-kv-store",
     "examples/tonic-resilient-greeter",

--- a/crates/tower-resilience-core/src/error.rs
+++ b/crates/tower-resilience-core/src/error.rs
@@ -80,6 +80,9 @@
 //!         ResilienceError::RateLimited { retry_after } => {
 //!             eprintln!("Rate limited, retry after {:?}", retry_after);
 //!         }
+//!         ResilienceError::InstanceEjected { name } => {
+//!             eprintln!("Instance '{}' ejected by outlier detection", name);
+//!         }
 //!         ResilienceError::Application(app_err) => {
 //!             eprintln!("Application error: {}", app_err);
 //!         }
@@ -218,6 +221,12 @@ pub enum ResilienceError<E> {
         retry_after: Option<Duration>,
     },
 
+    /// An instance was ejected by outlier detection.
+    InstanceEjected {
+        /// The name of the ejected instance
+        name: String,
+    },
+
     /// The underlying application service returned an error.
     Application(E),
 }
@@ -241,6 +250,9 @@ where
                 Some(d) => write!(f, "Rate limited, retry after {:?}", d),
                 None => write!(f, "Rate limited"),
             },
+            ResilienceError::InstanceEjected { name } => {
+                write!(f, "Instance '{}' ejected by outlier detection", name)
+            }
             ResilienceError::Application(e) => write!(f, "Application error: {}", e),
         }
     }
@@ -271,6 +283,11 @@ impl<E> ResilienceError<E> {
     /// Returns `true` if this is a rate limiter error.
     pub fn is_rate_limited(&self) -> bool {
         matches!(self, ResilienceError::RateLimited { .. })
+    }
+
+    /// Returns `true` if this is an instance ejection error from outlier detection.
+    pub fn is_instance_ejected(&self) -> bool {
+        matches!(self, ResilienceError::InstanceEjected { .. })
     }
 
     /// Returns `true` if this is an application error.
@@ -314,6 +331,7 @@ impl<E> ResilienceError<E> {
             ResilienceError::RateLimited { retry_after } => {
                 ResilienceError::RateLimited { retry_after }
             }
+            ResilienceError::InstanceEjected { name } => ResilienceError::InstanceEjected { name },
             ResilienceError::Application(e) => ResilienceError::Application(f(e)),
         }
     }

--- a/crates/tower-resilience-outlier/Cargo.toml
+++ b/crates/tower-resilience-outlier/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "tower-resilience-outlier"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+readme = "../../README.md"
+description = "Outlier detection pattern for Tower services - fleet-aware instance ejection"
+categories = ["network-programming", "rust-patterns"]
+keywords = ["tower", "outlier", "resilience", "middleware", "ejection"]
+
+[dependencies]
+tower-resilience-core = { workspace = true }
+tower = { workspace = true }
+tower-layer = { workspace = true }
+tower-service = { workspace = true }
+tokio = { workspace = true }
+futures = { workspace = true }
+thiserror = { workspace = true }
+
+# Optional dependencies
+tracing = { workspace = true, optional = true }
+metrics = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros", "rt-multi-thread", "time"] }
+
+[features]
+default = []
+# Enable distributed tracing via the tracing crate
+tracing = ["dep:tracing"]
+# Enable metrics (ejections, recoveries, etc.)
+metrics = ["dep:metrics"]

--- a/crates/tower-resilience-outlier/src/config.rs
+++ b/crates/tower-resilience-outlier/src/config.rs
@@ -1,0 +1,135 @@
+//! Configuration and builder for the outlier detection middleware.
+
+use crate::detector::OutlierDetector;
+use crate::layer::OutlierDetectionLayer;
+use tower_resilience_core::classifier::{DefaultClassifier, FnClassifier};
+
+/// Configuration for an outlier detection instance.
+#[derive(Clone)]
+pub struct OutlierDetectionConfig<C = DefaultClassifier> {
+    /// The shared fleet-level detector.
+    pub(crate) detector: OutlierDetector,
+    /// The name of this instance within the fleet.
+    pub(crate) instance_name: String,
+    /// The failure classifier.
+    pub(crate) classifier: C,
+    /// Whether to use backpressure mode (poll_ready returns Pending).
+    pub(crate) backpressure: bool,
+}
+
+/// Builder for configuring outlier detection instances.
+pub struct OutlierDetectionConfigBuilder<C = DefaultClassifier> {
+    detector: Option<OutlierDetector>,
+    instance_name: String,
+    classifier: C,
+    backpressure: bool,
+}
+
+impl OutlierDetectionConfigBuilder<DefaultClassifier> {
+    /// Creates a new builder with default settings.
+    pub fn new() -> Self {
+        Self {
+            detector: None,
+            instance_name: "instance".to_string(),
+            classifier: DefaultClassifier,
+            backpressure: true, // Backpressure is the default
+        }
+    }
+
+    /// Sets a custom failure classifier function.
+    ///
+    /// This replaces the default classifier (which treats all `Err` results as failures)
+    /// with a custom function that can inspect both `Ok` and `Err` results.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tower_resilience_outlier::OutlierDetectionLayer;
+    /// use tower_resilience_outlier::OutlierDetector;
+    ///
+    /// let detector = OutlierDetector::new();
+    /// detector.register("backend-1", 5);
+    ///
+    /// let layer = OutlierDetectionLayer::builder()
+    ///     .detector(detector)
+    ///     .instance_name("backend-1")
+    ///     .failure_classifier(|result: &Result<String, std::io::Error>| {
+    ///         match result {
+    ///             Ok(_) => false,
+    ///             Err(e) => e.kind() == std::io::ErrorKind::ConnectionRefused,
+    ///         }
+    ///     })
+    ///     .build();
+    /// ```
+    pub fn failure_classifier<F>(self, f: F) -> OutlierDetectionConfigBuilder<FnClassifier<F>> {
+        OutlierDetectionConfigBuilder {
+            detector: self.detector,
+            instance_name: self.instance_name,
+            classifier: FnClassifier::new(f),
+            backpressure: self.backpressure,
+        }
+    }
+}
+
+impl<C> OutlierDetectionConfigBuilder<C> {
+    /// Sets the shared fleet-level detector.
+    ///
+    /// The detector coordinates ejection state across all instances
+    /// and enforces the `max_ejection_percent` limit.
+    pub fn detector(mut self, detector: OutlierDetector) -> Self {
+        self.detector = Some(detector);
+        self
+    }
+
+    /// Sets the name of this instance within the fleet.
+    ///
+    /// This name is used to identify the instance in the shared detector
+    /// and in events.
+    pub fn instance_name(mut self, name: impl Into<String>) -> Self {
+        self.instance_name = name.into();
+        self
+    }
+
+    /// Enables error-on-ejection mode instead of the default backpressure mode.
+    ///
+    /// In error mode, `call()` returns `OutlierDetectionError::Ejected` when
+    /// the instance is ejected. In backpressure mode (default), `poll_ready()`
+    /// returns `Pending`, which integrates naturally with Tower load balancers.
+    pub fn error_on_ejection(mut self) -> Self {
+        self.backpressure = false;
+        self
+    }
+
+    /// Enables backpressure mode (the default).
+    ///
+    /// In backpressure mode, `poll_ready()` returns `Pending` when the
+    /// instance is ejected, allowing Tower load balancers to route around it.
+    pub fn backpressure(mut self) -> Self {
+        self.backpressure = true;
+        self
+    }
+
+    /// Builds the `OutlierDetectionLayer`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no detector was provided.
+    pub fn build(self) -> OutlierDetectionLayer<C> {
+        let detector = self
+            .detector
+            .expect("OutlierDetectionConfigBuilder requires a detector");
+        let config = OutlierDetectionConfig {
+            detector,
+            instance_name: self.instance_name,
+            classifier: self.classifier,
+            backpressure: self.backpressure,
+        };
+        OutlierDetectionLayer::new(config)
+    }
+}
+
+impl Default for OutlierDetectionConfigBuilder<DefaultClassifier> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/tower-resilience-outlier/src/detector.rs
+++ b/crates/tower-resilience-outlier/src/detector.rs
@@ -1,0 +1,461 @@
+//! Shared fleet-level outlier detector state.
+//!
+//! The [`OutlierDetector`] coordinates ejection state across all instances
+//! in a fleet, enforcing the `max_ejection_percent` limit to prevent
+//! cascading ejections.
+
+use crate::events::OutlierDetectionEvent;
+use crate::strategy::EjectionStrategy;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tower_resilience_core::events::EventListeners;
+
+/// State for a single instance tracked by the detector.
+struct InstanceState {
+    /// Whether this instance is currently ejected.
+    ejected: bool,
+    /// When the instance was ejected (if ejected).
+    ejected_at: Option<Instant>,
+    /// How long the current ejection lasts.
+    ejection_duration: Duration,
+    /// Number of times this instance has been ejected (for exponential backoff).
+    ejection_count: usize,
+    /// The ejection strategy for this instance.
+    strategy: Arc<dyn EjectionStrategy>,
+}
+
+/// Shared fleet-level state for outlier detection.
+///
+/// The `OutlierDetector` is shared (via `Arc<Mutex<...>>` internally) across
+/// all instances in a fleet. It tracks which instances are ejected and enforces
+/// the `max_ejection_percent` limit.
+///
+/// # Examples
+///
+/// ```
+/// use tower_resilience_outlier::OutlierDetector;
+/// use std::time::Duration;
+///
+/// let detector = OutlierDetector::new()
+///     .max_ejection_percent(50)
+///     .base_ejection_duration(Duration::from_secs(30));
+///
+/// // Register instances
+/// detector.register("backend-1", 5);
+/// detector.register("backend-2", 5);
+/// ```
+#[derive(Clone)]
+pub struct OutlierDetector {
+    inner: Arc<Mutex<DetectorInner>>,
+}
+
+struct DetectorInner {
+    instances: HashMap<String, InstanceState>,
+    max_ejection_percent: f64,
+    base_ejection_duration: Duration,
+    max_ejection_duration: Option<Duration>,
+    pattern_name: String,
+    event_listeners: EventListeners<OutlierDetectionEvent>,
+}
+
+impl OutlierDetector {
+    /// Creates a new `OutlierDetector` with default settings.
+    ///
+    /// Defaults:
+    /// - `max_ejection_percent`: 50%
+    /// - `base_ejection_duration`: 30 seconds
+    /// - No max ejection duration cap
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(DetectorInner {
+                instances: HashMap::new(),
+                max_ejection_percent: 50.0,
+                base_ejection_duration: Duration::from_secs(30),
+                max_ejection_duration: None,
+                pattern_name: "outlier_detection".to_string(),
+                event_listeners: EventListeners::new(),
+            })),
+        }
+    }
+
+    /// Sets the maximum percentage of instances that can be ejected simultaneously.
+    ///
+    /// This prevents cascading ejections from taking down the entire fleet.
+    /// Value should be between 0 and 100. Default is 50.
+    pub fn max_ejection_percent(self, percent: usize) -> Self {
+        self.inner.lock().unwrap().max_ejection_percent = percent as f64;
+        self
+    }
+
+    /// Sets the base ejection duration.
+    ///
+    /// The actual ejection duration for an instance is
+    /// `base_ejection_duration * 2^(ejection_count - 1)`, providing
+    /// exponential backoff for repeatedly-ejected instances.
+    pub fn base_ejection_duration(self, duration: Duration) -> Self {
+        self.inner.lock().unwrap().base_ejection_duration = duration;
+        self
+    }
+
+    /// Sets the maximum ejection duration cap.
+    ///
+    /// Without this, exponential backoff can grow very large for
+    /// repeatedly-ejected instances. When set, the ejection duration
+    /// is capped at this value.
+    pub fn max_ejection_duration(self, duration: Duration) -> Self {
+        self.inner.lock().unwrap().max_ejection_duration = Some(duration);
+        self
+    }
+
+    /// Sets the pattern name used in events.
+    pub fn name(self, name: impl Into<String>) -> Self {
+        self.inner.lock().unwrap().pattern_name = name.into();
+        self
+    }
+
+    /// Adds an event listener for ejection events.
+    pub fn on_ejection<F>(self, f: F) -> Self
+    where
+        F: Fn(&str, usize) + Send + Sync + 'static,
+    {
+        self.inner.lock().unwrap().event_listeners.add(
+            tower_resilience_core::events::FnListener::new(move |event| {
+                if let OutlierDetectionEvent::Ejected {
+                    instance_name,
+                    consecutive_errors,
+                    ..
+                } = event
+                {
+                    f(instance_name, *consecutive_errors);
+                }
+            }),
+        );
+        self
+    }
+
+    /// Adds an event listener for recovery events.
+    pub fn on_recovery<F>(self, f: F) -> Self
+    where
+        F: Fn(&str, Duration) + Send + Sync + 'static,
+    {
+        self.inner.lock().unwrap().event_listeners.add(
+            tower_resilience_core::events::FnListener::new(move |event| {
+                if let OutlierDetectionEvent::Recovered {
+                    instance_name,
+                    ejected_duration,
+                    ..
+                } = event
+                {
+                    f(instance_name, *ejected_duration);
+                }
+            }),
+        );
+        self
+    }
+
+    /// Registers an instance with the detector using the consecutive errors strategy.
+    ///
+    /// `consecutive_error_threshold` is the number of consecutive errors
+    /// before the instance is ejected.
+    pub fn register(&self, name: impl Into<String>, consecutive_error_threshold: usize) {
+        self.register_with_strategy(
+            name,
+            Arc::new(crate::strategy::ConsecutiveErrors::new(
+                consecutive_error_threshold,
+            )),
+        );
+    }
+
+    /// Registers an instance with a custom ejection strategy.
+    pub fn register_with_strategy(
+        &self,
+        name: impl Into<String>,
+        strategy: Arc<dyn EjectionStrategy>,
+    ) {
+        let name = name.into();
+        let mut inner = self.inner.lock().unwrap();
+        inner.instances.insert(
+            name,
+            InstanceState {
+                ejected: false,
+                ejected_at: None,
+                ejection_duration: Duration::ZERO,
+                ejection_count: 0,
+                strategy,
+            },
+        );
+    }
+
+    /// Records a successful call for the named instance.
+    pub fn record_success(&self, name: &str) {
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(instance) = inner.instances.get_mut(name) {
+            instance.strategy.record_success();
+        }
+    }
+
+    /// Records a failed call for the named instance.
+    ///
+    /// Returns `true` if the instance was ejected as a result.
+    pub fn record_failure(&self, name: &str) -> bool {
+        let mut inner = self.inner.lock().unwrap();
+
+        let (should_eject, failure_count) = {
+            if let Some(instance) = inner.instances.get(name) {
+                if instance.ejected {
+                    return false;
+                }
+                let should_eject = instance.strategy.record_failure();
+                let count = instance.strategy.failure_count();
+                (should_eject, count)
+            } else {
+                return false;
+            }
+        };
+
+        if !should_eject {
+            return false;
+        }
+
+        // Check max_ejection_percent
+        let total = inner.instances.len();
+        let currently_ejected = inner.instances.values().filter(|i| i.ejected).count();
+        let ejection_percent = if total > 0 {
+            ((currently_ejected + 1) as f64 / total as f64) * 100.0
+        } else {
+            0.0
+        };
+
+        if ejection_percent > inner.max_ejection_percent {
+            let event = OutlierDetectionEvent::EjectionSkipped {
+                pattern_name: inner.pattern_name.clone(),
+                timestamp: Instant::now(),
+                instance_name: name.to_string(),
+                current_ejection_percent: (currently_ejected as f64 / total as f64) * 100.0,
+            };
+            inner.event_listeners.emit(&event);
+            return false;
+        }
+
+        // Read config values before mutable borrow of instances
+        let base_duration = inner.base_ejection_duration;
+        let max_duration = inner.max_ejection_duration;
+        let pattern_name = inner.pattern_name.clone();
+
+        // Eject the instance
+        let instance = inner.instances.get_mut(name).unwrap();
+        instance.ejection_count += 1;
+        let ejection_duration =
+            Self::compute_ejection_duration(base_duration, max_duration, instance.ejection_count);
+        instance.ejected = true;
+        instance.ejected_at = Some(Instant::now());
+        instance.ejection_duration = ejection_duration;
+
+        let event = OutlierDetectionEvent::Ejected {
+            pattern_name,
+            timestamp: Instant::now(),
+            instance_name: name.to_string(),
+            consecutive_errors: failure_count,
+            ejection_duration,
+        };
+        inner.event_listeners.emit(&event);
+
+        true
+    }
+
+    /// Checks if the named instance is currently ejected.
+    ///
+    /// Also handles automatic recovery: if the ejection duration has elapsed,
+    /// the instance is recovered and this returns `false`.
+    pub fn is_ejected(&self, name: &str) -> bool {
+        let mut inner = self.inner.lock().unwrap();
+
+        let should_recover = if let Some(instance) = inner.instances.get(name) {
+            if !instance.ejected {
+                return false;
+            }
+            if let Some(ejected_at) = instance.ejected_at {
+                ejected_at.elapsed() >= instance.ejection_duration
+            } else {
+                false
+            }
+        } else {
+            return false;
+        };
+
+        if should_recover {
+            let instance = inner.instances.get_mut(name).unwrap();
+            let ejected_duration = instance.ejected_at.map(|t| t.elapsed()).unwrap_or_default();
+            instance.ejected = false;
+            instance.ejected_at = None;
+            instance.strategy.reset();
+
+            let event = OutlierDetectionEvent::Recovered {
+                pattern_name: inner.pattern_name.clone(),
+                timestamp: Instant::now(),
+                instance_name: name.to_string(),
+                ejected_duration,
+            };
+            inner.event_listeners.emit(&event);
+
+            return false;
+        }
+
+        true
+    }
+
+    /// Returns the number of currently ejected instances.
+    pub fn ejected_count(&self) -> usize {
+        self.inner
+            .lock()
+            .unwrap()
+            .instances
+            .values()
+            .filter(|i| i.ejected)
+            .count()
+    }
+
+    /// Returns the total number of registered instances.
+    pub fn instance_count(&self) -> usize {
+        self.inner.lock().unwrap().instances.len()
+    }
+
+    /// Returns the pattern name.
+    pub fn pattern_name(&self) -> String {
+        self.inner.lock().unwrap().pattern_name.clone()
+    }
+
+    fn compute_ejection_duration(
+        base: Duration,
+        max: Option<Duration>,
+        ejection_count: usize,
+    ) -> Duration {
+        let multiplier = 2u32.saturating_pow((ejection_count - 1) as u32);
+        let duration = base.saturating_mul(multiplier);
+        match max {
+            Some(max_dur) => duration.min(max_dur),
+            None => duration,
+        }
+    }
+}
+
+impl Default for OutlierDetector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_register_and_eject() {
+        let detector = OutlierDetector::new().max_ejection_percent(100);
+        detector.register("backend-1", 3);
+
+        assert!(!detector.is_ejected("backend-1"));
+
+        // 2 failures - not ejected yet
+        assert!(!detector.record_failure("backend-1"));
+        assert!(!detector.record_failure("backend-1"));
+
+        // 3rd failure - ejected
+        assert!(detector.record_failure("backend-1"));
+        assert!(detector.is_ejected("backend-1"));
+    }
+
+    #[test]
+    fn test_success_resets_count() {
+        let detector = OutlierDetector::new().max_ejection_percent(100);
+        detector.register("backend-1", 3);
+
+        assert!(!detector.record_failure("backend-1"));
+        assert!(!detector.record_failure("backend-1"));
+        detector.record_success("backend-1");
+
+        // Need 3 more consecutive failures
+        assert!(!detector.record_failure("backend-1"));
+        assert!(!detector.record_failure("backend-1"));
+        assert!(detector.record_failure("backend-1"));
+    }
+
+    #[test]
+    fn test_max_ejection_percent() {
+        let detector = OutlierDetector::new().max_ejection_percent(50);
+
+        detector.register("backend-1", 1);
+        detector.register("backend-2", 1);
+        detector.register("backend-3", 1);
+        detector.register("backend-4", 1);
+
+        // Eject first two (50%)
+        assert!(detector.record_failure("backend-1"));
+        assert!(detector.record_failure("backend-2"));
+
+        // Third ejection would exceed 50%, should be skipped
+        assert!(!detector.record_failure("backend-3"));
+        assert!(!detector.is_ejected("backend-3"));
+
+        assert_eq!(detector.ejected_count(), 2);
+    }
+
+    #[test]
+    fn test_auto_recovery() {
+        let detector = OutlierDetector::new()
+            .base_ejection_duration(Duration::from_millis(10))
+            .max_ejection_percent(100);
+
+        detector.register("backend-1", 1);
+        assert!(detector.record_failure("backend-1"));
+        assert!(detector.is_ejected("backend-1"));
+
+        // Wait for ejection to expire
+        std::thread::sleep(Duration::from_millis(20));
+
+        // Should auto-recover
+        assert!(!detector.is_ejected("backend-1"));
+    }
+
+    #[test]
+    fn test_exponential_backoff() {
+        let dur = OutlierDetector::compute_ejection_duration(
+            Duration::from_secs(30),
+            None,
+            1, // first ejection
+        );
+        assert_eq!(dur, Duration::from_secs(30));
+
+        let dur = OutlierDetector::compute_ejection_duration(
+            Duration::from_secs(30),
+            None,
+            2, // second ejection
+        );
+        assert_eq!(dur, Duration::from_secs(60));
+
+        let dur = OutlierDetector::compute_ejection_duration(
+            Duration::from_secs(30),
+            None,
+            3, // third ejection
+        );
+        assert_eq!(dur, Duration::from_secs(120));
+    }
+
+    #[test]
+    fn test_max_ejection_duration_cap() {
+        let dur = OutlierDetector::compute_ejection_duration(
+            Duration::from_secs(30),
+            Some(Duration::from_secs(90)),
+            3, // would be 120s, capped at 90s
+        );
+        assert_eq!(dur, Duration::from_secs(90));
+    }
+
+    #[test]
+    fn test_unknown_instance() {
+        let detector = OutlierDetector::new();
+        assert!(!detector.is_ejected("unknown"));
+        assert!(!detector.record_failure("unknown"));
+    }
+}

--- a/crates/tower-resilience-outlier/src/error.rs
+++ b/crates/tower-resilience-outlier/src/error.rs
@@ -1,0 +1,92 @@
+//! Error types for the outlier detection middleware.
+
+use tower_resilience_core::ResilienceError;
+
+/// Errors specific to the outlier detection pattern.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum OutlierDetectionError {
+    /// The instance has been ejected due to outlier detection.
+    #[error("instance '{name}' is ejected by outlier detection")]
+    Ejected {
+        /// The name of the ejected instance.
+        name: String,
+    },
+}
+
+/// Service-level error that wraps both outlier detection and inner service errors.
+#[derive(Debug)]
+pub enum OutlierDetectionServiceError<E> {
+    /// An outlier detection error (e.g., instance ejected).
+    OutlierDetection(OutlierDetectionError),
+    /// An error from the inner service.
+    Inner(E),
+}
+
+impl<E> OutlierDetectionServiceError<E> {
+    /// Returns `true` if this is an outlier detection error.
+    pub fn is_outlier_detection(&self) -> bool {
+        matches!(self, OutlierDetectionServiceError::OutlierDetection(_))
+    }
+
+    /// Returns `true` if this is an inner service error.
+    pub fn is_inner(&self) -> bool {
+        matches!(self, OutlierDetectionServiceError::Inner(_))
+    }
+
+    /// Consumes self and returns the inner error, if present.
+    pub fn into_inner(self) -> Option<E> {
+        match self {
+            OutlierDetectionServiceError::Inner(e) => Some(e),
+            OutlierDetectionServiceError::OutlierDetection(_) => None,
+        }
+    }
+
+    /// Returns a reference to the outlier detection error, if present.
+    pub fn outlier_detection_error(&self) -> Option<&OutlierDetectionError> {
+        match self {
+            OutlierDetectionServiceError::OutlierDetection(e) => Some(e),
+            OutlierDetectionServiceError::Inner(_) => None,
+        }
+    }
+}
+
+impl<E: std::fmt::Display> std::fmt::Display for OutlierDetectionServiceError<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OutlierDetectionServiceError::OutlierDetection(e) => write!(f, "{}", e),
+            OutlierDetectionServiceError::Inner(e) => write!(f, "inner service error: {}", e),
+        }
+    }
+}
+
+impl<E: std::error::Error + 'static> std::error::Error for OutlierDetectionServiceError<E> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            OutlierDetectionServiceError::OutlierDetection(e) => Some(e),
+            OutlierDetectionServiceError::Inner(e) => Some(e),
+        }
+    }
+}
+
+impl<E> From<OutlierDetectionError> for OutlierDetectionServiceError<E> {
+    fn from(err: OutlierDetectionError) -> Self {
+        OutlierDetectionServiceError::OutlierDetection(err)
+    }
+}
+
+impl<E> From<OutlierDetectionError> for ResilienceError<E> {
+    fn from(err: OutlierDetectionError) -> Self {
+        match err {
+            OutlierDetectionError::Ejected { name } => ResilienceError::InstanceEjected { name },
+        }
+    }
+}
+
+impl<E> From<OutlierDetectionServiceError<E>> for ResilienceError<E> {
+    fn from(err: OutlierDetectionServiceError<E>) -> Self {
+        match err {
+            OutlierDetectionServiceError::OutlierDetection(e) => e.into(),
+            OutlierDetectionServiceError::Inner(e) => ResilienceError::Application(e),
+        }
+    }
+}

--- a/crates/tower-resilience-outlier/src/events.rs
+++ b/crates/tower-resilience-outlier/src/events.rs
@@ -1,0 +1,125 @@
+//! Events emitted by the outlier detection middleware.
+
+use std::time::{Duration, Instant};
+use tower_resilience_core::events::ResilienceEvent;
+
+/// Events emitted by the outlier detection middleware.
+#[derive(Debug, Clone)]
+pub enum OutlierDetectionEvent {
+    /// An instance has been ejected.
+    Ejected {
+        /// The pattern name.
+        pattern_name: String,
+        /// When the ejection occurred.
+        timestamp: Instant,
+        /// The name of the ejected instance.
+        instance_name: String,
+        /// The number of consecutive errors that triggered ejection.
+        consecutive_errors: usize,
+        /// How long the instance will be ejected.
+        ejection_duration: Duration,
+    },
+    /// An instance has recovered from ejection.
+    Recovered {
+        /// The pattern name.
+        pattern_name: String,
+        /// When recovery occurred.
+        timestamp: Instant,
+        /// The name of the recovered instance.
+        instance_name: String,
+        /// How long the instance was ejected.
+        ejected_duration: Duration,
+    },
+    /// A request was rejected because the instance is ejected.
+    Rejected {
+        /// The pattern name.
+        pattern_name: String,
+        /// When the rejection occurred.
+        timestamp: Instant,
+        /// The name of the ejected instance.
+        instance_name: String,
+    },
+    /// An ejection was skipped because max_ejection_percent would be exceeded.
+    EjectionSkipped {
+        /// The pattern name.
+        pattern_name: String,
+        /// When the skip occurred.
+        timestamp: Instant,
+        /// The name of the instance that would have been ejected.
+        instance_name: String,
+        /// Current ejection percentage.
+        current_ejection_percent: f64,
+    },
+}
+
+impl ResilienceEvent for OutlierDetectionEvent {
+    fn event_type(&self) -> &'static str {
+        match self {
+            OutlierDetectionEvent::Ejected { .. } => "ejected",
+            OutlierDetectionEvent::Recovered { .. } => "recovered",
+            OutlierDetectionEvent::Rejected { .. } => "rejected",
+            OutlierDetectionEvent::EjectionSkipped { .. } => "ejection_skipped",
+        }
+    }
+
+    fn timestamp(&self) -> Instant {
+        match self {
+            OutlierDetectionEvent::Ejected { timestamp, .. }
+            | OutlierDetectionEvent::Recovered { timestamp, .. }
+            | OutlierDetectionEvent::Rejected { timestamp, .. }
+            | OutlierDetectionEvent::EjectionSkipped { timestamp, .. } => *timestamp,
+        }
+    }
+
+    fn pattern_name(&self) -> &str {
+        match self {
+            OutlierDetectionEvent::Ejected { pattern_name, .. }
+            | OutlierDetectionEvent::Recovered { pattern_name, .. }
+            | OutlierDetectionEvent::Rejected { pattern_name, .. }
+            | OutlierDetectionEvent::EjectionSkipped { pattern_name, .. } => pattern_name,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_event_types() {
+        let now = Instant::now();
+
+        let ejected = OutlierDetectionEvent::Ejected {
+            pattern_name: "test".to_string(),
+            timestamp: now,
+            instance_name: "backend-1".to_string(),
+            consecutive_errors: 5,
+            ejection_duration: Duration::from_secs(30),
+        };
+        assert_eq!(ejected.event_type(), "ejected");
+        assert_eq!(ejected.pattern_name(), "test");
+
+        let recovered = OutlierDetectionEvent::Recovered {
+            pattern_name: "test".to_string(),
+            timestamp: now,
+            instance_name: "backend-1".to_string(),
+            ejected_duration: Duration::from_secs(30),
+        };
+        assert_eq!(recovered.event_type(), "recovered");
+
+        let rejected = OutlierDetectionEvent::Rejected {
+            pattern_name: "test".to_string(),
+            timestamp: now,
+            instance_name: "backend-1".to_string(),
+        };
+        assert_eq!(rejected.event_type(), "rejected");
+
+        let skipped = OutlierDetectionEvent::EjectionSkipped {
+            pattern_name: "test".to_string(),
+            timestamp: now,
+            instance_name: "backend-1".to_string(),
+            current_ejection_percent: 50.0,
+        };
+        assert_eq!(skipped.event_type(), "ejection_skipped");
+    }
+}

--- a/crates/tower-resilience-outlier/src/layer.rs
+++ b/crates/tower-resilience-outlier/src/layer.rs
@@ -1,0 +1,70 @@
+//! Tower Layer implementation for outlier detection.
+
+use crate::config::{OutlierDetectionConfig, OutlierDetectionConfigBuilder};
+use crate::service::OutlierDetectionService;
+use tower::Layer;
+use tower_resilience_core::classifier::{DefaultClassifier, FnClassifier};
+
+/// A Tower Layer that applies outlier detection behavior to an inner service.
+///
+/// Each `OutlierDetectionLayer` wraps a single backend instance. Multiple layers
+/// sharing the same [`OutlierDetector`](crate::OutlierDetector) coordinate to
+/// provide fleet-aware ejection.
+///
+/// # Examples
+///
+/// ```rust
+/// use tower_resilience_outlier::{OutlierDetectionLayer, OutlierDetector};
+/// use tower::{ServiceBuilder, service_fn};
+///
+/// let detector = OutlierDetector::new()
+///     .max_ejection_percent(50);
+///
+/// detector.register("backend-1", 5);
+///
+/// let layer = OutlierDetectionLayer::builder()
+///     .detector(detector)
+///     .instance_name("backend-1")
+///     .build();
+///
+/// let service = ServiceBuilder::new()
+///     .layer(layer)
+///     .service(service_fn(|req: String| async move { Ok::<_, std::io::Error>(req) }));
+/// ```
+#[derive(Clone)]
+pub struct OutlierDetectionLayer<C = DefaultClassifier> {
+    config: OutlierDetectionConfig<C>,
+}
+
+impl<C> OutlierDetectionLayer<C> {
+    /// Creates a new `OutlierDetectionLayer` from the given configuration.
+    pub(crate) fn new(config: OutlierDetectionConfig<C>) -> Self {
+        Self { config }
+    }
+}
+
+impl OutlierDetectionLayer<DefaultClassifier> {
+    /// Creates a new builder for configuring an outlier detection layer.
+    pub fn builder() -> OutlierDetectionConfigBuilder<DefaultClassifier> {
+        OutlierDetectionConfigBuilder::new()
+    }
+}
+
+impl<S> Layer<S> for OutlierDetectionLayer<DefaultClassifier> {
+    type Service = OutlierDetectionService<S, DefaultClassifier>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        OutlierDetectionService::new(service, self.config.clone())
+    }
+}
+
+impl<S, F> Layer<S> for OutlierDetectionLayer<FnClassifier<F>>
+where
+    F: Clone,
+{
+    type Service = OutlierDetectionService<S, FnClassifier<F>>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        OutlierDetectionService::new(service, self.config.clone())
+    }
+}

--- a/crates/tower-resilience-outlier/src/lib.rs
+++ b/crates/tower-resilience-outlier/src/lib.rs
@@ -1,0 +1,77 @@
+//! Outlier detection middleware for Tower services.
+//!
+//! Outlier detection tracks per-instance health on live traffic and ejects
+//! unhealthy instances from a fleet. This is complementary to circuit breaker:
+//!
+//! | | Circuit Breaker | Outlier Detection |
+//! |---|---|---|
+//! | Trigger | Failure *rate* over sliding window | *Consecutive* errors |
+//! | Scope | Per-service, isolated | Fleet-aware (`max_ejection_percent`) |
+//! | Detection speed | Needs `minimum_calls` before evaluating | Catches hard-down immediately |
+//! | Recovery | Half-open state with probe calls | Time-based automatic recovery |
+//!
+//! # Quick Start
+//!
+//! ```rust
+//! use tower_resilience_outlier::{OutlierDetectionLayer, OutlierDetector};
+//! use tower::{ServiceBuilder, service_fn};
+//! use std::time::Duration;
+//!
+//! // Create a shared detector for the fleet
+//! let detector = OutlierDetector::new()
+//!     .max_ejection_percent(50)
+//!     .base_ejection_duration(Duration::from_secs(30));
+//!
+//! // Register instances
+//! detector.register("backend-1", 5);  // eject after 5 consecutive errors
+//! detector.register("backend-2", 5);
+//!
+//! // Create per-instance layers sharing the same detector
+//! let layer1 = OutlierDetectionLayer::builder()
+//!     .detector(detector.clone())
+//!     .instance_name("backend-1")
+//!     .build();
+//!
+//! let layer2 = OutlierDetectionLayer::builder()
+//!     .detector(detector.clone())
+//!     .instance_name("backend-2")
+//!     .build();
+//!
+//! // Apply to services
+//! let svc1 = ServiceBuilder::new()
+//!     .layer(layer1)
+//!     .service(service_fn(|req: String| async move { Ok::<_, std::io::Error>(req) }));
+//! ```
+//!
+//! # Backpressure vs Error Mode
+//!
+//! By default, ejected instances return `Pending` from `poll_ready()`, which
+//! causes Tower load balancers to route around them. For cases where you want
+//! an explicit error, use `.error_on_ejection()`:
+//!
+//! ```rust
+//! # use tower_resilience_outlier::{OutlierDetectionLayer, OutlierDetector};
+//! # let detector = OutlierDetector::new();
+//! # detector.register("backend-1", 5);
+//! let layer = OutlierDetectionLayer::builder()
+//!     .detector(detector)
+//!     .instance_name("backend-1")
+//!     .error_on_ejection()
+//!     .build();
+//! ```
+
+pub mod config;
+pub mod detector;
+pub mod error;
+pub mod events;
+pub mod layer;
+pub mod service;
+pub mod strategy;
+
+pub use config::{OutlierDetectionConfig, OutlierDetectionConfigBuilder};
+pub use detector::OutlierDetector;
+pub use error::{OutlierDetectionError, OutlierDetectionServiceError};
+pub use events::OutlierDetectionEvent;
+pub use layer::OutlierDetectionLayer;
+pub use service::OutlierDetectionService;
+pub use strategy::{ConsecutiveErrors, EjectionStrategy};

--- a/crates/tower-resilience-outlier/src/service.rs
+++ b/crates/tower-resilience-outlier/src/service.rs
@@ -1,0 +1,188 @@
+//! Tower Service implementation for outlier detection.
+
+use crate::config::OutlierDetectionConfig;
+use crate::error::{OutlierDetectionError, OutlierDetectionServiceError};
+use futures::future::BoxFuture;
+use std::task::{Context, Poll};
+use tower::Service;
+use tower_resilience_core::classifier::FailureClassifier;
+
+/// A Tower Service that applies outlier detection to an inner service.
+///
+/// This wraps a single backend instance. The shared
+/// [`OutlierDetector`](crate::OutlierDetector) coordinates ejection state
+/// across all instances.
+///
+/// # Backpressure vs Error Mode
+///
+/// - **Backpressure (default)**: `poll_ready()` returns `Pending` when ejected,
+///   causing Tower load balancers to route around this instance.
+/// - **Error mode**: `call()` returns `OutlierDetectionError::Ejected`.
+pub struct OutlierDetectionService<S, C> {
+    inner: S,
+    config: OutlierDetectionConfig<C>,
+}
+
+impl<S, C> OutlierDetectionService<S, C> {
+    /// Creates a new `OutlierDetectionService`.
+    pub(crate) fn new(inner: S, config: OutlierDetectionConfig<C>) -> Self {
+        Self { inner, config }
+    }
+
+    /// Returns the name of this instance.
+    pub fn instance_name(&self) -> &str {
+        &self.config.instance_name
+    }
+
+    /// Returns `true` if this instance is currently ejected.
+    pub fn is_ejected(&self) -> bool {
+        self.config.detector.is_ejected(&self.config.instance_name)
+    }
+}
+
+impl<S: Clone, C: Clone> Clone for OutlierDetectionService<S, C> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            config: self.config.clone(),
+        }
+    }
+}
+
+impl<S, C, Request> Service<Request> for OutlierDetectionService<S, C>
+where
+    S: Service<Request> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Response: Send + 'static,
+    S::Error: Send + 'static,
+    C: FailureClassifier<S::Response, S::Error> + Clone + Send + 'static,
+    Request: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = OutlierDetectionServiceError<S::Error>;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // In backpressure mode, return Pending when ejected
+        if self.config.backpressure && self.config.detector.is_ejected(&self.config.instance_name) {
+            // We need to register a waker. Since recovery is timer-based,
+            // we'll wake on the next poll cycle. The load balancer will
+            // try other backends in the meantime.
+            cx.waker().wake_by_ref();
+            return Poll::Pending;
+        }
+
+        // Check inner service readiness
+        match self.inner.poll_ready(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(e)) => Poll::Ready(Err(OutlierDetectionServiceError::Inner(e))),
+            Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
+        }
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let instance_name = self.config.instance_name.clone();
+        let detector = self.config.detector.clone();
+        let classifier = self.config.classifier.clone();
+        let backpressure = self.config.backpressure;
+
+        // In error mode, check ejection in call()
+        if !backpressure && detector.is_ejected(&instance_name) {
+            return Box::pin(async move {
+                Err(OutlierDetectionServiceError::OutlierDetection(
+                    OutlierDetectionError::Ejected {
+                        name: instance_name,
+                    },
+                ))
+            });
+        }
+
+        let mut inner = self.inner.clone();
+        // Swap so the clone becomes the "pending" one
+        std::mem::swap(&mut self.inner, &mut inner);
+
+        Box::pin(async move {
+            let result = inner.call(request).await;
+
+            // Classify the result
+            let is_failure = classifier.classify(&result);
+
+            if is_failure {
+                detector.record_failure(&instance_name);
+            } else {
+                detector.record_success(&instance_name);
+            }
+
+            result.map_err(OutlierDetectionServiceError::Inner)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::OutlierDetector;
+    use tower::ServiceExt;
+
+    async fn make_service(
+        detector: OutlierDetector,
+        name: &str,
+        backpressure: bool,
+    ) -> OutlierDetectionService<
+        tower::util::BoxCloneService<String, String, std::io::Error>,
+        tower_resilience_core::classifier::DefaultClassifier,
+    > {
+        let svc = tower::service_fn(|req: String| async move { Ok::<_, std::io::Error>(req) });
+        let boxed = tower::util::BoxCloneService::new(svc);
+        let mut builder = crate::OutlierDetectionLayer::builder()
+            .detector(detector)
+            .instance_name(name);
+        if !backpressure {
+            builder = builder.error_on_ejection();
+        }
+        let layer = builder.build();
+        tower::Layer::layer(&layer, boxed)
+    }
+
+    #[tokio::test]
+    async fn test_healthy_instance_passes_through() {
+        let detector = OutlierDetector::new();
+        detector.register("backend-1", 5);
+
+        let mut svc = make_service(detector, "backend-1", false).await;
+        let resp = svc.ready().await.unwrap().call("hello".to_string()).await;
+        assert!(resp.is_ok());
+        assert_eq!(resp.unwrap(), "hello");
+    }
+
+    #[tokio::test]
+    async fn test_error_mode_rejects_ejected() {
+        let detector = OutlierDetector::new().max_ejection_percent(100);
+        detector.register("backend-1", 1);
+
+        // Create a failing service to trigger ejection
+        let fail_svc = tower::service_fn(|_req: String| async {
+            Err::<String, std::io::Error>(std::io::Error::new(
+                std::io::ErrorKind::ConnectionRefused,
+                "down",
+            ))
+        });
+        let boxed = tower::util::BoxCloneService::new(fail_svc);
+        let layer = crate::OutlierDetectionLayer::builder()
+            .detector(detector.clone())
+            .instance_name("backend-1")
+            .error_on_ejection()
+            .build();
+        let mut svc = tower::Layer::layer(&layer, boxed);
+
+        // First call fails (inner error) and triggers ejection
+        let resp = svc.ready().await.unwrap().call("hello".to_string()).await;
+        assert!(resp.is_err());
+        assert!(resp.unwrap_err().is_inner());
+
+        // Second call should be rejected by outlier detection
+        let resp = svc.ready().await.unwrap().call("hello".to_string()).await;
+        assert!(resp.is_err());
+        assert!(resp.unwrap_err().is_outlier_detection());
+    }
+}

--- a/crates/tower-resilience-outlier/src/strategy.rs
+++ b/crates/tower-resilience-outlier/src/strategy.rs
@@ -1,0 +1,145 @@
+//! Ejection strategies for outlier detection.
+//!
+//! Strategies determine when an instance should be ejected based on
+//! observed failures. The [`EjectionStrategy`] trait defines the interface,
+//! and [`ConsecutiveErrors`] provides the simplest and most common strategy.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Trait for ejection decision strategies.
+///
+/// Implementations track per-instance failure patterns and decide when
+/// an instance should be ejected. Recovery is handled separately by the
+/// [`OutlierDetector`](crate::detector::OutlierDetector) via timers.
+pub trait EjectionStrategy: Send + Sync {
+    /// Record a successful call. Resets failure tracking.
+    fn record_success(&self);
+
+    /// Record a failed call. Returns `true` if the instance should be ejected.
+    fn record_failure(&self) -> bool;
+
+    /// Reset the strategy state (called after successful recovery probe).
+    fn reset(&self);
+
+    /// Returns the current failure count for observability.
+    fn failure_count(&self) -> usize;
+}
+
+/// Ejects an instance after N consecutive errors.
+///
+/// The simplest and most universally useful strategy. When an instance
+/// produces N errors in a row without any successes, it is marked for
+/// ejection. A single success resets the counter.
+///
+/// # Examples
+///
+/// ```
+/// use tower_resilience_outlier::strategy::{ConsecutiveErrors, EjectionStrategy};
+///
+/// let strategy = ConsecutiveErrors::new(3);
+///
+/// // Two failures - not yet ejected
+/// assert!(!strategy.record_failure());
+/// assert!(!strategy.record_failure());
+///
+/// // Third failure triggers ejection
+/// assert!(strategy.record_failure());
+///
+/// // A success resets the counter
+/// strategy.record_success();
+/// assert!(!strategy.record_failure());
+/// ```
+pub struct ConsecutiveErrors {
+    threshold: usize,
+    count: AtomicUsize,
+}
+
+impl ConsecutiveErrors {
+    /// Creates a new `ConsecutiveErrors` strategy with the given threshold.
+    ///
+    /// The instance will be ejected after `threshold` consecutive errors.
+    pub fn new(threshold: usize) -> Self {
+        Self {
+            threshold,
+            count: AtomicUsize::new(0),
+        }
+    }
+
+    /// Returns the configured threshold.
+    pub fn threshold(&self) -> usize {
+        self.threshold
+    }
+
+    /// Returns the current consecutive error count.
+    pub fn current_count(&self) -> usize {
+        self.count.load(Ordering::Relaxed)
+    }
+}
+
+impl EjectionStrategy for ConsecutiveErrors {
+    fn record_success(&self) {
+        self.count.store(0, Ordering::Relaxed);
+    }
+
+    fn record_failure(&self) -> bool {
+        let prev = self.count.fetch_add(1, Ordering::Relaxed);
+        prev + 1 >= self.threshold
+    }
+
+    fn reset(&self) {
+        self.count.store(0, Ordering::Relaxed);
+    }
+
+    fn failure_count(&self) -> usize {
+        self.count.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn consecutive_errors_threshold() {
+        let strategy = ConsecutiveErrors::new(3);
+
+        assert!(!strategy.record_failure());
+        assert!(!strategy.record_failure());
+        assert!(strategy.record_failure());
+        // Continues returning true after threshold
+        assert!(strategy.record_failure());
+    }
+
+    #[test]
+    fn consecutive_errors_reset_on_success() {
+        let strategy = ConsecutiveErrors::new(3);
+
+        assert!(!strategy.record_failure());
+        assert!(!strategy.record_failure());
+        strategy.record_success();
+        assert_eq!(strategy.current_count(), 0);
+
+        // Need 3 more consecutive failures
+        assert!(!strategy.record_failure());
+        assert!(!strategy.record_failure());
+        assert!(strategy.record_failure());
+    }
+
+    #[test]
+    fn consecutive_errors_reset() {
+        let strategy = ConsecutiveErrors::new(2);
+
+        assert!(!strategy.record_failure());
+        assert!(strategy.record_failure());
+
+        strategy.reset();
+        assert_eq!(strategy.current_count(), 0);
+        assert!(!strategy.record_failure());
+    }
+
+    #[test]
+    fn consecutive_errors_threshold_of_one() {
+        let strategy = ConsecutiveErrors::new(1);
+        assert!(strategy.record_failure());
+    }
+}

--- a/crates/tower-resilience/Cargo.toml
+++ b/crates/tower-resilience/Cargo.toml
@@ -29,6 +29,7 @@ tower-resilience-hedge = { version = "0.8.0", path = "../tower-resilience-hedge"
 tower-resilience-executor = { version = "0.8.0", path = "../tower-resilience-executor", optional = true }
 tower-resilience-adaptive = { version = "0.8.0", path = "../tower-resilience-adaptive", optional = true }
 tower-resilience-coalesce = { version = "0.8.0", path = "../tower-resilience-coalesce", optional = true }
+tower-resilience-outlier = { version = "0.8.0", path = "../tower-resilience-outlier", optional = true }
 
 [features]
 default = []
@@ -60,9 +61,11 @@ executor = ["dep:tower-resilience-executor"]
 adaptive = ["dep:tower-resilience-adaptive"]
 # Coalesce: deduplicate concurrent identical requests (singleflight)
 coalesce = ["dep:tower-resilience-coalesce"]
+# Outlier detection: fleet-aware instance ejection based on health tracking
+outlier = ["dep:tower-resilience-outlier"]
 
 # Enable all patterns at once
-full = ["circuitbreaker", "bulkhead", "timelimiter", "cache", "retry", "ratelimiter", "reconnect", "healthcheck", "fallback", "hedge", "executor", "adaptive", "coalesce"]
+full = ["circuitbreaker", "bulkhead", "timelimiter", "cache", "retry", "ratelimiter", "reconnect", "healthcheck", "fallback", "hedge", "executor", "adaptive", "coalesce", "outlier"]
 
 # Integration: health checks can proactively open/close circuit breakers
 health-circuitbreaker = [

--- a/crates/tower-resilience/src/lib.rs
+++ b/crates/tower-resilience/src/lib.rs
@@ -235,6 +235,9 @@
 //!         ResilienceError::RateLimited { retry_after } => {
 //!             eprintln!("Rate limited, retry after {:?}", retry_after);
 //!         }
+//!         ResilienceError::InstanceEjected { name } => {
+//!             eprintln!("Instance '{}' ejected by outlier detection", name);
+//!         }
 //!         ResilienceError::Application(app_err) => {
 //!             eprintln!("Application error: {}", app_err);
 //!         }
@@ -318,3 +321,6 @@ pub use tower_resilience_adaptive as adaptive;
 
 #[cfg(feature = "coalesce")]
 pub use tower_resilience_coalesce as coalesce;
+
+#[cfg(feature = "outlier")]
+pub use tower_resilience_outlier as outlier;


### PR DESCRIPTION
## Summary

Adds fleet-aware outlier detection as a new resilience pattern (#238). Tracks per-instance health on live traffic and ejects unhealthy instances, complementary to circuit breaker.

- **New crate**: `tower-resilience-outlier` with `ConsecutiveErrors` ejection strategy
- **Shared `OutlierDetector`**: coordinates fleet state, enforces `max_ejection_percent`
- **Backpressure mode** (default): `poll_ready` returns `Pending` for ejected instances, integrating naturally with Tower load balancers
- **Error mode** (opt-in): `call` returns `OutlierDetectionError::Ejected`
- **`EjectionStrategy` trait**: extensible for future strategies (success rate, failure percentage)
- **Exponential backoff recovery**: `base_ejection_duration * 2^(ejection_count - 1)` with optional cap
- **`FailureClassifier` from core**: custom response-based failure detection via builder
- **New `ResilienceError::InstanceEjected` variant**: distinct from `CircuitOpen` for clear pattern matching
- Feature-gated in umbrella crate as `outlier`

Closes #238

## Test plan

- [x] 14 unit tests + 6 doc tests pass
- [x] `cargo clippy --all-targets --all-features` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Full workspace tests pass