### PR TITLE
fix: resolve clippy warnings across workspace

### DIFF
--- a/crates/tower-resilience-cache/src/shared_layer.rs
+++ b/crates/tower-resilience-cache/src/shared_layer.rs
@@ -358,7 +358,7 @@ mod tests {
         let mut wrapped2 = shared_layer.layer(service2);
 
         // First call on service1 - cache miss
-        let response1 = (&mut wrapped1)
+        let response1 = wrapped1
             .ready()
             .await
             .unwrap()
@@ -369,7 +369,7 @@ mod tests {
         assert_eq!(call_count.load(Ordering::SeqCst), 1);
 
         // Call on service2 with same key - should be cache HIT (shared store!)
-        let response2 = (&mut wrapped2)
+        let response2 = wrapped2
             .ready()
             .await
             .unwrap()
@@ -417,7 +417,7 @@ mod tests {
         let mut wrapped2 = layer.layer(service2);
 
         // First call on service1 - cache miss
-        (&mut wrapped1)
+        wrapped1
             .ready()
             .await
             .unwrap()
@@ -427,7 +427,7 @@ mod tests {
         assert_eq!(call_count.load(Ordering::SeqCst), 1);
 
         // Call on service2 with same key - ALSO a cache miss (separate stores!)
-        (&mut wrapped2)
+        wrapped2
             .ready()
             .await
             .unwrap()

--- a/crates/tower-resilience-healthcheck/src/selector.rs
+++ b/crates/tower-resilience-healthcheck/src/selector.rs
@@ -269,8 +269,7 @@ mod tests {
             statuses
                 .iter()
                 .enumerate()
-                .filter(|(_, s)| s.is_healthy())
-                .next_back()
+                .rfind(|(_, s)| s.is_healthy())
                 .map(|(i, _)| i)
         });
 

--- a/crates/tower-resilience/src/composition.rs
+++ b/crates/tower-resilience/src/composition.rs
@@ -26,7 +26,6 @@
 //! Use Health Check to **select** healthy resources, then apply Tower layers to the
 //! selected resource for request-level resilience.
 
-/// Pattern selection guide - how to choose the right patterns
 pub mod selection {
     //! # Pattern Selection Guide
     //!
@@ -130,7 +129,6 @@ pub mod selection {
     //! ```
 }
 
-/// Progressive stacks for different service types
 pub mod stacks {
     //! # Progressive Stacks by Service Type
     //!
@@ -349,7 +347,6 @@ pub mod stacks {
     //! ```
 }
 
-/// Common composition patterns
 pub mod patterns {
     //! # Composition Patterns
     //!
@@ -456,7 +453,6 @@ pub mod patterns {
     //! ```
 }
 
-/// Layer ordering guide
 pub mod ordering {
     //! # Layer Ordering
     //!
@@ -575,7 +571,6 @@ pub mod ordering {
     //! ```
 }
 
-/// Common anti-patterns to avoid
 pub mod anti_patterns {
     //! # Common Anti-Patterns
     //!
@@ -748,7 +743,6 @@ pub mod anti_patterns {
     //! ```
 }
 
-/// Error type integration strategies
 pub mod error_types {
     //! # Error Type Integration
     //!
@@ -877,7 +871,6 @@ pub mod error_types {
     //! ```
 }
 
-/// Advanced composition techniques
 pub mod advanced {
     //! # Advanced Composition
     //!
@@ -1070,7 +1063,6 @@ pub mod advanced {
     //! [`examples/message_queue_worker.rs`]: https://github.com/joshrotenberg/tower-resilience/blob/main/examples/message_queue_worker.rs
 }
 
-/// References and further reading
 pub mod references {
     //! # References
     //!

--- a/crates/tower-resilience/src/observability.rs
+++ b/crates/tower-resilience/src/observability.rs
@@ -2,8 +2,6 @@
 //!
 //! This module provides comprehensive guidance on metrics, tracing, and monitoring
 //! for all resilience patterns.
-
-/// Metrics documentation
 pub mod metrics {
     //! # Metrics Guide
     //!
@@ -134,7 +132,6 @@ pub mod metrics {
     //! ```
 }
 
-/// Tracing documentation
 pub mod tracing_guide {
     //! # Tracing Guide
     //!
@@ -156,7 +153,6 @@ pub mod tracing_guide {
     //! ```
 }
 
-/// Event system documentation
 pub mod events {
     //! # Event System Guide
     //!

--- a/crates/tower-resilience/src/patterns.rs
+++ b/crates/tower-resilience/src/patterns.rs
@@ -19,7 +19,6 @@
 //! - [Adaptive Concurrency](adaptive) - Dynamic concurrency limiting with AIMD/Vegas
 //! - [Coalesce](coalesce) - Deduplicate concurrent identical requests (singleflight)
 
-/// Circuit Breaker pattern guide
 pub mod circuit_breaker {
     //! # Circuit Breaker
     //!
@@ -91,7 +90,6 @@ pub mod circuit_breaker {
     //! ```
 }
 
-/// Health Check pattern guide
 pub mod healthcheck {
     //! # Health Check
     //!
@@ -261,7 +259,6 @@ pub mod healthcheck {
     //! ```
 }
 
-/// Reconnect pattern guide
 pub mod reconnect {
     //! # Reconnect
     //!
@@ -353,7 +350,6 @@ pub mod reconnect {
     //! ```
 }
 
-/// Bulkhead pattern guide
 pub mod bulkhead {
     //! # Bulkhead
     //!
@@ -427,7 +423,6 @@ pub mod bulkhead {
     //! ```
 }
 
-/// Time Limiter pattern guide
 pub mod time_limiter {
     //! # Time Limiter
     //!
@@ -501,7 +496,6 @@ pub mod time_limiter {
     //! ```
 }
 
-/// Retry pattern guide
 pub mod retry {
     //! # Retry
     //!
@@ -581,7 +575,6 @@ pub mod retry {
     //! ```
 }
 
-/// Rate Limiter pattern guide
 pub mod rate_limiter {
     //! # Rate Limiter
     //!
@@ -653,7 +646,6 @@ pub mod rate_limiter {
     //! ```
 }
 
-/// Cache pattern guide
 pub mod cache {
     //! # Cache
     //!
@@ -730,7 +722,6 @@ pub mod cache {
     //! ```
 }
 
-/// Fallback pattern guide
 pub mod fallback {
     //! # Fallback
     //!
@@ -910,7 +901,6 @@ pub mod fallback {
     //! ```
 }
 
-/// Executor pattern guide
 pub mod executor {
     //! # Executor
     //!
@@ -1005,7 +995,6 @@ pub mod executor {
     //! ```
 }
 
-/// Hedge pattern guide
 pub mod hedge {
     //! # Hedge
     //!
@@ -1224,7 +1213,6 @@ pub mod hedge {
     //! ```
 }
 
-/// Adaptive Concurrency pattern guide
 pub mod adaptive {
     //! # Adaptive Concurrency
     //!
@@ -1387,7 +1375,6 @@ pub mod adaptive {
     //! ```
 }
 
-/// Coalesce pattern guide
 pub mod coalesce {
     //! # Coalesce (Singleflight)
     //!

--- a/crates/tower-resilience/src/use_cases.rs
+++ b/crates/tower-resilience/src/use_cases.rs
@@ -2,7 +2,6 @@
 //!
 //! Real-world scenarios and recommendations for applying resilience patterns.
 
-/// Database client use cases
 pub mod database {
     //! # Database Clients
     //!
@@ -25,7 +24,6 @@ pub mod database {
     //! ```
 }
 
-/// Message queue use cases
 pub mod message_queue {
     //! # Message Queue Workers
     //!
@@ -47,7 +45,6 @@ pub mod message_queue {
     //! ```
 }
 
-/// Microservices use cases
 pub mod microservices {
     //! # Microservices
     //!
@@ -66,7 +63,6 @@ pub mod microservices {
     //! ```
 }
 
-/// Background job use cases
 pub mod background_jobs {
     //! # Background Jobs
     //!


### PR DESCRIPTION
## Summary

- Remove mixed inner/outer doc attributes (`mixed_attributes_style`) on `pub mod` declarations in composition.rs, patterns.rs, observability.rs, and use_cases.rs
- Replace `.filter().next_back()` with `.rfind()` (`filter_next`) in healthcheck selector
- Remove needless borrows (`needless_borrow`) in cache shared_layer tests

## Test plan

- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` passes clean
- [x] `cargo test --lib --all-features --workspace` passes
- [x] `cargo test --doc --all-features --workspace` passes
- [x] `cargo doc --no-deps --all-features --workspace` builds clean
- [x] `cargo fmt --all -- --check` passes