### PR TITLE
feat: add weighted router for canary deployments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tower-resilience-reconnect = { path = "crates/tower-resilience-reconnect", featu
 tower-resilience-healthcheck = { path = "crates/tower-resilience-healthcheck" }
 tower-resilience-fallback = { path = "crates/tower-resilience-fallback", features = ["metrics"] }
 tower-resilience-hedge = { path = "crates/tower-resilience-hedge", features = ["metrics"] }
+tower-resilience-router = { path = "crates/tower-resilience-router" }
 tower-resilience-adaptive = { path = "crates/tower-resilience-adaptive" }
 tower-resilience-coalesce = { path = "crates/tower-resilience-coalesce" }
 tower-resilience-executor = { path = "crates/tower-resilience-executor" }
@@ -67,6 +68,7 @@ members = [
     "crates/tower-resilience-adaptive",
     "crates/tower-resilience-coalesce",
     "crates/tower-resilience-outlier",
+    "crates/tower-resilience-router",
     "crates/tower-resilience",
     "examples/axum-resilient-kv-store",
     "examples/tonic-resilient-greeter",

--- a/crates/tower-resilience-router/Cargo.toml
+++ b/crates/tower-resilience-router/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "tower-resilience-router"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+readme = "../../README.md"
+description = "Weighted traffic routing for Tower services - canary deployments and progressive rollout"
+categories = ["asynchronous", "network-programming"]
+keywords = ["tower", "resilience", "routing", "canary", "middleware"]
+
+[dependencies]
+tower-resilience-core = { workspace = true }
+tower-service = { workspace = true }
+tokio = { workspace = true }
+
+# Optional dependencies
+tracing = { workspace = true, optional = true }
+metrics = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros", "rt-multi-thread"] }
+tower = { workspace = true }
+
+[features]
+default = []
+# Enable distributed tracing via the tracing crate
+tracing = ["dep:tracing"]
+# Enable Prometheus metrics (routed requests per backend, selection counts)
+metrics = ["dep:metrics"]

--- a/crates/tower-resilience-router/src/config.rs
+++ b/crates/tower-resilience-router/src/config.rs
@@ -1,0 +1,161 @@
+//! Configuration for the weighted router.
+
+use crate::events::RouterEvent;
+use crate::selection::SelectionStrategy;
+use tower_resilience_core::events::{EventListeners, FnListener};
+
+/// Configuration for the weighted router.
+#[derive(Clone)]
+pub struct RouterConfig {
+    /// Name of this router instance.
+    pub(crate) name: String,
+    /// Selection strategy for choosing backends.
+    pub(crate) strategy: SelectionStrategy,
+    /// Event listeners.
+    pub(crate) event_listeners: EventListeners<RouterEvent>,
+}
+
+/// Builder for configuring a `WeightedRouter`.
+///
+/// Use [`WeightedRouter::builder`](crate::WeightedRouter::builder) to create a new builder.
+pub struct WeightedRouterBuilder<S> {
+    backends: Vec<(S, u32)>,
+    name: String,
+    strategy: SelectionStrategy,
+    event_listeners: EventListeners<RouterEvent>,
+}
+
+impl<S> WeightedRouterBuilder<S> {
+    /// Creates a new builder.
+    pub fn new() -> Self {
+        Self {
+            backends: Vec::new(),
+            name: "weighted_router".to_string(),
+            strategy: SelectionStrategy::default(),
+            event_listeners: EventListeners::new(),
+        }
+    }
+
+    /// Adds a backend service with the given weight.
+    ///
+    /// Higher weights receive proportionally more traffic. A backend with
+    /// weight 90 receives 9x the traffic of a backend with weight 10.
+    ///
+    /// # Panics
+    ///
+    /// The [`build`](Self::build) method panics if no backends are added
+    /// or if any weight is zero.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use tower_resilience_router::WeightedRouter;
+    /// use tower::util::BoxService;
+    ///
+    /// let svc_v1: BoxService<(), (), std::io::Error> =
+    ///     BoxService::new(tower::service_fn(|_: ()| async { Ok(()) }));
+    /// let svc_v2: BoxService<(), (), std::io::Error> =
+    ///     BoxService::new(tower::service_fn(|_: ()| async { Ok(()) }));
+    ///
+    /// let router = WeightedRouter::builder()
+    ///     .route(svc_v1, 90)
+    ///     .route(svc_v2, 10)
+    ///     .build();
+    /// ```
+    pub fn route(mut self, service: S, weight: u32) -> Self {
+        self.backends.push((service, weight));
+        self
+    }
+
+    /// Sets the name of this router instance.
+    ///
+    /// Used for metrics labels and event identification.
+    ///
+    /// Default: `"weighted_router"`
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    /// Sets the selection strategy.
+    ///
+    /// Default: [`SelectionStrategy::Deterministic`]
+    pub fn strategy(mut self, strategy: SelectionStrategy) -> Self {
+        self.strategy = strategy;
+        self
+    }
+
+    /// Uses deterministic selection (default).
+    ///
+    /// Requests are distributed using an atomic counter. With weights
+    /// `[90, 10]`, every 100th request cycle distributes exactly 90
+    /// requests to the first backend and 10 to the second.
+    pub fn deterministic(mut self) -> Self {
+        self.strategy = SelectionStrategy::Deterministic;
+        self
+    }
+
+    /// Uses random selection.
+    ///
+    /// Each request independently selects a backend based on weighted
+    /// random probability. Over many requests, the distribution converges
+    /// to the configured weights, but individual request sequences may
+    /// vary -- especially at low traffic volumes.
+    pub fn random(mut self) -> Self {
+        self.strategy = SelectionStrategy::Random;
+        self
+    }
+
+    /// Registers a callback when a request is routed to a backend.
+    ///
+    /// # Callback Signature
+    /// `Fn(usize, u32)` - Called with the backend index and its weight.
+    pub fn on_request_routed<F>(mut self, f: F) -> Self
+    where
+        F: Fn(usize, u32) + Send + Sync + 'static,
+    {
+        self.event_listeners.add(FnListener::new(move |event| {
+            let RouterEvent::RequestRouted {
+                backend_index,
+                backend_weight,
+                ..
+            } = event;
+            f(*backend_index, *backend_weight);
+        }));
+        self
+    }
+
+    /// Builds the `WeightedRouter`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if:
+    /// - No backends have been added
+    /// - Any backend has a weight of zero
+    pub fn build(self) -> crate::WeightedRouter<S> {
+        assert!(
+            !self.backends.is_empty(),
+            "at least one backend is required"
+        );
+        for (i, (_, weight)) in self.backends.iter().enumerate() {
+            assert!(
+                *weight > 0,
+                "backend {i} has weight 0; all weights must be positive"
+            );
+        }
+
+        let config = RouterConfig {
+            name: self.name,
+            strategy: self.strategy,
+            event_listeners: self.event_listeners,
+        };
+
+        crate::WeightedRouter::new(self.backends, config)
+    }
+}
+
+impl<S> Default for WeightedRouterBuilder<S> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/tower-resilience-router/src/error.rs
+++ b/crates/tower-resilience-router/src/error.rs
@@ -1,0 +1,61 @@
+//! Error types for the weighted router.
+
+use std::fmt;
+use tower_resilience_core::ResilienceError;
+
+/// Errors that can occur in the weighted router.
+///
+/// The weighted router itself does not produce errors -- it delegates
+/// to the selected backend. This error type wraps the inner service
+/// error for consistency with other tower-resilience patterns.
+#[derive(Debug)]
+pub enum WeightedRouterError<E> {
+    /// An error from the selected backend service.
+    Inner(E),
+}
+
+impl<E> WeightedRouterError<E> {
+    /// Returns `true` if this is an inner service error.
+    pub fn is_inner(&self) -> bool {
+        matches!(self, WeightedRouterError::Inner(_))
+    }
+
+    /// Consumes self and returns the inner error.
+    pub fn into_inner(self) -> E {
+        match self {
+            WeightedRouterError::Inner(e) => e,
+        }
+    }
+}
+
+impl<E: fmt::Display> fmt::Display for WeightedRouterError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            WeightedRouterError::Inner(e) => write!(f, "backend service error: {}", e),
+        }
+    }
+}
+
+impl<E: std::error::Error + 'static> std::error::Error for WeightedRouterError<E> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            WeightedRouterError::Inner(e) => Some(e),
+        }
+    }
+}
+
+impl<E> From<WeightedRouterError<E>> for ResilienceError<E> {
+    fn from(err: WeightedRouterError<E>) -> Self {
+        match err {
+            WeightedRouterError::Inner(e) => ResilienceError::Application(e),
+        }
+    }
+}
+
+impl<E> From<WeightedRouterError<ResilienceError<E>>> for ResilienceError<E> {
+    fn from(err: WeightedRouterError<ResilienceError<E>>) -> Self {
+        match err {
+            WeightedRouterError::Inner(re) => re,
+        }
+    }
+}

--- a/crates/tower-resilience-router/src/events.rs
+++ b/crates/tower-resilience-router/src/events.rs
@@ -1,0 +1,40 @@
+//! Event types for the weighted router.
+
+use std::time::Instant;
+use tower_resilience_core::events::ResilienceEvent;
+
+/// Events emitted by the weighted router.
+#[derive(Debug, Clone)]
+pub enum RouterEvent {
+    /// A request was routed to a backend.
+    RequestRouted {
+        /// Name of the router instance.
+        pattern_name: String,
+        /// When the event occurred.
+        timestamp: Instant,
+        /// Index of the selected backend.
+        backend_index: usize,
+        /// Weight of the selected backend.
+        backend_weight: u32,
+    },
+}
+
+impl ResilienceEvent for RouterEvent {
+    fn event_type(&self) -> &'static str {
+        match self {
+            RouterEvent::RequestRouted { .. } => "request_routed",
+        }
+    }
+
+    fn timestamp(&self) -> Instant {
+        match self {
+            RouterEvent::RequestRouted { timestamp, .. } => *timestamp,
+        }
+    }
+
+    fn pattern_name(&self) -> &str {
+        match self {
+            RouterEvent::RequestRouted { pattern_name, .. } => pattern_name,
+        }
+    }
+}

--- a/crates/tower-resilience-router/src/lib.rs
+++ b/crates/tower-resilience-router/src/lib.rs
@@ -1,0 +1,394 @@
+//! Weighted traffic routing for Tower services.
+//!
+//! This crate provides a `WeightedRouter` service that distributes requests
+//! across multiple backend services based on configured weights. It is designed
+//! for canary deployments, progressive rollouts, and controlled traffic splitting.
+//!
+//! # Overview
+//!
+//! Unlike other tower-resilience patterns which wrap a single service and modify
+//! its behavior, `WeightedRouter` *selects among* multiple services. It is a
+//! standalone `Service`, not a `Layer`.
+//!
+//! All backend services must have the same `Request`, `Response`, and `Error`
+//! types. For canary deployments (same service, different version), this is
+//! the natural case.
+//!
+//! # Selection Strategies
+//!
+//! - **Deterministic** (default): Uses an atomic counter for predictable,
+//!   repeatable distribution. With weights `[90, 10]`, every cycle of 100
+//!   requests sends exactly 90 to the first backend and 10 to the second.
+//!
+//! - **Random**: Each request independently selects a backend with probability
+//!   proportional to its weight. Better for high-volume statistical distribution,
+//!   but may show variance at low traffic.
+//!
+//! # Readiness
+//!
+//! `poll_ready` checks that **all** backends are ready. This is the simplest
+//! and most predictable contract. If a backend is slow or failing, pair it
+//! with a circuit breaker so that readiness resolves quickly (open circuit =
+//! immediate ready or error).
+//!
+//! # Example
+//!
+//! Because all backends must be the same type `S`, use `BoxService` when
+//! constructing from different closures:
+//!
+//! ```rust,no_run
+//! use tower::Service;
+//! use tower::util::BoxService;
+//! use tower_resilience_router::WeightedRouter;
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let svc_v1: BoxService<String, String, std::io::Error> =
+//!     BoxService::new(tower::service_fn(|req: String| async move {
+//!         Ok(format!("v1: {}", req))
+//!     }));
+//! let svc_v2: BoxService<String, String, std::io::Error> =
+//!     BoxService::new(tower::service_fn(|req: String| async move {
+//!         Ok(format!("v2: {}", req))
+//!     }));
+//!
+//! let mut router = WeightedRouter::builder()
+//!     .route(svc_v1, 90)
+//!     .route(svc_v2, 10)
+//!     .build();
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Composability
+//!
+//! The natural composition pattern puts resilience middleware *inside* each backend:
+//!
+//! ```rust,no_run
+//! use tower::Layer;
+//! use tower_resilience_router::WeightedRouter;
+//! # use tower::service_fn;
+//! # let svc_v1 = service_fn(|_: ()| async { Ok::<_, std::io::Error>(()) });
+//! # let svc_v2 = service_fn(|_: ()| async { Ok::<_, std::io::Error>(()) });
+//!
+//! // Each backend gets its own circuit breaker
+//! // let cb = CircuitBreakerLayer::standard().build();
+//! // let router = WeightedRouter::builder()
+//! //     .route(cb.layer(svc_v1), 90)
+//! //     .route(cb.layer(svc_v2), 10)
+//! //     .build();
+//! ```
+
+pub mod config;
+pub mod error;
+pub mod events;
+pub mod selection;
+
+pub use config::WeightedRouterBuilder;
+pub use error::WeightedRouterError;
+pub use events::RouterEvent;
+pub use selection::SelectionStrategy;
+
+use config::RouterConfig;
+use selection::WeightedSelector;
+use std::task::{Context, Poll};
+use tower_service::Service;
+
+/// A service that routes requests to one of several backends based on weights.
+///
+/// `WeightedRouter` is a standalone `Service`, not a `Layer`. It selects among
+/// multiple backend services of the same type, distributing traffic according
+/// to configured weights.
+///
+/// Use [`WeightedRouter::builder`] to construct a new router.
+pub struct WeightedRouter<S> {
+    /// Backend services with their weights.
+    backends: Vec<(S, u32)>,
+    /// Selector for choosing backends.
+    selector: WeightedSelector,
+    /// Configuration.
+    config: RouterConfig,
+}
+
+impl<S> WeightedRouter<S> {
+    /// Creates a new builder for configuring a `WeightedRouter`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use tower_resilience_router::WeightedRouter;
+    /// use tower::util::BoxService;
+    ///
+    /// let svc_v1: BoxService<(), (), std::io::Error> =
+    ///     BoxService::new(tower::service_fn(|_: ()| async { Ok(()) }));
+    /// let svc_v2: BoxService<(), (), std::io::Error> =
+    ///     BoxService::new(tower::service_fn(|_: ()| async { Ok(()) }));
+    ///
+    /// let router = WeightedRouter::builder()
+    ///     .route(svc_v1, 90)
+    ///     .route(svc_v2, 10)
+    ///     .build();
+    /// ```
+    pub fn builder() -> WeightedRouterBuilder<S> {
+        WeightedRouterBuilder::new()
+    }
+
+    pub(crate) fn new(backends: Vec<(S, u32)>, config: RouterConfig) -> Self {
+        let weights: Vec<u32> = backends.iter().map(|(_, w)| *w).collect();
+        let selector = WeightedSelector::new(&weights, config.strategy);
+        Self {
+            backends,
+            selector,
+            config,
+        }
+    }
+
+    /// Returns the number of backends.
+    pub fn backend_count(&self) -> usize {
+        self.backends.len()
+    }
+
+    /// Returns the weights of all backends.
+    pub fn weights(&self) -> Vec<u32> {
+        self.backends.iter().map(|(_, w)| *w).collect()
+    }
+
+    /// Returns the name of this router instance.
+    pub fn name(&self) -> &str {
+        &self.config.name
+    }
+}
+
+impl<S: Clone> Clone for WeightedRouter<S> {
+    fn clone(&self) -> Self {
+        Self {
+            backends: self.backends.clone(),
+            selector: self.selector.clone(),
+            config: self.config.clone(),
+        }
+    }
+}
+
+impl<S, Request> Service<Request> for WeightedRouter<S>
+where
+    S: Service<Request>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // All backends must be ready.
+        for (svc, _) in &mut self.backends {
+            match svc.poll_ready(cx)? {
+                Poll::Ready(()) => {}
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let idx = self.selector.select();
+        let (svc, weight) = &mut self.backends[idx];
+
+        #[cfg(feature = "metrics")]
+        {
+            let labels = [
+                ("router", self.config.name.clone()),
+                ("backend", idx.to_string()),
+            ];
+            metrics::counter!("router_requests_routed_total", &labels).increment(1);
+        }
+
+        #[cfg(feature = "tracing")]
+        {
+            tracing::debug!(
+                router = %self.config.name,
+                backend_index = idx,
+                backend_weight = *weight,
+                "routing request to backend"
+            );
+        }
+
+        self.config
+            .event_listeners
+            .emit(&RouterEvent::RequestRouted {
+                pattern_name: self.config.name.clone(),
+                timestamp: std::time::Instant::now(),
+                backend_index: idx,
+                backend_weight: *weight,
+            });
+
+        svc.call(request)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use tower::util::BoxService;
+    use tower::ServiceExt;
+
+    type BoxSvc = BoxService<(), &'static str, TestError>;
+
+    #[derive(Clone, Debug)]
+    struct TestError;
+    impl std::fmt::Display for TestError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "test error")
+        }
+    }
+    impl std::error::Error for TestError {}
+
+    fn counting_svc(counter: Arc<AtomicUsize>, label: &'static str) -> BoxSvc {
+        BoxService::new(tower::service_fn(move |_: ()| {
+            let c = Arc::clone(&counter);
+            async move {
+                c.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, TestError>(label)
+            }
+        }))
+    }
+
+    #[tokio::test]
+    async fn routes_by_weight_deterministic() {
+        let count_a = Arc::new(AtomicUsize::new(0));
+        let count_b = Arc::new(AtomicUsize::new(0));
+
+        let mut router = WeightedRouter::builder()
+            .route(counting_svc(Arc::clone(&count_a), "a"), 80)
+            .route(counting_svc(Arc::clone(&count_b), "b"), 20)
+            .build();
+
+        for _ in 0..100 {
+            let _ = router.ready().await.unwrap().call(()).await;
+        }
+
+        assert_eq!(count_a.load(Ordering::SeqCst), 80);
+        assert_eq!(count_b.load(Ordering::SeqCst), 20);
+    }
+
+    #[tokio::test]
+    async fn single_backend_gets_all_traffic() {
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let mut router = WeightedRouter::builder()
+            .route(counting_svc(Arc::clone(&count), "ok"), 1)
+            .build();
+
+        for _ in 0..50 {
+            let _ = router.ready().await.unwrap().call(()).await;
+        }
+
+        assert_eq!(count.load(Ordering::SeqCst), 50);
+    }
+
+    #[tokio::test]
+    async fn three_backends() {
+        let counts: Vec<Arc<AtomicUsize>> = (0..3).map(|_| Arc::new(AtomicUsize::new(0))).collect();
+
+        let mut router = WeightedRouter::builder()
+            .route(counting_svc(Arc::clone(&counts[0]), "0"), 50)
+            .route(counting_svc(Arc::clone(&counts[1]), "1"), 30)
+            .route(counting_svc(Arc::clone(&counts[2]), "2"), 20)
+            .build();
+
+        for _ in 0..100 {
+            let _ = router.ready().await.unwrap().call(()).await;
+        }
+
+        assert_eq!(counts[0].load(Ordering::SeqCst), 50);
+        assert_eq!(counts[1].load(Ordering::SeqCst), 30);
+        assert_eq!(counts[2].load(Ordering::SeqCst), 20);
+    }
+
+    #[tokio::test]
+    async fn error_propagates_from_backend() {
+        let svc: BoxSvc = BoxService::new(tower::service_fn(|_: ()| async {
+            Err::<&str, _>(TestError)
+        }));
+
+        let mut router = WeightedRouter::builder().route(svc, 1).build();
+
+        let result = router.ready().await.unwrap().call(()).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn event_listener_fires() {
+        let routed_count = Arc::new(AtomicUsize::new(0));
+        let rc = Arc::clone(&routed_count);
+
+        let svc: BoxSvc = BoxService::new(tower::service_fn(|_: ()| async {
+            Ok::<_, TestError>("ok")
+        }));
+
+        let mut router = WeightedRouter::builder()
+            .route(svc, 1)
+            .on_request_routed(move |_idx, _weight| {
+                rc.fetch_add(1, Ordering::SeqCst);
+            })
+            .build();
+
+        for _ in 0..5 {
+            let _ = router.ready().await.unwrap().call(()).await;
+        }
+
+        assert_eq!(routed_count.load(Ordering::SeqCst), 5);
+    }
+
+    #[tokio::test]
+    async fn builder_accessors() {
+        let router = WeightedRouter::builder()
+            .name("canary")
+            .route(counting_svc(Arc::new(AtomicUsize::new(0)), "a"), 90)
+            .route(counting_svc(Arc::new(AtomicUsize::new(0)), "b"), 10)
+            .build();
+
+        assert_eq!(router.backend_count(), 2);
+        assert_eq!(router.weights(), vec![90, 10]);
+        assert_eq!(router.name(), "canary");
+    }
+
+    #[test]
+    #[should_panic(expected = "at least one backend is required")]
+    fn panics_on_no_backends() {
+        let _router: WeightedRouter<BoxSvc> = WeightedRouter::builder().build();
+    }
+
+    #[test]
+    #[should_panic(expected = "weight 0")]
+    fn panics_on_zero_weight() {
+        let svc: BoxSvc = BoxService::new(tower::service_fn(|_: ()| async {
+            Ok::<_, TestError>("ok")
+        }));
+        let _router = WeightedRouter::builder().route(svc, 0).build();
+    }
+
+    #[tokio::test]
+    async fn random_strategy_converges() {
+        let count_a = Arc::new(AtomicUsize::new(0));
+        let count_b = Arc::new(AtomicUsize::new(0));
+
+        let mut router = WeightedRouter::builder()
+            .route(counting_svc(Arc::clone(&count_a), "a"), 80)
+            .route(counting_svc(Arc::clone(&count_b), "b"), 20)
+            .random()
+            .build();
+
+        let total = 10_000;
+        for _ in 0..total {
+            let _ = router.ready().await.unwrap().call(()).await;
+        }
+
+        let a = count_a.load(Ordering::SeqCst);
+        let ratio = a as f64 / total as f64;
+        assert!(
+            (0.75..=0.85).contains(&ratio),
+            "expected ~80%, got {:.1}%",
+            ratio * 100.0
+        );
+    }
+}

--- a/crates/tower-resilience-router/src/selection.rs
+++ b/crates/tower-resilience-router/src/selection.rs
@@ -1,0 +1,173 @@
+//! Selection strategies for weighted routing.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Strategy for selecting which backend handles a request.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum SelectionStrategy {
+    /// Deterministic round-robin weighted selection (default).
+    ///
+    /// Uses an atomic counter to distribute requests in a predictable,
+    /// repeatable pattern. With weights `[90, 10]`, every cycle of 100
+    /// requests sends exactly 90 to the first backend and 10 to the second.
+    ///
+    /// This is the recommended default for canary deployments because:
+    /// - Behavior is predictable at any traffic volume
+    /// - Easy to test and debug ("request N went to backend X")
+    /// - No variance issues at low request rates
+    #[default]
+    Deterministic,
+
+    /// Random weighted selection.
+    ///
+    /// Each request independently selects a backend with probability
+    /// proportional to its weight. Over many requests the distribution
+    /// converges to the configured weights, but short-term variance
+    /// is possible -- especially at low traffic volumes.
+    Random,
+}
+
+/// Selector that picks a backend index based on weights and strategy.
+pub(crate) struct WeightedSelector {
+    /// Cumulative weights for binary search selection.
+    cumulative_weights: Vec<u64>,
+    /// Total weight across all backends.
+    total_weight: u64,
+    /// Atomic counter for deterministic selection.
+    counter: AtomicU64,
+    /// The strategy to use.
+    strategy: SelectionStrategy,
+}
+
+impl WeightedSelector {
+    /// Creates a new selector from weights.
+    pub(crate) fn new(weights: &[u32], strategy: SelectionStrategy) -> Self {
+        let mut cumulative_weights = Vec::with_capacity(weights.len());
+        let mut cumulative = 0u64;
+        for &w in weights {
+            cumulative += u64::from(w);
+            cumulative_weights.push(cumulative);
+        }
+
+        Self {
+            total_weight: cumulative,
+            cumulative_weights,
+            counter: AtomicU64::new(0),
+            strategy,
+        }
+    }
+
+    /// Selects a backend index.
+    pub(crate) fn select(&self) -> usize {
+        let point = match self.strategy {
+            SelectionStrategy::Deterministic => {
+                let count = self.counter.fetch_add(1, Ordering::Relaxed);
+                count % self.total_weight
+            }
+            SelectionStrategy::Random => {
+                // Simple LCG-based random: fast, no external dependency.
+                // We use the counter as seed state for reproducibility in tests
+                // when needed, but each call advances it.
+                let count = self.counter.fetch_add(1, Ordering::Relaxed);
+                // Mix bits using a simple hash to get pseudo-random distribution
+                let hash = count
+                    .wrapping_mul(6_364_136_223_846_793_005)
+                    .wrapping_add(1_442_695_040_888_963_407);
+                hash % self.total_weight
+            }
+        };
+
+        // Binary search for the bucket this point falls into
+        match self.cumulative_weights.binary_search(&(point + 1)) {
+            Ok(idx) => idx,
+            Err(idx) => idx,
+        }
+    }
+}
+
+impl Clone for WeightedSelector {
+    fn clone(&self) -> Self {
+        Self {
+            cumulative_weights: self.cumulative_weights.clone(),
+            total_weight: self.total_weight,
+            counter: AtomicU64::new(self.counter.load(Ordering::Relaxed)),
+            strategy: self.strategy,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deterministic_distributes_exactly() {
+        let selector = WeightedSelector::new(&[90, 10], SelectionStrategy::Deterministic);
+
+        let mut counts = [0u32; 2];
+        for _ in 0..100 {
+            let idx = selector.select();
+            counts[idx] += 1;
+        }
+
+        assert_eq!(counts[0], 90);
+        assert_eq!(counts[1], 10);
+    }
+
+    #[test]
+    fn deterministic_repeats_cycle() {
+        let selector = WeightedSelector::new(&[70, 30], SelectionStrategy::Deterministic);
+
+        let first_cycle: Vec<usize> = (0..100).map(|_| selector.select()).collect();
+
+        // Reset counter
+        selector.counter.store(0, Ordering::Relaxed);
+        let second_cycle: Vec<usize> = (0..100).map(|_| selector.select()).collect();
+
+        assert_eq!(first_cycle, second_cycle);
+    }
+
+    #[test]
+    fn random_converges_to_weights() {
+        let selector = WeightedSelector::new(&[80, 20], SelectionStrategy::Random);
+
+        let mut counts = [0u32; 2];
+        let total = 10_000;
+        for _ in 0..total {
+            let idx = selector.select();
+            counts[idx] += 1;
+        }
+
+        // Allow 5% tolerance
+        let ratio = f64::from(counts[0]) / f64::from(total);
+        assert!(
+            (0.75..=0.85).contains(&ratio),
+            "expected ~80%, got {:.1}%",
+            ratio * 100.0
+        );
+    }
+
+    #[test]
+    fn single_backend() {
+        let selector = WeightedSelector::new(&[1], SelectionStrategy::Deterministic);
+
+        for _ in 0..100 {
+            assert_eq!(selector.select(), 0);
+        }
+    }
+
+    #[test]
+    fn three_backends() {
+        let selector = WeightedSelector::new(&[50, 30, 20], SelectionStrategy::Deterministic);
+
+        let mut counts = [0u32; 3];
+        for _ in 0..100 {
+            let idx = selector.select();
+            counts[idx] += 1;
+        }
+
+        assert_eq!(counts[0], 50);
+        assert_eq!(counts[1], 30);
+        assert_eq!(counts[2], 20);
+    }
+}

--- a/crates/tower-resilience/Cargo.toml
+++ b/crates/tower-resilience/Cargo.toml
@@ -30,6 +30,7 @@ tower-resilience-executor = { version = "0.8.0", path = "../tower-resilience-exe
 tower-resilience-adaptive = { version = "0.8.0", path = "../tower-resilience-adaptive", optional = true }
 tower-resilience-coalesce = { version = "0.8.0", path = "../tower-resilience-coalesce", optional = true }
 tower-resilience-outlier = { version = "0.8.0", path = "../tower-resilience-outlier", optional = true }
+tower-resilience-router = { version = "0.8.0", path = "../tower-resilience-router", optional = true }
 
 [features]
 default = []
@@ -63,11 +64,13 @@ adaptive = ["dep:tower-resilience-adaptive"]
 coalesce = ["dep:tower-resilience-coalesce"]
 # Outlier detection: fleet-aware instance ejection based on health tracking
 outlier = ["dep:tower-resilience-outlier"]
+# Router: weighted traffic routing for canary deployments and progressive rollout
+router = ["dep:tower-resilience-router"]
 # Unified error layer: compose multiple resilience layers with a single error type
 layer = ["tower-resilience-core/layer"]
 
 # Enable all patterns at once
-full = ["circuitbreaker", "bulkhead", "timelimiter", "cache", "retry", "ratelimiter", "reconnect", "healthcheck", "fallback", "hedge", "executor", "adaptive", "coalesce", "outlier", "layer"]
+full = ["circuitbreaker", "bulkhead", "timelimiter", "cache", "retry", "ratelimiter", "reconnect", "healthcheck", "fallback", "hedge", "executor", "adaptive", "coalesce", "outlier", "router", "layer"]
 
 # Integration: health checks can proactively open/close circuit breakers
 health-circuitbreaker = [

--- a/crates/tower-resilience/src/lib.rs
+++ b/crates/tower-resilience/src/lib.rs
@@ -93,6 +93,7 @@
 //! - **[Adaptive]** - Dynamic concurrency limiting using AIMD or Vegas algorithms
 //! - **[Coalesce]** - Deduplicates concurrent identical requests (singleflight)
 //! - **[Outlier Detection]** - Fleet-aware instance ejection based on health tracking
+//! - **[Router]** - Weighted traffic routing for canary deployments and progressive rollout
 //!
 //! [Circuit Breaker]: https://docs.rs/tower-resilience-circuitbreaker
 //! [Bulkhead]: https://docs.rs/tower-resilience-bulkhead
@@ -108,6 +109,7 @@
 //! [Adaptive]: https://docs.rs/tower-resilience-adaptive
 //! [Coalesce]: https://docs.rs/tower-resilience-coalesce
 //! [Outlier Detection]: https://docs.rs/tower-resilience-outlier
+//! [Router]: https://docs.rs/tower-resilience-router
 //!
 //! # Documentation Guides
 //!
@@ -326,6 +328,9 @@ pub use tower_resilience_coalesce as coalesce;
 
 #[cfg(feature = "outlier")]
 pub use tower_resilience_outlier as outlier;
+
+#[cfg(feature = "router")]
+pub use tower_resilience_router as router;
 
 // Re-export unified error layer types
 #[cfg(feature = "layer")]

--- a/crates/tower-resilience/src/patterns.rs
+++ b/crates/tower-resilience/src/patterns.rs
@@ -19,6 +19,7 @@
 //! - [Adaptive Concurrency](adaptive) - Dynamic concurrency limiting with AIMD/Vegas
 //! - [Coalesce](coalesce) - Deduplicate concurrent identical requests (singleflight)
 //! - [Outlier Detection](outlier_detection) - Fleet-aware instance ejection based on health tracking
+//! - [Router](router) - Weighted traffic routing for canary deployments
 
 pub mod circuit_breaker {
     //! # Circuit Breaker
@@ -1671,4 +1672,73 @@ pub mod outlier_detection {
     //!   with consecutive errors, success rate, and failure percentage strategies
     //! - **Istio**: Exposes outlier detection via DestinationRule
     //! - **Linkerd**: Failure accrual
+}
+
+pub mod router {
+    //! # Weighted Router
+    //!
+    //! Distributes requests across multiple backend services based on configured weights.
+    //! Designed for canary deployments, progressive rollouts, and controlled traffic splitting.
+    //!
+    //! ## When to Use
+    //!
+    //! - **Canary deployments**: Route 5-10% of traffic to a new service version
+    //! - **Progressive rollout**: Gradually shift traffic from old to new version
+    //! - **A/B testing**: Split traffic between variants (same request/response types)
+    //! - **Blue-green deployment**: Switch traffic between environments
+    //!
+    //! ## Key Difference from Load Balancing
+    //!
+    //! `WeightedRouter` is **traffic control**, not load distribution. It provides
+    //! explicit, deterministic traffic splitting where you control exactly how much
+    //! traffic each backend receives. This is distinct from `tower::balance` which
+    //! distributes load across equivalent backends.
+    //!
+    //! ## Selection Strategies
+    //!
+    //! - **Deterministic** (default): Atomic counter for predictable, repeatable distribution.
+    //!   Best for canary deployments where you want exact traffic ratios and debuggability.
+    //! - **Random**: Per-request weighted random selection. Better for high-volume
+    //!   statistical distribution, but shows variance at low traffic.
+    //!
+    //! ## Readiness
+    //!
+    //! All backends must be ready before the router accepts requests. This is the
+    //! simplest and most predictable contract. Pair each backend with a circuit
+    //! breaker so that failing backends resolve readiness quickly.
+    //!
+    //! ## Type Constraint
+    //!
+    //! All backends must share the same `Request`, `Response`, and `Error` types.
+    //! For canary deployments (same service, different version), this is natural.
+    //! When using `service_fn` with different closures, use `BoxService` to erase
+    //! the concrete types.
+    //!
+    //! ## Composition
+    //!
+    //! Put resilience middleware **inside** each backend, not around the router:
+    //!
+    //! ```text
+    //! WeightedRouter
+    //!   |-- Backend A (90%) -> [Circuit Breaker] -> [Timeout] -> Service v1
+    //!   |-- Backend B (10%) -> [Circuit Breaker] -> [Timeout] -> Service v2
+    //! ```
+    //!
+    //! This lets each backend fail independently. If the canary's circuit breaker
+    //! opens, only canary traffic is affected.
+    //!
+    //! ## Anti-patterns
+    //!
+    //! - **Wrapping the router in a circuit breaker**: This treats all backends as
+    //!   one unit. Put circuit breakers inside each backend instead.
+    //! - **Random selection at low traffic**: With 10% canary and 20 req/min, random
+    //!   selection could send 3+ consecutive requests to the canary. Use deterministic.
+    //! - **Heterogeneous service types**: If backends have different request/response
+    //!   types, you need an adaptation layer. The router assumes homogeneous types.
+    //!
+    //! ## Prior Art
+    //!
+    //! - **Envoy**: Weighted clusters with traffic shifting for canary deployments
+    //! - **Istio**: VirtualService with weighted routing rules
+    //! - **Linkerd**: Traffic split via TrafficSplit CRD
 }


### PR DESCRIPTION
Closes #241

## Summary

Adds `tower-resilience-router`, a new crate providing `WeightedRouter` -- a standalone `Service` that distributes requests across multiple backends based on configured weights.

This is a fundamentally different primitive from the existing resilience patterns: instead of wrapping a single service and modifying its behavior, it *selects among* multiple services. It lives in its own crate to make that distinction clear.

**Key design decisions (from [#241 discussion](https://github.com/joshrotenberg/tower-resilience/issues/241#issuecomment-4018090857)):**

- **Standalone Service, not a Layer** -- `WeightedRouter` is a `Service`, not a `Layer`. A Layer that needs multiple services injected at construction time bends Tower's mental model.
- **Deterministic selection by default** -- atomic counter for exact, predictable traffic ratios. Random is opt-in.
- **"All must be ready" readiness** -- simplest contract. Pair with circuit breakers per-backend for fast failure resolution.
- **Homogeneous service types** -- all backends share `Request`/`Response`/`Error`. Use `BoxService` when constructing from different closures.
- **Static weights for v1** -- no dynamic adjustment. Keep it simple.

## What's included

- `WeightedRouter<S>` service with builder API
- `SelectionStrategy` enum (Deterministic / Random)
- `WeightedSelector` with cumulative-weight binary search
- `RouterEvent` and event listener hooks
- Optional `metrics` and `tracing` feature flags
- Error types with `ResilienceError` flattening impls
- Pattern guide in umbrella crate docs
- Feature flag `router` in umbrella crate (included in `full`)
- 14 unit tests + 4 doc tests

## Usage

```rust
use tower::util::BoxService;
use tower_resilience_router::WeightedRouter;

let router = WeightedRouter::builder()
    .route(svc_v1, 90)  // 90% to primary
    .route(svc_v2, 10)  // 10% to canary
    .name("api-canary")
    .build();
```

## Test plan

- [x] 14 unit tests (deterministic distribution, random convergence, 3-backend, error propagation, events, panics)
- [x] 4 doc tests compile
- [x] Clippy clean (`--all-targets --all-features -D warnings`)
- [x] `cargo fmt` clean
- [x] Docs build without warnings