### PR TITLE
docs: add outlier detection to all documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Resilience patterns for [Tower](https://docs.rs/tower) services, inspired by [Re
 - **Executor** - Delegates request processing to dedicated executors for parallelism
 - **Adaptive Concurrency** - Dynamic concurrency limiting using AIMD or Vegas algorithms
 - **Coalesce** - Deduplicates concurrent identical requests (singleflight pattern)
+- **Outlier Detection** - Fleet-aware instance ejection based on consecutive error tracking
 - **Chaos** - Inject failures and latency for testing resilience (development/testing only)
 
 ## Quick Start
@@ -458,6 +459,40 @@ Use cases:
 - **Load shedding**: Automatically reduces load when backends struggle
 
 **Full examples:** [adaptive.rs](examples/adaptive.rs)
+
+### Outlier Detection
+
+Fleet-aware instance ejection that tracks per-instance health and routes around unhealthy backends:
+
+```rust
+use tower_resilience::outlier::{OutlierDetectionLayer, OutlierDetector};
+use tower::{ServiceBuilder, service_fn};
+use std::time::Duration;
+
+// Shared detector coordinates ejection across all instances
+let detector = OutlierDetector::new()
+    .max_ejection_percent(50)
+    .base_ejection_duration(Duration::from_secs(30));
+
+// Register instances (eject after 5 consecutive errors)
+detector.register("backend-1", 5);
+detector.register("backend-2", 5);
+
+// Per-instance layers share the detector
+let layer = OutlierDetectionLayer::builder()
+    .detector(detector.clone())
+    .instance_name("backend-1")
+    .build();
+
+let service = ServiceBuilder::new()
+    .layer(layer)
+    .service(service_fn(|req: String| async move { Ok::<_, std::io::Error>(req) }));
+```
+
+Key features:
+- **Backpressure mode** (default): `poll_ready` returns `Pending` for ejected instances, integrating naturally with Tower load balancers
+- **Fleet protection**: `max_ejection_percent` prevents cascading ejections
+- **Exponential backoff**: Repeatedly-ejected instances stay out longer
 
 ### Chaos (Testing Only)
 

--- a/crates/tower-resilience/src/composition.rs
+++ b/crates/tower-resilience/src/composition.rs
@@ -90,6 +90,7 @@ pub mod selection {
     //! | **Hedge** | Reduce tail latency | Idempotent reads, P99 matters | Expensive operations |
     //! | **Cache** | Reduce load, improve latency | High read:write ratio | Frequently changing data |
     //! | **Adaptive** | Auto-tune concurrency | Unknown optimal limits | Known fixed capacity |
+    //! | **Outlier** | Eject unhealthy instances | Fleet of backends, hard failures | Single backend |
     //!
     //! ## Decision Flowchart
     //!
@@ -105,6 +106,8 @@ pub mod selection {
     //! │   ├─► Can hang indefinitely? ───────────► Add TimeLimiter
     //! │   │
     //! │   ├─► Can be completely down? ──────────► Add CircuitBreaker
+    //! │   │
+    //! │   ├─► Fleet of backends? ─────────────► Add OutlierDetection
     //! │   │
     //! │   ├─► Has rate limits? ─────────────────► Add RateLimiter (client-side)
     //! │   │

--- a/crates/tower-resilience/src/lib.rs
+++ b/crates/tower-resilience/src/lib.rs
@@ -92,6 +92,7 @@
 //! - **[Executor]** - Delegates request processing to dedicated executors
 //! - **[Adaptive]** - Dynamic concurrency limiting using AIMD or Vegas algorithms
 //! - **[Coalesce]** - Deduplicates concurrent identical requests (singleflight)
+//! - **[Outlier Detection]** - Fleet-aware instance ejection based on health tracking
 //!
 //! [Circuit Breaker]: https://docs.rs/tower-resilience-circuitbreaker
 //! [Bulkhead]: https://docs.rs/tower-resilience-bulkhead
@@ -106,6 +107,7 @@
 //! [Executor]: https://docs.rs/tower-resilience-executor
 //! [Adaptive]: https://docs.rs/tower-resilience-adaptive
 //! [Coalesce]: https://docs.rs/tower-resilience-coalesce
+//! [Outlier Detection]: https://docs.rs/tower-resilience-outlier
 //!
 //! # Documentation Guides
 //!

--- a/crates/tower-resilience/src/patterns.rs
+++ b/crates/tower-resilience/src/patterns.rs
@@ -18,6 +18,7 @@
 //! - [Executor](executor) - Delegate request processing to dedicated executors
 //! - [Adaptive Concurrency](adaptive) - Dynamic concurrency limiting with AIMD/Vegas
 //! - [Coalesce](coalesce) - Deduplicate concurrent identical requests (singleflight)
+//! - [Outlier Detection](outlier_detection) - Fleet-aware instance ejection based on health tracking
 
 /// Circuit Breaker pattern guide
 pub mod circuit_breaker {
@@ -1575,4 +1576,112 @@ pub mod coalesce {
     //! - **Singleflight** (Go's `golang.org/x/sync/singleflight`)
     //! - **Request deduplication**
     //! - **Request collapsing**
+}
+
+/// Outlier Detection pattern guide
+pub mod outlier_detection {
+    //! # Outlier Detection
+    //!
+    //! Tracks per-instance health on live traffic and ejects unhealthy instances from a fleet.
+    //! Complementary to circuit breaker -- outlier detection is fleet-aware and catches
+    //! hard-down instances immediately via consecutive error counting.
+    //!
+    //! ## When to Use
+    //!
+    //! - **Fleet of backends**: Multiple instances behind a load balancer
+    //! - **Hard failures**: Instances that crash or become unreachable
+    //! - **Partial outages**: Some instances down while others are healthy
+    //! - **Dynamic backends**: Instances added/removed at runtime
+    //!
+    //! ## When NOT to Use
+    //!
+    //! - **Single backend**: Use circuit breaker instead
+    //! - **Gradual degradation**: Circuit breaker with failure rate threshold is better
+    //! - **Rate-based issues**: Rate limiter is more appropriate
+    //!
+    //! ## How It Differs from Circuit Breaker
+    //!
+    //! | | Circuit Breaker | Outlier Detection |
+    //! |---|---|---|
+    //! | **Trigger** | Failure *rate* over sliding window | *Consecutive* errors |
+    //! | **Scope** | Per-service, isolated | Fleet-aware (`max_ejection_percent`) |
+    //! | **Detection speed** | Needs `minimum_calls` first | Catches hard-down immediately |
+    //! | **Recovery** | Half-open state with probes | Time-based with exponential backoff |
+    //! | **Use case** | Gradual degradation | Hard failures, instance health |
+    //!
+    //! ## Key Concepts
+    //!
+    //! - **`OutlierDetector`**: Shared fleet state. Tracks which instances are ejected and
+    //!   enforces `max_ejection_percent` to prevent cascading ejections.
+    //! - **`EjectionStrategy`**: Determines when to eject. `ConsecutiveErrors` ejects after
+    //!   N errors in a row. The trait is extensible for future strategies.
+    //! - **Backpressure mode** (default): `poll_ready` returns `Pending` for ejected instances,
+    //!   causing Tower load balancers to route around them naturally.
+    //! - **Error mode** (opt-in): `call` returns `OutlierDetectionError::Ejected`.
+    //! - **Recovery**: Automatic after `base_ejection_duration * 2^(ejection_count - 1)`.
+    //!
+    //! ## Trade-offs
+    //!
+    //! | Advantage | Disadvantage |
+    //! |-----------|--------------|
+    //! | Catches hard failures fast | False positives from transient errors |
+    //! | Fleet-aware ejection cap | Shared state requires coordination |
+    //! | Integrates with load balancers | No gradual failure rate detection |
+    //! | Exponential backoff on re-ejection | Timer-based recovery (no probing) |
+    //!
+    //! ## Example
+    //!
+    //! ```rust
+    //! # #[cfg(feature = "outlier")]
+    //! # {
+    //! use tower_resilience::outlier::{OutlierDetectionLayer, OutlierDetector};
+    //! use tower::{ServiceBuilder, service_fn};
+    //! use std::time::Duration;
+    //!
+    //! let detector = OutlierDetector::new()
+    //!     .max_ejection_percent(50)
+    //!     .base_ejection_duration(Duration::from_secs(30))
+    //!     .max_ejection_duration(Duration::from_secs(300));
+    //!
+    //! // Register instances with consecutive error thresholds
+    //! detector.register("backend-1", 5);
+    //! detector.register("backend-2", 5);
+    //! detector.register("backend-3", 5);
+    //!
+    //! // Create per-instance layers sharing the same detector
+    //! let layer = OutlierDetectionLayer::builder()
+    //!     .detector(detector.clone())
+    //!     .instance_name("backend-1")
+    //!     .build();
+    //!
+    //! let service = ServiceBuilder::new()
+    //!     .layer(layer)
+    //!     .service(service_fn(|req: String| async move { Ok::<_, std::io::Error>(req) }));
+    //! # }
+    //! ```
+    //!
+    //! ## Composition
+    //!
+    //! Outlier detection is typically the **outermost** layer so it observes errors
+    //! after all other middleware has had a chance to handle them:
+    //!
+    //! ```text
+    //! Request -> [Outlier Detection] -> [Circuit Breaker] -> [Timeout] -> [Retry] -> Service
+    //! ```
+    //!
+    //! ## Anti-patterns
+    //!
+    //! - **Threshold of 1**: A single error ejects the instance. Too aggressive for most
+    //!   workloads -- transient errors will cause unnecessary ejections.
+    //! - **No ejection cap**: Without `max_ejection_percent`, a fleet-wide issue can eject
+    //!   all instances simultaneously. Always set a cap (50% is a good default).
+    //! - **Using with single backend**: Outlier detection with one instance just adds
+    //!   overhead. Use circuit breaker instead.
+    //!
+    //! ## Prior Art
+    //!
+    //! - **Envoy**: [Outlier detection](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/outlier)
+    //!   with consecutive errors, success rate, and failure percentage strategies
+    //! - **Istio**: Exposes outlier detection via DestinationRule
+    //! - **Linkerd**: Failure accrual
 }

--- a/crates/tower-resilience/src/use_cases.rs
+++ b/crates/tower-resilience/src/use_cases.rs
@@ -8,6 +8,7 @@ pub mod database {
     //!
     //! ```text
     //! Read Replicas (Multiple Instances)
+    //! ├─ Outlier detection for replica health
     //! ├─ Health Check wrapper for automatic failover
     //! ├─ Reconnect for dropped connections
     //! ├─ Circuit breaker per replica
@@ -53,6 +54,7 @@ pub mod microservices {
     //!
     //! ```text
     //! Service-to-Service
+    //! ├─ Outlier detection for fleet health (multiple instances)
     //! ├─ Circuit breaker per dependency
     //! ├─ Retry for transient errors
     //! ├─ Timeout for tail latency


### PR DESCRIPTION
## Summary

Adds outlier detection pattern to all documentation surfaces that were missing it after #247 was merged.

- **Umbrella `lib.rs`**: Added to patterns list with docs.rs link
- **`patterns.rs`**: Full pattern guide with when-to-use, trade-offs, comparison table vs circuit breaker, example, composition guidance, anti-patterns, and prior art
- **`composition.rs`**: Added to selection quick reference table and decision flowchart
- **`use_cases.rs`**: Added to database (read replicas) and microservices (service-to-service) use cases
- **`README.md`**: Added to patterns list + full usage section with code example

## Test plan

- [x] `cargo doc --no-deps -p tower-resilience --all-features` builds clean
- [x] `cargo test --doc -p tower-resilience --all-features` passes (41 tests, including new outlier doc test)
- [x] `cargo clippy --all-targets --all-features` clean