### PR TITLE
docs: add doc comments to pub mod declarations

### DIFF
--- a/crates/tower-resilience-bulkhead/src/lib.rs
+++ b/crates/tower-resilience-bulkhead/src/lib.rs
@@ -253,10 +253,15 @@
 //! # }
 //! ```
 
+/// Configuration types for the bulkhead pattern.
 pub mod config;
+/// Error types for bulkhead rejections.
 pub mod error;
+/// Event types emitted by the bulkhead.
 pub mod events;
+/// Tower `Layer` implementation for the bulkhead.
 pub mod layer;
+/// Tower `Service` implementation for the bulkhead.
 pub mod service;
 
 pub use config::{BulkheadConfig, BulkheadConfigBuilder};

--- a/crates/tower-resilience-chaos/src/lib.rs
+++ b/crates/tower-resilience-chaos/src/lib.rs
@@ -187,9 +187,13 @@
 //! # }
 //! ```
 
+/// Configuration types for chaos injection.
 pub mod config;
+/// Event types emitted by chaos injection.
 pub mod events;
+/// Tower `Layer` implementation for chaos injection.
 pub mod layer;
+/// Tower `Service` implementation for chaos injection.
 pub mod service;
 
 pub use config::{

--- a/crates/tower-resilience-circuitbreaker/src/lib.rs
+++ b/crates/tower-resilience-circuitbreaker/src/lib.rs
@@ -310,6 +310,7 @@ pub use events::CircuitBreakerEvent;
 pub use layer::CircuitBreakerLayer;
 
 mod circuit;
+/// Custom failure classifiers for circuit breaker evaluation.
 pub mod classifier;
 mod config;
 mod error;

--- a/crates/tower-resilience-core/src/lib.rs
+++ b/crates/tower-resilience-core/src/lib.rs
@@ -9,14 +9,20 @@
 //! - AIMD controller for congestion control
 //! - Health integration traits for proactive resilience
 
+/// AIMD (Additive Increase / Multiplicative Decrease) controller.
 pub mod aimd;
+/// Failure classification traits and default implementations.
 pub mod classifier;
+/// Common error types for resilience patterns.
 pub mod error;
+/// Event system for resilience pattern observability.
 pub mod events;
 
+/// Unified error layer for composing resilience middleware.
 #[cfg(feature = "layer")]
 pub mod error_layer;
 
+/// Health integration traits for proactive resilience.
 #[cfg(feature = "health-integration")]
 pub mod health_integration;
 

--- a/crates/tower-resilience-outlier/src/lib.rs
+++ b/crates/tower-resilience-outlier/src/lib.rs
@@ -60,12 +60,19 @@
 //!     .build();
 //! ```
 
+/// Configuration types for outlier detection.
 pub mod config;
+/// Shared fleet-level outlier detector state.
 pub mod detector;
+/// Error types for outlier detection.
 pub mod error;
+/// Event types emitted by outlier detection.
 pub mod events;
+/// Tower `Layer` implementation for outlier detection.
 pub mod layer;
+/// Tower `Service` implementation for outlier detection.
 pub mod service;
+/// Ejection strategies (e.g., consecutive errors).
 pub mod strategy;
 
 pub use config::{OutlierDetectionConfig, OutlierDetectionConfigBuilder};

--- a/crates/tower-resilience-router/src/lib.rs
+++ b/crates/tower-resilience-router/src/lib.rs
@@ -78,9 +78,13 @@
 //! //     .build();
 //! ```
 
+/// Configuration and builder types for the weighted router.
 pub mod config;
+/// Error types for routing failures.
 pub mod error;
+/// Event types emitted when requests are routed.
 pub mod events;
+/// Backend selection strategies (deterministic, random).
 pub mod selection;
 
 pub use config::WeightedRouterBuilder;


### PR DESCRIPTION
## Summary

- Adds one-line `///` doc comments to all bare `pub mod` declarations across 6 crates:
  - `tower-resilience-outlier` (7 modules)
  - `tower-resilience-bulkhead` (5 modules)
  - `tower-resilience-router` (4 modules)
  - `tower-resilience-core` (6 modules, including cfg-gated ones)
  - `tower-resilience-chaos` (4 modules)
  - `tower-resilience-circuitbreaker` (1 module)

Closes #256

## Test plan

- [x] `cargo doc --no-deps --all-features` builds without warnings
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean