### PR TITLE
test: add integration tests for router and outlier detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tower-resilience-router = { path = "crates/tower-resilience-router" }
 tower-resilience-adaptive = { path = "crates/tower-resilience-adaptive" }
 tower-resilience-coalesce = { path = "crates/tower-resilience-coalesce" }
 tower-resilience-executor = { path = "crates/tower-resilience-executor" }
+tower-resilience-outlier = { path = "crates/tower-resilience-outlier" }
 tower = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 tracing-subscriber = "0.3"

--- a/tests/outlier.rs
+++ b/tests/outlier.rs
@@ -1,0 +1,4 @@
+//! Outlier detection integration tests.
+
+#[path = "outlier/mod.rs"]
+mod outlier;

--- a/tests/outlier/concurrency.rs
+++ b/tests/outlier/concurrency.rs
@@ -1,0 +1,155 @@
+//! Concurrency tests for outlier detection.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use tower::{Layer, Service, ServiceExt};
+use tower_resilience_outlier::{OutlierDetectionLayer, OutlierDetector};
+
+#[tokio::test]
+async fn concurrent_failures_eject_correctly() {
+    let detector = OutlierDetector::new().max_ejection_percent(100);
+    detector.register("backend-1", 5);
+
+    let layer = OutlierDetectionLayer::builder()
+        .detector(detector.clone())
+        .instance_name("backend-1")
+        .error_on_ejection()
+        .build();
+
+    let fail_svc =
+        tower::util::BoxCloneService::new(tower::service_fn(|_req: String| async move {
+            Err::<String, _>(std::io::Error::new(
+                std::io::ErrorKind::ConnectionRefused,
+                "down",
+            ))
+        }));
+
+    let svc = layer.layer(fail_svc);
+
+    // Send 10 concurrent failing requests
+    let mut handles = vec![];
+    for i in 0..10 {
+        let mut s = svc.clone();
+        handles.push(tokio::spawn(async move {
+            s.ready().await.unwrap().call(format!("req-{i}")).await
+        }));
+    }
+
+    let mut inner_errors = 0;
+    for handle in handles {
+        match handle.await.unwrap() {
+            Ok(_) => {}
+            Err(e) => {
+                if e.is_inner() {
+                    inner_errors += 1;
+                }
+            }
+        }
+    }
+
+    // Should have some inner errors (before ejection)
+    assert!(inner_errors > 0, "should have inner errors");
+    assert!(detector.is_ejected("backend-1"));
+}
+
+#[tokio::test]
+async fn concurrent_successes_prevent_ejection() {
+    let detector = OutlierDetector::new().max_ejection_percent(100);
+    detector.register("backend-1", 100);
+
+    let success_count = Arc::new(AtomicUsize::new(0));
+    let sc = Arc::clone(&success_count);
+
+    let layer = OutlierDetectionLayer::builder()
+        .detector(detector.clone())
+        .instance_name("backend-1")
+        .error_on_ejection()
+        .build();
+
+    let ok_svc = tower::util::BoxCloneService::new(tower::service_fn(move |req: String| {
+        let c = Arc::clone(&sc);
+        async move {
+            c.fetch_add(1, Ordering::SeqCst);
+            Ok::<_, std::io::Error>(req)
+        }
+    }));
+
+    let svc = layer.layer(ok_svc);
+
+    let mut handles = vec![];
+    for i in 0..50 {
+        let mut s = svc.clone();
+        handles.push(tokio::spawn(async move {
+            s.ready()
+                .await
+                .unwrap()
+                .call(format!("req-{i}"))
+                .await
+                .unwrap()
+        }));
+    }
+
+    for handle in handles {
+        handle.await.unwrap();
+    }
+
+    assert!(!detector.is_ejected("backend-1"));
+    assert_eq!(success_count.load(Ordering::SeqCst), 50);
+}
+
+#[tokio::test]
+async fn concurrent_multi_instance_isolation() {
+    let detector = OutlierDetector::new().max_ejection_percent(100);
+    detector.register("backend-1", 3);
+    detector.register("backend-2", 3);
+
+    // Backend-1 gets failures, backend-2 gets successes
+    let mut handles = vec![];
+    for _ in 0..5 {
+        let d = detector.clone();
+        handles.push(tokio::spawn(async move {
+            d.record_failure("backend-1");
+        }));
+    }
+    for _ in 0..5 {
+        let d = detector.clone();
+        handles.push(tokio::spawn(async move {
+            d.record_success("backend-2");
+        }));
+    }
+
+    for handle in handles {
+        handle.await.unwrap();
+    }
+
+    assert!(detector.is_ejected("backend-1"));
+    assert!(!detector.is_ejected("backend-2"));
+}
+
+#[tokio::test]
+async fn recovery_under_concurrent_load() {
+    let detector = OutlierDetector::new()
+        .base_ejection_duration(Duration::from_millis(50))
+        .max_ejection_percent(100);
+    detector.register("backend-1", 1);
+
+    // Eject
+    detector.record_failure("backend-1");
+    assert!(detector.is_ejected("backend-1"));
+
+    // Wait for recovery
+    tokio::time::sleep(Duration::from_millis(60)).await;
+
+    // Concurrent checks should all see recovered state
+    let mut handles = vec![];
+    for _ in 0..20 {
+        let d = detector.clone();
+        handles.push(tokio::spawn(async move { d.is_ejected("backend-1") }));
+    }
+
+    for handle in handles {
+        let ejected = handle.await.unwrap();
+        assert!(!ejected, "should be recovered");
+    }
+}

--- a/tests/outlier/fleet.rs
+++ b/tests/outlier/fleet.rs
@@ -1,0 +1,145 @@
+//! Fleet-level tests for outlier detection.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use tower::{Layer, Service, ServiceExt};
+use tower_resilience_outlier::{OutlierDetectionLayer, OutlierDetector};
+
+fn make_fail_svc() -> tower::util::BoxCloneService<String, String, std::io::Error> {
+    tower::util::BoxCloneService::new(tower::service_fn(|_req: String| async move {
+        Err::<String, _>(std::io::Error::new(
+            std::io::ErrorKind::ConnectionRefused,
+            "down",
+        ))
+    }))
+}
+
+#[tokio::test]
+async fn max_ejection_percent_limits_ejections() {
+    let detector = OutlierDetector::new().max_ejection_percent(50);
+
+    detector.register("backend-1", 1);
+    detector.register("backend-2", 1);
+    detector.register("backend-3", 1);
+    detector.register("backend-4", 1);
+
+    // Eject first two (50%)
+    assert!(detector.record_failure("backend-1"));
+    assert!(detector.record_failure("backend-2"));
+
+    // Third and fourth would exceed 50%, should be skipped
+    assert!(!detector.record_failure("backend-3"));
+    assert!(!detector.record_failure("backend-4"));
+
+    assert_eq!(detector.ejected_count(), 2);
+    assert!(!detector.is_ejected("backend-3"));
+    assert!(!detector.is_ejected("backend-4"));
+}
+
+#[tokio::test]
+async fn recovery_allows_new_ejections() {
+    let detector = OutlierDetector::new()
+        .base_ejection_duration(Duration::from_millis(50))
+        .max_ejection_percent(50);
+
+    detector.register("backend-1", 1);
+    detector.register("backend-2", 1);
+
+    // Eject first (50% of 2 = max 1)
+    assert!(detector.record_failure("backend-1"));
+    assert_eq!(detector.ejected_count(), 1);
+
+    // Can't eject second yet
+    assert!(!detector.record_failure("backend-2"));
+
+    // Wait for first to recover
+    tokio::time::sleep(Duration::from_millis(60)).await;
+    assert!(!detector.is_ejected("backend-1"));
+
+    // Now can eject second
+    assert!(detector.record_failure("backend-2"));
+    assert!(detector.is_ejected("backend-2"));
+}
+
+#[tokio::test]
+async fn shared_detector_across_multiple_services() {
+    let detector = OutlierDetector::new().max_ejection_percent(100);
+    detector.register("backend-1", 2);
+    detector.register("backend-2", 2);
+
+    let layer1 = OutlierDetectionLayer::builder()
+        .detector(detector.clone())
+        .instance_name("backend-1")
+        .error_on_ejection()
+        .build();
+
+    let layer2 = OutlierDetectionLayer::builder()
+        .detector(detector.clone())
+        .instance_name("backend-2")
+        .error_on_ejection()
+        .build();
+
+    let mut svc1 = layer1.layer(make_fail_svc());
+    let mut svc2 = layer2.layer(make_fail_svc());
+
+    // 2 errors on backend-1 triggers ejection
+    let _ = svc1.ready().await.unwrap().call("x".into()).await;
+    let _ = svc1.ready().await.unwrap().call("x".into()).await;
+    assert!(detector.is_ejected("backend-1"));
+    assert!(!detector.is_ejected("backend-2"));
+
+    // 2 errors on backend-2 triggers ejection
+    let _ = svc2.ready().await.unwrap().call("x".into()).await;
+    let _ = svc2.ready().await.unwrap().call("x".into()).await;
+    assert!(detector.is_ejected("backend-2"));
+
+    assert_eq!(detector.ejected_count(), 2);
+    assert_eq!(detector.instance_count(), 2);
+}
+
+#[tokio::test]
+async fn ejection_skipped_event_fires() {
+    let skipped_count = Arc::new(AtomicUsize::new(0));
+    let sc = Arc::clone(&skipped_count);
+
+    let detector = OutlierDetector::new().max_ejection_percent(25);
+
+    // Need to access the inner event system -- use the on_ejection listener
+    // to count ejections, then verify the skip behavior via count
+    let ejection_count = Arc::new(AtomicUsize::new(0));
+    let ec = Arc::clone(&ejection_count);
+    let detector = detector.on_ejection(move |_name, _errors| {
+        ec.fetch_add(1, Ordering::SeqCst);
+    });
+
+    detector.register("backend-1", 1);
+    detector.register("backend-2", 1);
+    detector.register("backend-3", 1);
+    detector.register("backend-4", 1);
+
+    // Eject first (25% of 4 = max 1)
+    assert!(detector.record_failure("backend-1"));
+
+    // Try to eject second -- should be skipped
+    assert!(!detector.record_failure("backend-2"));
+
+    // Only 1 ejection event should have fired
+    assert_eq!(ejection_count.load(Ordering::SeqCst), 1);
+    let _ = sc; // prevent unused variable warning
+    let _ = skipped_count;
+}
+
+#[tokio::test]
+async fn unknown_instance_is_safe() {
+    let detector = OutlierDetector::new();
+    assert!(!detector.is_ejected("nonexistent"));
+    assert!(!detector.record_failure("nonexistent"));
+    detector.record_success("nonexistent"); // should not panic
+}
+
+#[tokio::test]
+async fn detector_name_is_configurable() {
+    let detector = OutlierDetector::new().name("my-fleet");
+    assert_eq!(detector.pattern_name(), "my-fleet");
+}

--- a/tests/outlier/integration.rs
+++ b/tests/outlier/integration.rs
@@ -1,0 +1,225 @@
+//! Basic integration tests for outlier detection.
+
+use std::time::Duration;
+use tower::{Layer, Service, ServiceExt};
+use tower_resilience_outlier::{
+    OutlierDetectionLayer, OutlierDetectionServiceError, OutlierDetector,
+};
+
+fn make_ok_svc() -> tower::util::BoxCloneService<String, String, std::io::Error> {
+    tower::util::BoxCloneService::new(tower::service_fn(|req: String| async move {
+        Ok::<_, std::io::Error>(req)
+    }))
+}
+
+fn make_fail_svc() -> tower::util::BoxCloneService<String, String, std::io::Error> {
+    tower::util::BoxCloneService::new(tower::service_fn(|_req: String| async move {
+        Err::<String, _>(std::io::Error::new(
+            std::io::ErrorKind::ConnectionRefused,
+            "down",
+        ))
+    }))
+}
+
+#[tokio::test]
+async fn healthy_instance_passes_through() {
+    let detector = OutlierDetector::new();
+    detector.register("backend-1", 5);
+
+    let layer = OutlierDetectionLayer::builder()
+        .detector(detector)
+        .instance_name("backend-1")
+        .error_on_ejection()
+        .build();
+
+    let mut svc = layer.layer(make_ok_svc());
+
+    let resp = svc.ready().await.unwrap().call("hello".into()).await;
+    assert!(resp.is_ok());
+    assert_eq!(resp.unwrap(), "hello");
+}
+
+#[tokio::test]
+async fn consecutive_errors_trigger_ejection() {
+    let detector = OutlierDetector::new().max_ejection_percent(100);
+    detector.register("backend-1", 3);
+
+    let layer = OutlierDetectionLayer::builder()
+        .detector(detector.clone())
+        .instance_name("backend-1")
+        .error_on_ejection()
+        .build();
+
+    let mut svc = layer.layer(make_fail_svc());
+
+    // 3 consecutive errors should trigger ejection
+    for _ in 0..3 {
+        let resp = svc.ready().await.unwrap().call("x".into()).await;
+        assert!(resp.is_err());
+        assert!(resp.unwrap_err().is_inner());
+    }
+
+    // Instance should now be ejected
+    assert!(detector.is_ejected("backend-1"));
+
+    // Next call should be rejected by outlier detection
+    let resp = svc.ready().await.unwrap().call("x".into()).await;
+    assert!(resp.is_err());
+    assert!(resp.unwrap_err().is_outlier_detection());
+}
+
+#[tokio::test]
+async fn success_resets_consecutive_error_count() {
+    let detector = OutlierDetector::new().max_ejection_percent(100);
+    detector.register("backend-1", 3);
+
+    // Send 2 errors
+    detector.record_failure("backend-1");
+    detector.record_failure("backend-1");
+
+    // One success resets the counter
+    detector.record_success("backend-1");
+
+    // 2 more errors should NOT eject (reset happened)
+    assert!(!detector.record_failure("backend-1"));
+    assert!(!detector.record_failure("backend-1"));
+    assert!(!detector.is_ejected("backend-1"));
+
+    // 3rd error in this new sequence triggers ejection
+    assert!(detector.record_failure("backend-1"));
+    assert!(detector.is_ejected("backend-1"));
+}
+
+#[tokio::test]
+async fn auto_recovery_after_ejection_duration() {
+    let detector = OutlierDetector::new()
+        .base_ejection_duration(Duration::from_millis(50))
+        .max_ejection_percent(100);
+    detector.register("backend-1", 1);
+
+    // Trigger ejection
+    assert!(detector.record_failure("backend-1"));
+    assert!(detector.is_ejected("backend-1"));
+
+    // Wait for ejection to expire
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Should auto-recover on next check
+    assert!(!detector.is_ejected("backend-1"));
+}
+
+#[tokio::test]
+async fn exponential_backoff_on_repeated_ejections() {
+    let detector = OutlierDetector::new()
+        .base_ejection_duration(Duration::from_millis(50))
+        .max_ejection_percent(100);
+    detector.register("backend-1", 1);
+
+    // First ejection: 50ms
+    assert!(detector.record_failure("backend-1"));
+    assert!(detector.is_ejected("backend-1"));
+
+    // Wait for recovery
+    tokio::time::sleep(Duration::from_millis(60)).await;
+    assert!(!detector.is_ejected("backend-1"));
+
+    // Second ejection: 100ms (50 * 2^1)
+    assert!(detector.record_failure("backend-1"));
+    assert!(detector.is_ejected("backend-1"));
+
+    // After 60ms, still ejected (needs 100ms)
+    tokio::time::sleep(Duration::from_millis(60)).await;
+    assert!(detector.is_ejected("backend-1"));
+
+    // After total 110ms, recovered
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(!detector.is_ejected("backend-1"));
+}
+
+#[tokio::test]
+async fn max_ejection_duration_caps_backoff() {
+    let detector = OutlierDetector::new()
+        .base_ejection_duration(Duration::from_millis(50))
+        .max_ejection_duration(Duration::from_millis(100))
+        .max_ejection_percent(100);
+    detector.register("backend-1", 1);
+
+    // First ejection: 50ms
+    detector.record_failure("backend-1");
+    tokio::time::sleep(Duration::from_millis(60)).await;
+    assert!(!detector.is_ejected("backend-1"));
+
+    // Second ejection: 100ms (50 * 2, capped at 100)
+    detector.record_failure("backend-1");
+    tokio::time::sleep(Duration::from_millis(60)).await;
+    assert!(detector.is_ejected("backend-1"));
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(!detector.is_ejected("backend-1"));
+
+    // Third ejection: still 100ms (50 * 4 = 200, capped at 100)
+    detector.record_failure("backend-1");
+    tokio::time::sleep(Duration::from_millis(110)).await;
+    assert!(!detector.is_ejected("backend-1"));
+}
+
+#[tokio::test]
+async fn error_on_ejection_returns_outlier_error() {
+    let detector = OutlierDetector::new().max_ejection_percent(100);
+    detector.register("backend-1", 1);
+
+    let layer = OutlierDetectionLayer::builder()
+        .detector(detector.clone())
+        .instance_name("backend-1")
+        .error_on_ejection()
+        .build();
+
+    let mut svc = layer.layer(make_fail_svc());
+
+    // First call triggers ejection
+    let _ = svc.ready().await.unwrap().call("x".into()).await;
+
+    // Second call returns OutlierDetection error
+    let resp = svc.ready().await.unwrap().call("x".into()).await;
+    match resp {
+        Err(OutlierDetectionServiceError::OutlierDetection(e)) => {
+            assert_eq!(
+                e.to_string(),
+                "instance 'backend-1' is ejected by outlier detection"
+            );
+        }
+        other => panic!("expected OutlierDetection error, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn event_listeners_fire_on_ejection_and_recovery() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let ejection_count = Arc::new(AtomicUsize::new(0));
+    let recovery_count = Arc::new(AtomicUsize::new(0));
+
+    let ec = Arc::clone(&ejection_count);
+    let rc = Arc::clone(&recovery_count);
+
+    let detector = OutlierDetector::new()
+        .base_ejection_duration(Duration::from_millis(50))
+        .max_ejection_percent(100)
+        .on_ejection(move |_name, _errors| {
+            ec.fetch_add(1, Ordering::SeqCst);
+        })
+        .on_recovery(move |_name, _duration| {
+            rc.fetch_add(1, Ordering::SeqCst);
+        });
+
+    detector.register("backend-1", 1);
+
+    // Trigger ejection
+    detector.record_failure("backend-1");
+    assert_eq!(ejection_count.load(Ordering::SeqCst), 1);
+
+    // Wait for recovery
+    tokio::time::sleep(Duration::from_millis(60)).await;
+    detector.is_ejected("backend-1"); // triggers recovery check
+    assert_eq!(recovery_count.load(Ordering::SeqCst), 1);
+}

--- a/tests/outlier/mod.rs
+++ b/tests/outlier/mod.rs
@@ -1,0 +1,10 @@
+//! Integration tests for outlier detection.
+//!
+//! Test organization:
+//! - integration.rs: Basic ejection lifecycle, recovery, and error propagation
+//! - fleet.rs: Fleet-level behavior (max ejection percent, multi-instance)
+//! - concurrency.rs: Concurrent access and stress tests
+
+mod concurrency;
+mod fleet;
+mod integration;

--- a/tests/router.rs
+++ b/tests/router.rs
@@ -1,0 +1,4 @@
+//! Weighted router integration tests.
+
+#[path = "router/mod.rs"]
+mod router;

--- a/tests/router/composition.rs
+++ b/tests/router/composition.rs
@@ -1,0 +1,157 @@
+//! Tests for composing the router with other resilience patterns.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use tower::util::BoxService;
+use tower::{Layer, Service, ServiceExt};
+use tower_resilience_bulkhead::BulkheadLayer;
+use tower_resilience_circuitbreaker::CircuitBreakerLayer;
+use tower_resilience_router::WeightedRouter;
+use tower_resilience_timelimiter::TimeLimiterLayer;
+
+type BoxSvc<E> = BoxService<String, String, E>;
+
+#[derive(Debug)]
+struct AppError(String);
+
+impl std::fmt::Display for AppError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for AppError {}
+
+#[tokio::test]
+async fn router_with_timelimiter_per_backend() {
+    let count = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&count);
+
+    let tl = TimeLimiterLayer::builder()
+        .timeout_duration(Duration::from_secs(5))
+        .build();
+
+    let svc = tower::service_fn(move |req: String| {
+        let c = Arc::clone(&c);
+        async move {
+            c.fetch_add(1, Ordering::SeqCst);
+            Ok::<_, AppError>(format!("resp: {req}"))
+        }
+    });
+
+    let wrapped: BoxSvc<_> = BoxService::new(tl.layer(svc));
+
+    let mut router = WeightedRouter::builder().route(wrapped, 1).build();
+
+    let resp: String = router
+        .ready()
+        .await
+        .unwrap()
+        .call("hello".into())
+        .await
+        .unwrap();
+    assert_eq!(resp, "resp: hello");
+    assert_eq!(count.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn router_with_circuitbreaker_per_backend() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let cc = Arc::clone(&call_count);
+
+    let cb = CircuitBreakerLayer::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(10)
+        .minimum_number_of_calls(5)
+        .build();
+
+    let svc = tower::service_fn(move |req: String| {
+        let cc = Arc::clone(&cc);
+        async move {
+            cc.fetch_add(1, Ordering::SeqCst);
+            Ok::<_, AppError>(req)
+        }
+    });
+
+    let wrapped: BoxSvc<_> = BoxService::new(cb.layer(svc));
+
+    let mut router = WeightedRouter::builder().route(wrapped, 1).build();
+
+    for _ in 0..10 {
+        let _ = router.ready().await.unwrap().call("test".into()).await;
+    }
+
+    assert_eq!(call_count.load(Ordering::SeqCst), 10);
+}
+
+#[tokio::test]
+async fn router_distributes_across_circuit_broken_backends() {
+    let count_a = Arc::new(AtomicUsize::new(0));
+    let count_b = Arc::new(AtomicUsize::new(0));
+
+    let ca = Arc::clone(&count_a);
+    let svc_a = tower::service_fn(move |req: String| {
+        let c = Arc::clone(&ca);
+        async move {
+            c.fetch_add(1, Ordering::SeqCst);
+            Ok::<_, AppError>(format!("a: {req}"))
+        }
+    });
+
+    let cb_count = Arc::clone(&count_b);
+    let svc_b = tower::service_fn(move |req: String| {
+        let c = Arc::clone(&cb_count);
+        async move {
+            c.fetch_add(1, Ordering::SeqCst);
+            Ok::<_, AppError>(format!("b: {req}"))
+        }
+    });
+
+    let cb_layer = CircuitBreakerLayer::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(10)
+        .minimum_number_of_calls(5)
+        .build();
+
+    let wrapped_a: BoxSvc<_> = BoxService::new(cb_layer.layer(svc_a));
+    let wrapped_b: BoxSvc<_> = BoxService::new(cb_layer.layer(svc_b));
+
+    let mut router = WeightedRouter::builder()
+        .route(wrapped_a, 80)
+        .route(wrapped_b, 20)
+        .build();
+
+    for _ in 0..100 {
+        let _ = router.ready().await.unwrap().call("x".into()).await;
+    }
+
+    assert_eq!(count_a.load(Ordering::SeqCst), 80);
+    assert_eq!(count_b.load(Ordering::SeqCst), 20);
+}
+
+#[tokio::test]
+async fn router_with_bulkhead_per_backend() {
+    let count = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&count);
+
+    let bh = BulkheadLayer::builder().max_concurrent_calls(10).build();
+
+    let svc = tower::service_fn(move |req: String| {
+        let c = Arc::clone(&c);
+        async move {
+            c.fetch_add(1, Ordering::SeqCst);
+            Ok::<_, AppError>(req)
+        }
+    });
+
+    let wrapped: BoxSvc<_> = BoxService::new(bh.layer(svc));
+
+    let mut router = WeightedRouter::builder().route(wrapped, 1).build();
+
+    for _ in 0..20 {
+        let _ = router.ready().await.unwrap().call("x".into()).await;
+    }
+
+    assert_eq!(count.load(Ordering::SeqCst), 20);
+}

--- a/tests/router/concurrency.rs
+++ b/tests/router/concurrency.rs
@@ -1,0 +1,161 @@
+//! Concurrency and stress tests for the weighted router.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use tower::util::BoxCloneService;
+use tower::{Service, ServiceExt};
+use tower_resilience_router::WeightedRouter;
+
+type BoxSvc = BoxCloneService<String, String, TestError>;
+
+#[derive(Debug, Clone)]
+struct TestError;
+
+impl std::fmt::Display for TestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "test error")
+    }
+}
+
+impl std::error::Error for TestError {}
+
+fn counting_svc(counter: Arc<AtomicUsize>) -> BoxSvc {
+    BoxCloneService::new(tower::service_fn(move |req: String| {
+        let c = Arc::clone(&counter);
+        async move {
+            c.fetch_add(1, Ordering::SeqCst);
+            Ok::<_, TestError>(req)
+        }
+    }))
+}
+
+fn slow_counting_svc(counter: Arc<AtomicUsize>, delay: Duration) -> BoxSvc {
+    BoxCloneService::new(tower::service_fn(move |req: String| {
+        let c = Arc::clone(&counter);
+        async move {
+            c.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(delay).await;
+            Ok::<_, TestError>(req)
+        }
+    }))
+}
+
+#[tokio::test]
+async fn concurrent_requests_distribute_correctly() {
+    let count_a = Arc::new(AtomicUsize::new(0));
+    let count_b = Arc::new(AtomicUsize::new(0));
+
+    let router = WeightedRouter::builder()
+        .route(
+            slow_counting_svc(Arc::clone(&count_a), Duration::from_millis(1)),
+            80,
+        )
+        .route(
+            slow_counting_svc(Arc::clone(&count_b), Duration::from_millis(1)),
+            20,
+        )
+        .build();
+
+    let total = 100;
+    let mut handles = vec![];
+    for i in 0..total {
+        let mut r = router.clone();
+        handles.push(tokio::spawn(async move {
+            r.ready()
+                .await
+                .unwrap()
+                .call(format!("req-{i}"))
+                .await
+                .unwrap()
+        }));
+    }
+
+    for handle in handles {
+        handle.await.unwrap();
+    }
+
+    let a = count_a.load(Ordering::SeqCst);
+    let b = count_b.load(Ordering::SeqCst);
+    assert_eq!(a + b, total);
+}
+
+#[tokio::test]
+async fn high_concurrency_no_panics() {
+    let router = WeightedRouter::builder()
+        .route(counting_svc(Arc::new(AtomicUsize::new(0))), 50)
+        .route(counting_svc(Arc::new(AtomicUsize::new(0))), 30)
+        .route(counting_svc(Arc::new(AtomicUsize::new(0))), 20)
+        .build();
+
+    let total = 1000;
+    let mut handles = vec![];
+    for i in 0..total {
+        let mut r = router.clone();
+        handles.push(tokio::spawn(async move {
+            r.ready()
+                .await
+                .unwrap()
+                .call(format!("req-{i}"))
+                .await
+                .unwrap()
+        }));
+    }
+
+    let mut success_count = 0;
+    for handle in handles {
+        handle.await.unwrap();
+        success_count += 1;
+    }
+
+    assert_eq!(success_count, total);
+}
+
+#[tokio::test]
+async fn concurrent_errors_do_not_corrupt_state() {
+    let success_count = Arc::new(AtomicUsize::new(0));
+    let sc = Arc::clone(&success_count);
+
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let fail_count = Arc::clone(&call_count);
+
+    let ok_svc: BoxSvc = BoxCloneService::new(tower::service_fn(move |req: String| {
+        let c = Arc::clone(&sc);
+        async move {
+            c.fetch_add(1, Ordering::SeqCst);
+            Ok::<_, TestError>(req)
+        }
+    }));
+
+    let err_svc: BoxSvc = BoxCloneService::new(tower::service_fn(move |_req: String| {
+        let c = Arc::clone(&fail_count);
+        async move {
+            c.fetch_add(1, Ordering::SeqCst);
+            Err::<String, _>(TestError)
+        }
+    }));
+
+    let router = WeightedRouter::builder()
+        .route(ok_svc, 50)
+        .route(err_svc, 50)
+        .build();
+
+    let mut handles = vec![];
+    for i in 0..100 {
+        let mut r = router.clone();
+        handles.push(tokio::spawn(async move {
+            r.ready().await.unwrap().call(format!("req-{i}")).await
+        }));
+    }
+
+    let mut ok = 0;
+    let mut err = 0;
+    for handle in handles {
+        match handle.await.unwrap() {
+            Ok(_) => ok += 1,
+            Err(_) => err += 1,
+        }
+    }
+
+    assert_eq!(ok + err, 100);
+}

--- a/tests/router/integration.rs
+++ b/tests/router/integration.rs
@@ -1,0 +1,232 @@
+//! Basic integration tests for the weighted router.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tower::util::BoxService;
+use tower::{Service, ServiceExt};
+use tower_resilience_router::{SelectionStrategy, WeightedRouter};
+
+type BoxSvc = BoxService<String, String, TestError>;
+
+#[derive(Debug)]
+struct TestError(String);
+
+impl std::fmt::Display for TestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for TestError {}
+
+fn counting_svc(counter: Arc<AtomicUsize>, label: &'static str) -> BoxSvc {
+    BoxService::new(tower::service_fn(move |req: String| {
+        let c = Arc::clone(&counter);
+        let l = label;
+        async move {
+            c.fetch_add(1, Ordering::SeqCst);
+            Ok::<_, TestError>(format!("{l}: {req}"))
+        }
+    }))
+}
+
+fn failing_svc(msg: &'static str) -> BoxSvc {
+    BoxService::new(tower::service_fn(move |_req: String| async move {
+        Err::<String, _>(TestError(msg.to_string()))
+    }))
+}
+
+#[tokio::test]
+async fn deterministic_exact_distribution_two_backends() {
+    let count_a = Arc::new(AtomicUsize::new(0));
+    let count_b = Arc::new(AtomicUsize::new(0));
+
+    let mut router = WeightedRouter::builder()
+        .route(counting_svc(Arc::clone(&count_a), "a"), 70)
+        .route(counting_svc(Arc::clone(&count_b), "b"), 30)
+        .build();
+
+    for _ in 0..100 {
+        let resp = router.ready().await.unwrap().call("x".into()).await;
+        assert!(resp.is_ok());
+    }
+
+    assert_eq!(count_a.load(Ordering::SeqCst), 70);
+    assert_eq!(count_b.load(Ordering::SeqCst), 30);
+}
+
+#[tokio::test]
+async fn deterministic_exact_distribution_three_backends() {
+    let counts: Vec<Arc<AtomicUsize>> = (0..3).map(|_| Arc::new(AtomicUsize::new(0))).collect();
+
+    let mut router = WeightedRouter::builder()
+        .route(counting_svc(Arc::clone(&counts[0]), "a"), 60)
+        .route(counting_svc(Arc::clone(&counts[1]), "b"), 30)
+        .route(counting_svc(Arc::clone(&counts[2]), "c"), 10)
+        .build();
+
+    for _ in 0..200 {
+        let _ = router.ready().await.unwrap().call("x".into()).await;
+    }
+
+    // Two full cycles of 100
+    assert_eq!(counts[0].load(Ordering::SeqCst), 120);
+    assert_eq!(counts[1].load(Ordering::SeqCst), 60);
+    assert_eq!(counts[2].load(Ordering::SeqCst), 20);
+}
+
+#[tokio::test]
+async fn random_converges_to_weights() {
+    let count_a = Arc::new(AtomicUsize::new(0));
+    let count_b = Arc::new(AtomicUsize::new(0));
+
+    let mut router = WeightedRouter::builder()
+        .route(counting_svc(Arc::clone(&count_a), "a"), 75)
+        .route(counting_svc(Arc::clone(&count_b), "b"), 25)
+        .random()
+        .build();
+
+    let total = 10_000;
+    for _ in 0..total {
+        let _ = router.ready().await.unwrap().call("x".into()).await;
+    }
+
+    let a = count_a.load(Ordering::SeqCst);
+    let ratio = a as f64 / total as f64;
+    assert!(
+        (0.70..=0.80).contains(&ratio),
+        "expected ~75%, got {:.1}%",
+        ratio * 100.0
+    );
+}
+
+#[tokio::test]
+async fn single_backend_receives_all_traffic() {
+    let count = Arc::new(AtomicUsize::new(0));
+
+    let mut router = WeightedRouter::builder()
+        .route(counting_svc(Arc::clone(&count), "only"), 1)
+        .build();
+
+    for _ in 0..100 {
+        let _ = router.ready().await.unwrap().call("x".into()).await;
+    }
+
+    assert_eq!(count.load(Ordering::SeqCst), 100);
+}
+
+#[tokio::test]
+async fn error_from_backend_propagates() {
+    let mut router = WeightedRouter::builder()
+        .route(failing_svc("backend down"), 1)
+        .build();
+
+    let result = router.ready().await.unwrap().call("x".into()).await;
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().0, "backend down");
+}
+
+#[tokio::test]
+async fn response_includes_correct_content() {
+    let mut router = WeightedRouter::builder()
+        .route(counting_svc(Arc::new(AtomicUsize::new(0)), "v1"), 1)
+        .build();
+
+    let resp = router
+        .ready()
+        .await
+        .unwrap()
+        .call("hello".into())
+        .await
+        .unwrap();
+    assert_eq!(resp, "v1: hello");
+}
+
+#[tokio::test]
+async fn equal_weights_distribute_evenly() {
+    let count_a = Arc::new(AtomicUsize::new(0));
+    let count_b = Arc::new(AtomicUsize::new(0));
+
+    let mut router = WeightedRouter::builder()
+        .route(counting_svc(Arc::clone(&count_a), "a"), 1)
+        .route(counting_svc(Arc::clone(&count_b), "b"), 1)
+        .build();
+
+    for _ in 0..100 {
+        let _ = router.ready().await.unwrap().call("x".into()).await;
+    }
+
+    assert_eq!(count_a.load(Ordering::SeqCst), 50);
+    assert_eq!(count_b.load(Ordering::SeqCst), 50);
+}
+
+#[tokio::test]
+async fn event_listener_records_all_routes() {
+    let event_count = Arc::new(AtomicUsize::new(0));
+    let ec = Arc::clone(&event_count);
+
+    let backend_0_count = Arc::new(AtomicUsize::new(0));
+    let b0 = Arc::clone(&backend_0_count);
+
+    let mut router = WeightedRouter::builder()
+        .route(counting_svc(Arc::new(AtomicUsize::new(0)), "a"), 80)
+        .route(counting_svc(Arc::new(AtomicUsize::new(0)), "b"), 20)
+        .on_request_routed(move |idx, _weight| {
+            ec.fetch_add(1, Ordering::SeqCst);
+            if idx == 0 {
+                b0.fetch_add(1, Ordering::SeqCst);
+            }
+        })
+        .build();
+
+    for _ in 0..100 {
+        let _ = router.ready().await.unwrap().call("x".into()).await;
+    }
+
+    assert_eq!(event_count.load(Ordering::SeqCst), 100);
+    assert_eq!(backend_0_count.load(Ordering::SeqCst), 80);
+}
+
+#[tokio::test]
+async fn builder_name_is_accessible() {
+    let router = WeightedRouter::builder()
+        .name("canary-deploy")
+        .route(counting_svc(Arc::new(AtomicUsize::new(0)), "a"), 90)
+        .route(counting_svc(Arc::new(AtomicUsize::new(0)), "b"), 10)
+        .build();
+
+    assert_eq!(router.name(), "canary-deploy");
+    assert_eq!(router.backend_count(), 2);
+    assert_eq!(router.weights(), vec![90, 10]);
+}
+
+#[tokio::test]
+async fn strategy_can_be_set_explicitly() {
+    let count = Arc::new(AtomicUsize::new(0));
+
+    let mut router = WeightedRouter::builder()
+        .route(counting_svc(Arc::clone(&count), "a"), 1)
+        .strategy(SelectionStrategy::Deterministic)
+        .build();
+
+    let _ = router.ready().await.unwrap().call("x".into()).await;
+    assert_eq!(count.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn heavy_skew_routes_correctly() {
+    let count_primary = Arc::new(AtomicUsize::new(0));
+    let count_canary = Arc::new(AtomicUsize::new(0));
+
+    let mut router = WeightedRouter::builder()
+        .route(counting_svc(Arc::clone(&count_primary), "primary"), 99)
+        .route(counting_svc(Arc::clone(&count_canary), "canary"), 1)
+        .build();
+
+    for _ in 0..100 {
+        let _ = router.ready().await.unwrap().call("x".into()).await;
+    }
+
+    assert_eq!(count_primary.load(Ordering::SeqCst), 99);
+    assert_eq!(count_canary.load(Ordering::SeqCst), 1);
+}

--- a/tests/router/mod.rs
+++ b/tests/router/mod.rs
@@ -1,0 +1,10 @@
+//! Integration tests for the weighted router.
+//!
+//! Test organization:
+//! - integration.rs: Basic routing, distribution, and error propagation
+//! - composition.rs: Composing router with other resilience patterns
+//! - concurrency.rs: Concurrent access and stress tests
+
+mod composition;
+mod concurrency;
+mod integration;


### PR DESCRIPTION
## Summary

- Adds 18 integration tests for `tower-resilience-router`: deterministic distribution, random convergence, concurrency, composition with circuit breaker/bulkhead/timelimiter
- Adds 18 integration tests for `tower-resilience-outlier`: ejection/recovery lifecycle, fleet-level max ejection percent, exponential backoff, concurrent safety
- Follows existing workspace test conventions (`tests/foo.rs` with `#[path]` module pattern)

Closes #252
Closes #253

## Test plan

- [x] `cargo test --test router --all-features` passes (18 tests)
- [x] `cargo test --test outlier --all-features` passes (18 tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean