### PR TITLE
chore: release v0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 metrics = []
 
 [dependencies]
-tower-resilience-core = { version = "0.8.0", path = "crates/tower-resilience-core", features = ["layer"] }
+tower-resilience-core = { version = "0.9.0", path = "crates/tower-resilience-core", features = ["layer"] }
 tower-resilience-circuitbreaker = { path = "crates/tower-resilience-circuitbreaker", features = ["metrics", "tracing"] }
 tower-resilience-bulkhead = { path = "crates/tower-resilience-bulkhead", features = ["metrics"] }
 tower-resilience-cache = { path = "crates/tower-resilience-cache", features = ["metrics"] }
@@ -76,7 +76,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/joshrotenberg/tower-resilience"
@@ -97,7 +97,7 @@ serde = { version = "1.0", features = ["derive"] }
 pin-project-lite = "0.2"
 proptest = "1.6"
 
-tower-resilience-core = { version = "0.8.0", path = "crates/tower-resilience-core" }
+tower-resilience-core = { version = "0.9.0", path = "crates/tower-resilience-core" }
 
 [workspace.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Resilience patterns for [Tower](https://docs.rs/tower) services, inspired by [Re
 
 ```toml
 [dependencies]
-tower-resilience = "0.7"
+tower-resilience = "0.9"
 tower = "0.5"
 ```
 
@@ -493,6 +493,43 @@ Key features:
 - **Backpressure mode** (default): `poll_ready` returns `Pending` for ejected instances, integrating naturally with Tower load balancers
 - **Fleet protection**: `max_ejection_percent` prevents cascading ejections
 - **Exponential backoff**: Repeatedly-ejected instances stay out longer
+
+### Router
+
+Weighted traffic routing for canary deployments and progressive rollout:
+
+```rust
+use tower::util::BoxService;
+use tower_resilience::router::WeightedRouter;
+
+// Route 90% to stable, 10% to canary
+let svc_v1: BoxService<String, String, MyError> =
+    BoxService::new(tower::service_fn(|req: String| async move {
+        Ok(format!("v1: {}", req))
+    }));
+let svc_v2: BoxService<String, String, MyError> =
+    BoxService::new(tower::service_fn(|req: String| async move {
+        Ok(format!("v2: {}", req))
+    }));
+
+let router = WeightedRouter::builder()
+    .name("canary-deploy")
+    .route(svc_v1, 90)
+    .route(svc_v2, 10)
+    .on_request_routed(|idx, weight| {
+        println!("Routed to backend {} (weight: {})", idx, weight);
+    })
+    .build();
+```
+
+Key features:
+- **Deterministic** (default): Atomic counter for exact, repeatable distribution
+- **Random**: Probabilistic selection for high-volume statistical distribution
+- **Composable**: Wrap each backend with circuit breakers, bulkheads, etc.
+
+**Note:** Router is a standalone `Service`, not a `Layer`. Use `BoxService` to type-erase different backend implementations.
+
+**Full examples:** [router.rs](examples/router.rs)
 
 ### Chaos (Testing Only)
 

--- a/crates/tower-resilience-healthcheck/Cargo.toml
+++ b/crates/tower-resilience-healthcheck/Cargo.toml
@@ -10,12 +10,12 @@ rust-version.workspace = true
 [dependencies]
 tokio = { version = "1.0", features = ["rt", "time", "sync"] }
 rand = { version = "0.9", optional = true }
-tower-resilience-core = { version = "0.8.0", path = "../tower-resilience-core", optional = true }
+tower-resilience-core = { version = "0.9.0", path = "../tower-resilience-core", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }
 wiremock = "0.6"
-tower-resilience-chaos = { version = "0.8.0", path = "../tower-resilience-chaos" }
+tower-resilience-chaos = { version = "0.9.0", path = "../tower-resilience-chaos" }
 reqwest = "0.13"
 tower = "0.5"
 tower-layer = "0.3"

--- a/crates/tower-resilience-reconnect/Cargo.toml
+++ b/crates/tower-resilience-reconnect/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["tower", "reconnect", "resilience", "middleware", "connection"]
 
 [dependencies]
 tower-resilience-core = { workspace = true }
-tower-resilience-retry = { version = "0.8.0", path = "../tower-resilience-retry" }
+tower-resilience-retry = { version = "0.9.0", path = "../tower-resilience-retry" }
 tower = { workspace = true, features = ["make"] }
 futures = { workspace = true }
 tokio = { workspace = true }

--- a/crates/tower-resilience/Cargo.toml
+++ b/crates/tower-resilience/Cargo.toml
@@ -16,21 +16,22 @@ categories = ["asynchronous", "network-programming"]
 tower-resilience-core = { workspace = true }
 
 # Optional pattern dependencies
-tower-resilience-circuitbreaker = { version = "0.8.0", path = "../tower-resilience-circuitbreaker", optional = true }
-tower-resilience-bulkhead = { version = "0.8.0", path = "../tower-resilience-bulkhead", optional = true }
-tower-resilience-timelimiter = { version = "0.8.0", path = "../tower-resilience-timelimiter", optional = true }
-tower-resilience-cache = { version = "0.8.0", path = "../tower-resilience-cache", optional = true }
-tower-resilience-retry = { version = "0.8.0", path = "../tower-resilience-retry", optional = true }
-tower-resilience-ratelimiter = { version = "0.8.0", path = "../tower-resilience-ratelimiter", optional = true }
-tower-resilience-reconnect = { version = "0.8.0", path = "../tower-resilience-reconnect", optional = true }
-tower-resilience-healthcheck = { version = "0.8.0", path = "../tower-resilience-healthcheck", optional = true }
-tower-resilience-fallback = { version = "0.8.0", path = "../tower-resilience-fallback", optional = true }
-tower-resilience-hedge = { version = "0.8.0", path = "../tower-resilience-hedge", optional = true }
-tower-resilience-executor = { version = "0.8.0", path = "../tower-resilience-executor", optional = true }
-tower-resilience-adaptive = { version = "0.8.0", path = "../tower-resilience-adaptive", optional = true }
-tower-resilience-coalesce = { version = "0.8.0", path = "../tower-resilience-coalesce", optional = true }
-tower-resilience-outlier = { version = "0.8.0", path = "../tower-resilience-outlier", optional = true }
-tower-resilience-router = { version = "0.8.0", path = "../tower-resilience-router", optional = true }
+tower-resilience-circuitbreaker = { version = "0.9.0", path = "../tower-resilience-circuitbreaker", optional = true }
+tower-resilience-bulkhead = { version = "0.9.0", path = "../tower-resilience-bulkhead", optional = true }
+tower-resilience-timelimiter = { version = "0.9.0", path = "../tower-resilience-timelimiter", optional = true }
+tower-resilience-cache = { version = "0.9.0", path = "../tower-resilience-cache", optional = true }
+tower-resilience-retry = { version = "0.9.0", path = "../tower-resilience-retry", optional = true }
+tower-resilience-ratelimiter = { version = "0.9.0", path = "../tower-resilience-ratelimiter", optional = true }
+tower-resilience-reconnect = { version = "0.9.0", path = "../tower-resilience-reconnect", optional = true }
+tower-resilience-healthcheck = { version = "0.9.0", path = "../tower-resilience-healthcheck", optional = true }
+tower-resilience-fallback = { version = "0.9.0", path = "../tower-resilience-fallback", optional = true }
+tower-resilience-hedge = { version = "0.9.0", path = "../tower-resilience-hedge", optional = true }
+tower-resilience-executor = { version = "0.9.0", path = "../tower-resilience-executor", optional = true }
+tower-resilience-adaptive = { version = "0.9.0", path = "../tower-resilience-adaptive", optional = true }
+tower-resilience-coalesce = { version = "0.9.0", path = "../tower-resilience-coalesce", optional = true }
+tower-resilience-outlier = { version = "0.9.0", path = "../tower-resilience-outlier", optional = true }
+tower-resilience-router = { version = "0.9.0", path = "../tower-resilience-router", optional = true }
+tower-resilience-chaos = { version = "0.9.0", path = "../tower-resilience-chaos", optional = true }
 
 [features]
 default = []
@@ -66,11 +67,13 @@ coalesce = ["dep:tower-resilience-coalesce"]
 outlier = ["dep:tower-resilience-outlier"]
 # Router: weighted traffic routing for canary deployments and progressive rollout
 router = ["dep:tower-resilience-router"]
+# Chaos: inject failures and latency for testing resilience
+chaos = ["dep:tower-resilience-chaos"]
 # Unified error layer: compose multiple resilience layers with a single error type
 layer = ["tower-resilience-core/layer"]
 
 # Enable all patterns at once
-full = ["circuitbreaker", "bulkhead", "timelimiter", "cache", "retry", "ratelimiter", "reconnect", "healthcheck", "fallback", "hedge", "executor", "adaptive", "coalesce", "outlier", "router", "layer"]
+full = ["circuitbreaker", "bulkhead", "timelimiter", "cache", "retry", "ratelimiter", "reconnect", "healthcheck", "fallback", "hedge", "executor", "adaptive", "coalesce", "outlier", "router", "chaos", "layer"]
 
 # Integration: health checks can proactively open/close circuit breakers
 health-circuitbreaker = [

--- a/crates/tower-resilience/src/lib.rs
+++ b/crates/tower-resilience/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tower-resilience = { version = "0.7", features = ["circuitbreaker", "bulkhead"] }
+//! tower-resilience = { version = "0.9", features = ["circuitbreaker", "bulkhead"] }
 //! ```
 //!
 //! # Presets: Get Started Immediately
@@ -331,6 +331,9 @@ pub use tower_resilience_outlier as outlier;
 
 #[cfg(feature = "router")]
 pub use tower_resilience_router as router;
+
+#[cfg(feature = "chaos")]
+pub use tower_resilience_chaos as chaos;
 
 // Re-export unified error layer types
 #[cfg(feature = "layer")]


### PR DESCRIPTION
## Summary

Release readiness PR for v0.9.0. Addresses coverage gaps found during pattern audit and bumps all versions.

**Coverage fixes:**
- Add router section to README with code example and feature description
- Add chaos pattern to umbrella crate: optional dep, feature flag, `full` feature, `pub use` re-export

**Version bump:**
- Workspace version 0.8.0 -> 0.9.0
- All inter-crate dependency versions updated (healthcheck, reconnect, umbrella)
- README and lib.rs doc examples updated from 0.7 -> 0.9

Closes #260
Closes #261

**Open issues (non-blocking):**
- #263 healthcheck integration tests
- #264 executor integration tests

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --lib --all-features`
- [x] `cargo test --test '*' --all-features`
- [x] `cargo test --doc --all-features --workspace`
- [x] `cargo doc --no-deps --all-features`