### PR TITLE
docs: add examples for router and outlier detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tower-resilience-router = { path = "crates/tower-resilience-router" }
 tower-resilience-adaptive = { path = "crates/tower-resilience-adaptive" }
 tower-resilience-coalesce = { path = "crates/tower-resilience-coalesce" }
 tower-resilience-executor = { path = "crates/tower-resilience-executor" }
+tower-resilience-outlier = { path = "crates/tower-resilience-outlier" }
 tower = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 tracing-subscriber = "0.3"

--- a/examples/outlier.rs
+++ b/examples/outlier.rs
@@ -1,0 +1,127 @@
+//! Outlier detection example demonstrating fleet-aware instance ejection.
+//! Run with: cargo run --example outlier
+
+use std::time::Duration;
+use tower::{Layer, Service, ServiceExt};
+use tower_resilience_outlier::{OutlierDetectionLayer, OutlierDetector};
+
+#[tokio::main]
+async fn main() {
+    println!("=== Outlier Detection: Fleet-Aware Ejection ===\n");
+
+    // Create a shared detector for the fleet
+    let detector = OutlierDetector::new()
+        .name("my-fleet")
+        .base_ejection_duration(Duration::from_secs(1))
+        .max_ejection_percent(50)
+        .on_ejection(|name, errors| {
+            println!(
+                "  [EJECTED] Instance '{}' ejected after {} consecutive errors",
+                name, errors
+            );
+        })
+        .on_recovery(|name, duration: Duration| {
+            println!(
+                "  [RECOVERED] Instance '{}' recovered after {:.1}s",
+                name,
+                duration.as_secs_f64()
+            );
+        });
+
+    // Register 3 backends: eject after 3 consecutive errors
+    detector.register("backend-1", 3);
+    detector.register("backend-2", 3);
+    detector.register("backend-3", 3);
+
+    println!(
+        "Fleet '{}' with {} instances registered\n",
+        detector.pattern_name(),
+        detector.instance_count()
+    );
+
+    // --- Healthy instance passes through ---
+    println!("--- Healthy Instance ---");
+
+    let layer = OutlierDetectionLayer::builder()
+        .detector(detector.clone())
+        .instance_name("backend-1")
+        .error_on_ejection()
+        .build();
+
+    let ok_svc = tower::util::BoxCloneService::new(tower::service_fn(|req: String| async move {
+        Ok::<_, std::io::Error>(format!("OK: {}", req))
+    }));
+    let mut svc = layer.layer(ok_svc);
+
+    let resp = svc.ready().await.unwrap().call("hello".into()).await;
+    println!("Response: {:?}", resp);
+    println!("backend-1 ejected? {}\n", detector.is_ejected("backend-1"));
+
+    // --- Consecutive errors trigger ejection ---
+    println!("--- Triggering Ejection on backend-2 ---");
+
+    let layer2 = OutlierDetectionLayer::builder()
+        .detector(detector.clone())
+        .instance_name("backend-2")
+        .error_on_ejection()
+        .build();
+
+    let fail_svc =
+        tower::util::BoxCloneService::new(tower::service_fn(|_req: String| async move {
+            Err::<String, _>(std::io::Error::new(
+                std::io::ErrorKind::ConnectionRefused,
+                "connection refused",
+            ))
+        }));
+    let mut svc2 = layer2.layer(fail_svc);
+
+    for i in 1..=4 {
+        let resp = svc2.ready().await.unwrap().call(format!("req-{}", i)).await;
+        match &resp {
+            Ok(v) => println!("  Call {}: Ok({})", i, v),
+            Err(e) => println!("  Call {}: Err({})", i, e),
+        }
+    }
+
+    println!("\nbackend-2 ejected? {}", detector.is_ejected("backend-2"));
+    println!(
+        "Ejected count: {}/{}\n",
+        detector.ejected_count(),
+        detector.instance_count()
+    );
+
+    // --- Max ejection percent prevents cascading ejections ---
+    println!("--- Max Ejection Percent (50%) ---");
+    println!("Trying to eject backend-3 (would exceed 50% threshold)...");
+
+    // Simulate 3 consecutive failures on backend-3
+    for _ in 0..3 {
+        detector.record_failure("backend-3");
+    }
+    println!(
+        "backend-3 ejected? {} (should be false - would exceed 50%)",
+        detector.is_ejected("backend-3")
+    );
+    println!(
+        "Ejected count: {}/{}\n",
+        detector.ejected_count(),
+        detector.instance_count()
+    );
+
+    // --- Auto-recovery after ejection duration ---
+    println!("--- Auto Recovery ---");
+    println!("Waiting for backend-2 to recover (1s ejection duration)...");
+    tokio::time::sleep(Duration::from_millis(1100)).await;
+
+    println!(
+        "backend-2 ejected? {} (should be false after recovery)",
+        detector.is_ejected("backend-2")
+    );
+    println!(
+        "Ejected count: {}/{}",
+        detector.ejected_count(),
+        detector.instance_count()
+    );
+
+    println!("\nDone!");
+}

--- a/examples/router.rs
+++ b/examples/router.rs
@@ -1,0 +1,98 @@
+//! Weighted router example demonstrating canary deployment traffic splitting.
+//! Run with: cargo run --example router
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tower::util::BoxService;
+use tower::{Service, ServiceExt};
+use tower_resilience_router::WeightedRouter;
+
+type BoxSvc = BoxService<String, String, std::io::Error>;
+
+fn make_backend(name: &'static str, counter: Arc<AtomicUsize>) -> BoxSvc {
+    BoxService::new(tower::service_fn(move |req: String| {
+        let c = Arc::clone(&counter);
+        async move {
+            c.fetch_add(1, Ordering::SeqCst);
+            Ok::<_, std::io::Error>(format!("[{}] processed: {}", name, req))
+        }
+    }))
+}
+
+#[tokio::main]
+async fn main() {
+    println!("=== Weighted Router: Canary Deployment ===\n");
+
+    // Track how many requests each backend handles
+    let stable_count = Arc::new(AtomicUsize::new(0));
+    let canary_count = Arc::new(AtomicUsize::new(0));
+
+    // Route 90% of traffic to stable, 10% to canary
+    let mut router = WeightedRouter::builder()
+        .name("canary-deploy")
+        .route(make_backend("stable-v1", Arc::clone(&stable_count)), 90)
+        .route(make_backend("canary-v2", Arc::clone(&canary_count)), 10)
+        .on_request_routed(|idx, weight| {
+            let label = if idx == 0 { "stable" } else { "canary" };
+            println!(
+                "  [ROUTER] Routed to {} (index={}, weight={})",
+                label, idx, weight
+            );
+        })
+        .build();
+
+    println!(
+        "Router '{}' configured with {} backends, weights: {:?}\n",
+        router.name(),
+        router.backend_count(),
+        router.weights()
+    );
+
+    // Send 20 requests
+    println!("Sending 20 requests...\n");
+    for i in 1..=20 {
+        let resp = router
+            .ready()
+            .await
+            .unwrap()
+            .call(format!("request-{}", i))
+            .await
+            .unwrap();
+        println!("  Response: {}", resp);
+    }
+
+    let stable = stable_count.load(Ordering::SeqCst);
+    let canary = canary_count.load(Ordering::SeqCst);
+    println!("\n--- Results ---");
+    println!("Stable handled: {} (expected 18)", stable);
+    println!("Canary handled: {} (expected 2)", canary);
+    println!("Total: {}", stable + canary);
+
+    // Demonstrate random strategy
+    println!("\n=== Random Strategy ===\n");
+
+    let stable_count2 = Arc::new(AtomicUsize::new(0));
+    let canary_count2 = Arc::new(AtomicUsize::new(0));
+
+    let mut router = WeightedRouter::builder()
+        .name("random-canary")
+        .route(make_backend("stable-v1", Arc::clone(&stable_count2)), 80)
+        .route(make_backend("canary-v2", Arc::clone(&canary_count2)), 20)
+        .random()
+        .build();
+
+    for i in 1..=1000 {
+        let _ = router
+            .ready()
+            .await
+            .unwrap()
+            .call(format!("req-{}", i))
+            .await;
+    }
+
+    let stable = stable_count2.load(Ordering::SeqCst);
+    let canary = canary_count2.load(Ordering::SeqCst);
+    println!("After 1000 requests with random strategy (80/20 weights):");
+    println!("  Stable: {} ({:.1}%)", stable, stable as f64 / 10.0);
+    println!("  Canary: {} ({:.1}%)", canary, canary as f64 / 10.0);
+}


### PR DESCRIPTION
## Summary

- Adds `examples/router.rs`: demonstrates canary deployment with weighted routing (deterministic + random strategies), event listeners, builder accessors
- Adds `examples/outlier.rs`: demonstrates fleet-aware outlier detection with ejection, max ejection percent limiting, and auto-recovery
- Adds `tower-resilience-outlier` to root dependencies (needed for examples)

Closes #254
Closes #255

## Test plan

- [x] `cargo run --example router` runs successfully
- [x] `cargo run --example outlier` runs successfully
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean