### PR TITLE
docs: standardize all pattern lists to alphabetical order

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,22 +13,22 @@ Resilience patterns for [Tower](https://docs.rs/tower) services, inspired by [Re
 
 ## Resilience Patterns
 
-- **Circuit Breaker** - Prevents cascading failures by stopping calls to failing services
-- **Bulkhead** - Isolates resources to prevent system-wide failures  
-- **Time Limiter** - Advanced timeout handling with cancellation support
-- **Retry** - Intelligent retry with exponential backoff, jitter, and retry budgets
-- **Rate Limiter** - Controls request rate with fixed or sliding window algorithms
+- **Adaptive Concurrency** - Dynamic concurrency limiting using AIMD or Vegas algorithms
+- **Bulkhead** - Isolates resources to prevent system-wide failures
 - **Cache** - Response memoization to reduce load
+- **Chaos** - Inject failures and latency for testing resilience (development/testing only)
+- **Circuit Breaker** - Prevents cascading failures by stopping calls to failing services
+- **Coalesce** - Deduplicates concurrent identical requests (singleflight pattern)
+- **Executor** - Delegates request processing to dedicated executors for parallelism
 - **Fallback** - Graceful degradation when services fail
 - **Hedge** - Reduces tail latency by racing redundant requests
-- **Reconnect** - Automatic reconnection with configurable backoff strategies
 - **Health Check** - Proactive health monitoring with intelligent resource selection
-- **Executor** - Delegates request processing to dedicated executors for parallelism
-- **Adaptive Concurrency** - Dynamic concurrency limiting using AIMD or Vegas algorithms
-- **Coalesce** - Deduplicates concurrent identical requests (singleflight pattern)
 - **Outlier Detection** - Fleet-aware instance ejection based on consecutive error tracking
+- **Rate Limiter** - Controls request rate with fixed or sliding window algorithms
+- **Reconnect** - Automatic reconnection with configurable backoff strategies
+- **Retry** - Intelligent retry with exponential backoff, jitter, and retry budgets
 - **Router** - Weighted traffic routing for canary deployments and progressive rollout
-- **Chaos** - Inject failures and latency for testing resilience (development/testing only)
+- **Time Limiter** - Advanced timeout handling with cancellation support
 
 ## Quick Start
 
@@ -89,25 +89,25 @@ let hedge = HedgeLayer::standard();
 
 | Pattern | Presets | Description |
 |---------|---------|-------------|
-| **Retry** | `exponential_backoff()` | 3 attempts, 100ms base - balanced default |
-| | `aggressive()` | 5 attempts, 50ms base - fast recovery |
-| | `conservative()` | 2 attempts, 500ms base - minimal overhead |
-| **Circuit Breaker** | `standard()` | 50% threshold, 100 calls - balanced |
-| | `fast_fail()` | 25% threshold, 20 calls - fail fast |
-| | `tolerant()` | 75% threshold, 200 calls - high tolerance |
-| **Rate Limiter** | `per_second(n)` | n requests per second |
-| | `per_minute(n)` | n requests per minute |
-| | `burst(rate, size)` | Sustained rate with burst capacity |
 | **Bulkhead** | `small()` | 10 concurrent calls |
 | | `medium()` | 50 concurrent calls |
 | | `large()` | 200 concurrent calls |
+| **Circuit Breaker** | `standard()` | 50% threshold, 100 calls - balanced |
+| | `fast_fail()` | 25% threshold, 20 calls - fail fast |
+| | `tolerant()` | 75% threshold, 200 calls - high tolerance |
+| **Hedge** | `conservative()` | 500ms delay, 2 attempts |
+| | `standard()` | 100ms delay, 3 attempts |
+| | `aggressive()` | 50ms delay, 5 attempts |
+| **Rate Limiter** | `per_second(n)` | n requests per second |
+| | `per_minute(n)` | n requests per minute |
+| | `burst(rate, size)` | Sustained rate with burst capacity |
+| **Retry** | `exponential_backoff()` | 3 attempts, 100ms base - balanced default |
+| | `aggressive()` | 5 attempts, 50ms base - fast recovery |
+| | `conservative()` | 2 attempts, 500ms base - minimal overhead |
 | **Time Limiter** | `fast()` | 1s timeout, cancel on timeout |
 | | `standard()` | 5s timeout, cancel on timeout |
 | | `slow()` | 30s timeout, cancel on timeout |
 | | `streaming()` | 60s timeout, no cancellation |
-| **Hedge** | `conservative()` | 500ms delay, 2 attempts |
-| | `standard()` | 100ms delay, 3 attempts |
-| | `aggressive()` | 50ms delay, 5 attempts |
 
 Presets return builders, so you can customize any setting:
 
@@ -121,29 +121,48 @@ let breaker = CircuitBreakerLayer::fast_fail()
 
 ## Examples
 
-### Circuit Breaker
+### Adaptive Concurrency
 
-Prevent cascading failures by opening the circuit when error rate exceeds threshold:
+Dynamically adjust concurrency limits based on observed latency and error rates:
 
 ```rust
-use tower::Layer;
-use tower_resilience::circuitbreaker::CircuitBreakerLayer;
+use tower_resilience::adaptive::{AdaptiveLimiterLayer, Aimd, Vegas};
+use tower::ServiceBuilder;
 use std::time::Duration;
 
-let layer = CircuitBreakerLayer::builder()
-    .name("api-circuit")
-    .failure_rate_threshold(0.5)          // Open at 50% failure rate
-    .sliding_window_size(100)              // Track last 100 calls
-    .wait_duration_in_open(Duration::from_secs(60))  // Stay open 60s
-    .on_state_transition(|from, to| {
-        println!("Circuit breaker: {:?} -> {:?}", from, to);
-    })
-    .build();
+// AIMD: Classic TCP-style congestion control
+// Increases limit on success, decreases on failure/high latency
+let layer = AdaptiveLimiterLayer::new(
+    Aimd::builder()
+        .initial_limit(10)
+        .min_limit(1)
+        .max_limit(100)
+        .increase_by(1)                           // Add 1 on success
+        .decrease_factor(0.5)                     // Halve on failure
+        .latency_threshold(Duration::from_millis(100))
+        .build()
+);
 
-let service = layer.layer(my_service);
+// Vegas: More stable, uses RTT to estimate queue depth
+let layer = AdaptiveLimiterLayer::new(
+    Vegas::builder()
+        .initial_limit(10)
+        .alpha(3)    // Increase when queue < 3
+        .beta(6)     // Decrease when queue > 6
+        .build()
+);
+
+let service = ServiceBuilder::new()
+    .layer(layer)
+    .service(my_service);
 ```
 
-**Full examples:** [circuitbreaker.rs](examples/circuitbreaker.rs) | [circuitbreaker_fallback.rs](crates/tower-resilience-circuitbreaker/examples/circuitbreaker_fallback.rs) | [circuitbreaker_health_check.rs](crates/tower-resilience-circuitbreaker/examples/circuitbreaker_health_check.rs)
+Use cases:
+- **Auto-tuning**: No manual concurrency limit configuration needed
+- **Variable backends**: Adapts to changing downstream capacity
+- **Load shedding**: Automatically reduces load when backends struggle
+
+**Full examples:** [adaptive.rs](examples/adaptive.rs)
 
 ### Bulkhead
 
@@ -170,73 +189,6 @@ let service = layer.layer(my_service);
 
 **Full examples:** [bulkhead.rs](examples/bulkhead.rs) | [bulkhead_advanced.rs](crates/tower-resilience-bulkhead/examples/bulkhead_advanced.rs)
 
-### Time Limiter
-
-Enforce timeouts on operations with configurable cancellation:
-
-```rust
-use tower_resilience::timelimiter::TimeLimiterLayer;
-use std::time::Duration;
-
-let layer = TimeLimiterLayer::builder()
-    .timeout_duration(Duration::from_secs(30))
-    .cancel_running_future(true)  // Cancel on timeout
-    .on_timeout(|| {
-        println!("Operation timed out!");
-    })
-    .build();
-
-let service = layer.layer(my_service);
-```
-
-**Full examples:** [timelimiter.rs](examples/timelimiter.rs) | [timelimiter_example.rs](crates/tower-resilience-timelimiter/examples/timelimiter_example.rs)
-
-### Retry
-
-Retry failed requests with exponential backoff and jitter:
-
-```rust
-use tower_resilience::retry::RetryLayer;
-use std::time::Duration;
-
-let layer = RetryLayer::<(), (), MyError>::builder()
-    .max_attempts(5)
-    .exponential_backoff(Duration::from_millis(100))
-    .on_retry(|attempt, delay| {
-        println!("Retrying (attempt {}, delay {:?})", attempt, delay);
-    })
-    .on_success(|attempts| {
-        println!("Success after {} attempts", attempts);
-    })
-    .build();
-
-let service = layer.layer(my_service);
-```
-
-**Full examples:** [retry.rs](examples/retry.rs) | [retry_example.rs](crates/tower-resilience-retry/examples/retry_example.rs)
-
-### Rate Limiter
-
-Control request rate to protect downstream services:
-
-```rust
-use tower_resilience::ratelimiter::RateLimiterLayer;
-use std::time::Duration;
-
-let layer = RateLimiterLayer::builder()
-    .limit_for_period(100)                      // 100 requests
-    .refresh_period(Duration::from_secs(1))     // per second
-    .timeout_duration(Duration::from_millis(500))  // Wait up to 500ms
-    .on_permit_acquired(|wait| {
-        println!("Request permitted (waited {:?})", wait);
-    })
-    .build();
-
-let service = layer.layer(my_service);
-```
-
-**Full examples:** [ratelimiter.rs](examples/ratelimiter.rs) | [ratelimiter_example.rs](crates/tower-resilience-ratelimiter/examples/ratelimiter_example.rs)
-
 ### Cache
 
 Cache responses to reduce load on expensive operations:
@@ -259,120 +211,57 @@ let service = layer.layer(my_service);
 
 **Full examples:** [cache.rs](examples/cache.rs) | [cache_example.rs](crates/tower-resilience-cache/examples/cache_example.rs)
 
-### Fallback
+### Chaos (Testing Only)
 
-Provide fallback responses when the primary service fails:
-
-```rust
-use tower_resilience::fallback::FallbackLayer;
-
-// Return a static fallback value on error
-let layer = FallbackLayer::<Request, Response, MyError>::value(
-    Response::default()
-);
-
-// Or compute fallback from the error
-let layer = FallbackLayer::<Request, Response, MyError>::from_error(|err| {
-    Response::error_response(err)
-});
-
-// Or use a backup service
-let layer = FallbackLayer::<Request, Response, MyError>::service(|req| async {
-    backup_service.call(req).await
-});
-
-let service = layer.layer(primary_service);
-```
-
-### Hedge
-
-Reduce tail latency by firing backup requests after a delay:
+Inject failures and latency to test your resilience patterns:
 
 ```rust
-use tower_resilience::hedge::HedgeLayer;
+use tower_resilience::chaos::ChaosLayer;
 use std::time::Duration;
 
-// Fire a hedge request if primary takes > 100ms
-let layer = HedgeLayer::builder()
-    .delay(Duration::from_millis(100))
-    .max_hedged_attempts(2)
+// Types inferred from closure signature - no type parameters needed!
+let chaos = ChaosLayer::builder()
+    .name("test-chaos")
+    .error_rate(0.1)                               // 10% of requests fail
+    .error_fn(|_req: &String| std::io::Error::new(
+        std::io::ErrorKind::Other, "chaos!"
+    ))
+    .latency_rate(0.2)                             // 20% delayed
+    .min_latency(Duration::from_millis(50))
+    .max_latency(Duration::from_millis(200))
+    .seed(42)                                      // Deterministic chaos
     .build();
 
-// Or fire all requests in parallel (no delay)
-let layer = HedgeLayer::<(), String, MyError>::builder()
-    .no_delay()
-    .max_hedged_attempts(3)
-    .build();
-
-let service = layer.layer(my_service);
+let service = chaos.layer(my_service);
 ```
 
-**Note:** Hedge requires `Req: Clone` (requests are cloned for parallel execution) and `E: Clone` (for error handling). If your types don't implement Clone, consider wrapping them in `Arc`.
+**WARNING**: Only use in development/testing environments. Never in production.
 
-**Full examples:** [hedge.rs](examples/hedge.rs)
+**Full examples:** [chaos.rs](examples/chaos.rs) | [chaos_example.rs](crates/tower-resilience-chaos/examples/chaos_example.rs)
 
-### Reconnect
+### Circuit Breaker
 
-Automatically reconnect on connection failures with configurable backoff:
-
-```rust
-use tower_resilience::reconnect::{ReconnectLayer, ReconnectConfig, ReconnectPolicy};
-use std::time::Duration;
-
-let layer = ReconnectLayer::new(
-    ReconnectConfig::builder()
-        .policy(ReconnectPolicy::exponential(
-            Duration::from_millis(100),  // Start at 100ms
-            Duration::from_secs(5),       // Max 5 seconds
-        ))
-        .max_attempts(10)
-        .retry_on_reconnect(true)         // Retry request after reconnecting
-        .connection_errors_only()          // Only reconnect on connection errors
-        .on_state_change(|from, to| {
-            println!("Connection: {:?} -> {:?}", from, to);
-        })
-        .build()
-);
-
-let service = layer.layer(my_service);
-```
-
-**Full examples:** [reconnect.rs](examples/reconnect.rs) | [reconnect_basic.rs](crates/tower-resilience-reconnect/examples/reconnect_basic.rs) | [reconnect_custom_policy.rs](crates/tower-resilience-reconnect/examples/reconnect_custom_policy.rs)
-
-### Health Check
-
-Proactive health monitoring with intelligent resource selection:
+Prevent cascading failures by opening the circuit when error rate exceeds threshold:
 
 ```rust
-use tower_resilience::healthcheck::{HealthCheckWrapper, HealthStatus, SelectionStrategy};
+use tower::Layer;
+use tower_resilience::circuitbreaker::CircuitBreakerLayer;
 use std::time::Duration;
 
-// Create wrapper with multiple resources
-let wrapper = HealthCheckWrapper::builder()
-    .with_context(primary_db, "primary")
-    .with_context(secondary_db, "secondary")
-    .with_checker(|db| async move {
-        match db.ping().await {
-            Ok(_) => HealthStatus::Healthy,
-            Err(_) => HealthStatus::Unhealthy,
-        }
+let layer = CircuitBreakerLayer::builder()
+    .name("api-circuit")
+    .failure_rate_threshold(0.5)          // Open at 50% failure rate
+    .sliding_window_size(100)              // Track last 100 calls
+    .wait_duration_in_open(Duration::from_secs(60))  // Stay open 60s
+    .on_state_transition(|from, to| {
+        println!("Circuit breaker: {:?} -> {:?}", from, to);
     })
-    .with_interval(Duration::from_secs(5))
-    .with_selection_strategy(SelectionStrategy::RoundRobin)
     .build();
 
-// Start background health checking
-wrapper.start().await;
-
-// Get a healthy resource
-if let Some(db) = wrapper.get_healthy().await {
-    // Use healthy database
-}
+let service = layer.layer(my_service);
 ```
 
-**Note:** Health Check is not a Tower layer - it's a wrapper pattern for managing multiple resources with automatic failover.
-
-**Full examples:** [healthcheck_basic.rs](crates/tower-resilience-healthcheck/examples/healthcheck_basic.rs)
+**Full examples:** [circuitbreaker.rs](examples/circuitbreaker.rs) | [circuitbreaker_fallback.rs](crates/tower-resilience-circuitbreaker/examples/circuitbreaker_fallback.rs) | [circuitbreaker_health_check.rs](crates/tower-resilience-circuitbreaker/examples/circuitbreaker_health_check.rs)
 
 ### Coalesce
 
@@ -433,48 +322,92 @@ Use cases:
 - **Runtime isolation**: Process requests on a dedicated runtime
 - **Thread pool delegation**: Use specific thread pools for certain workloads
 
-### Adaptive Concurrency
+### Fallback
 
-Dynamically adjust concurrency limits based on observed latency and error rates:
+Provide fallback responses when the primary service fails:
 
 ```rust
-use tower_resilience::adaptive::{AdaptiveLimiterLayer, Aimd, Vegas};
-use tower::ServiceBuilder;
-use std::time::Duration;
+use tower_resilience::fallback::FallbackLayer;
 
-// AIMD: Classic TCP-style congestion control
-// Increases limit on success, decreases on failure/high latency
-let layer = AdaptiveLimiterLayer::new(
-    Aimd::builder()
-        .initial_limit(10)
-        .min_limit(1)
-        .max_limit(100)
-        .increase_by(1)                           // Add 1 on success
-        .decrease_factor(0.5)                     // Halve on failure
-        .latency_threshold(Duration::from_millis(100))
-        .build()
+// Return a static fallback value on error
+let layer = FallbackLayer::<Request, Response, MyError>::value(
+    Response::default()
 );
 
-// Vegas: More stable, uses RTT to estimate queue depth
-let layer = AdaptiveLimiterLayer::new(
-    Vegas::builder()
-        .initial_limit(10)
-        .alpha(3)    // Increase when queue < 3
-        .beta(6)     // Decrease when queue > 6
-        .build()
-);
+// Or compute fallback from the error
+let layer = FallbackLayer::<Request, Response, MyError>::from_error(|err| {
+    Response::error_response(err)
+});
 
-let service = ServiceBuilder::new()
-    .layer(layer)
-    .service(my_service);
+// Or use a backup service
+let layer = FallbackLayer::<Request, Response, MyError>::service(|req| async {
+    backup_service.call(req).await
+});
+
+let service = layer.layer(primary_service);
 ```
 
-Use cases:
-- **Auto-tuning**: No manual concurrency limit configuration needed
-- **Variable backends**: Adapts to changing downstream capacity
-- **Load shedding**: Automatically reduces load when backends struggle
+### Hedge
 
-**Full examples:** [adaptive.rs](examples/adaptive.rs)
+Reduce tail latency by firing backup requests after a delay:
+
+```rust
+use tower_resilience::hedge::HedgeLayer;
+use std::time::Duration;
+
+// Fire a hedge request if primary takes > 100ms
+let layer = HedgeLayer::builder()
+    .delay(Duration::from_millis(100))
+    .max_hedged_attempts(2)
+    .build();
+
+// Or fire all requests in parallel (no delay)
+let layer = HedgeLayer::<(), String, MyError>::builder()
+    .no_delay()
+    .max_hedged_attempts(3)
+    .build();
+
+let service = layer.layer(my_service);
+```
+
+**Note:** Hedge requires `Req: Clone` (requests are cloned for parallel execution) and `E: Clone` (for error handling). If your types don't implement Clone, consider wrapping them in `Arc`.
+
+**Full examples:** [hedge.rs](examples/hedge.rs)
+
+### Health Check
+
+Proactive health monitoring with intelligent resource selection:
+
+```rust
+use tower_resilience::healthcheck::{HealthCheckWrapper, HealthStatus, SelectionStrategy};
+use std::time::Duration;
+
+// Create wrapper with multiple resources
+let wrapper = HealthCheckWrapper::builder()
+    .with_context(primary_db, "primary")
+    .with_context(secondary_db, "secondary")
+    .with_checker(|db| async move {
+        match db.ping().await {
+            Ok(_) => HealthStatus::Healthy,
+            Err(_) => HealthStatus::Unhealthy,
+        }
+    })
+    .with_interval(Duration::from_secs(5))
+    .with_selection_strategy(SelectionStrategy::RoundRobin)
+    .build();
+
+// Start background health checking
+wrapper.start().await;
+
+// Get a healthy resource
+if let Some(db) = wrapper.get_healthy().await {
+    // Use healthy database
+}
+```
+
+**Note:** Health Check is not a Tower layer - it's a wrapper pattern for managing multiple resources with automatic failover.
+
+**Full examples:** [healthcheck_basic.rs](crates/tower-resilience-healthcheck/examples/healthcheck_basic.rs)
 
 ### Outlier Detection
 
@@ -509,6 +442,80 @@ Key features:
 - **Backpressure mode** (default): `poll_ready` returns `Pending` for ejected instances, integrating naturally with Tower load balancers
 - **Fleet protection**: `max_ejection_percent` prevents cascading ejections
 - **Exponential backoff**: Repeatedly-ejected instances stay out longer
+
+### Rate Limiter
+
+Control request rate to protect downstream services:
+
+```rust
+use tower_resilience::ratelimiter::RateLimiterLayer;
+use std::time::Duration;
+
+let layer = RateLimiterLayer::builder()
+    .limit_for_period(100)                      // 100 requests
+    .refresh_period(Duration::from_secs(1))     // per second
+    .timeout_duration(Duration::from_millis(500))  // Wait up to 500ms
+    .on_permit_acquired(|wait| {
+        println!("Request permitted (waited {:?})", wait);
+    })
+    .build();
+
+let service = layer.layer(my_service);
+```
+
+**Full examples:** [ratelimiter.rs](examples/ratelimiter.rs) | [ratelimiter_example.rs](crates/tower-resilience-ratelimiter/examples/ratelimiter_example.rs)
+
+### Reconnect
+
+Automatically reconnect on connection failures with configurable backoff:
+
+```rust
+use tower_resilience::reconnect::{ReconnectLayer, ReconnectConfig, ReconnectPolicy};
+use std::time::Duration;
+
+let layer = ReconnectLayer::new(
+    ReconnectConfig::builder()
+        .policy(ReconnectPolicy::exponential(
+            Duration::from_millis(100),  // Start at 100ms
+            Duration::from_secs(5),       // Max 5 seconds
+        ))
+        .max_attempts(10)
+        .retry_on_reconnect(true)         // Retry request after reconnecting
+        .connection_errors_only()          // Only reconnect on connection errors
+        .on_state_change(|from, to| {
+            println!("Connection: {:?} -> {:?}", from, to);
+        })
+        .build()
+);
+
+let service = layer.layer(my_service);
+```
+
+**Full examples:** [reconnect.rs](examples/reconnect.rs) | [reconnect_basic.rs](crates/tower-resilience-reconnect/examples/reconnect_basic.rs) | [reconnect_custom_policy.rs](crates/tower-resilience-reconnect/examples/reconnect_custom_policy.rs)
+
+### Retry
+
+Retry failed requests with exponential backoff and jitter:
+
+```rust
+use tower_resilience::retry::RetryLayer;
+use std::time::Duration;
+
+let layer = RetryLayer::<(), (), MyError>::builder()
+    .max_attempts(5)
+    .exponential_backoff(Duration::from_millis(100))
+    .on_retry(|attempt, delay| {
+        println!("Retrying (attempt {}, delay {:?})", attempt, delay);
+    })
+    .on_success(|attempts| {
+        println!("Success after {} attempts", attempts);
+    })
+    .build();
+
+let service = layer.layer(my_service);
+```
+
+**Full examples:** [retry.rs](examples/retry.rs) | [retry_example.rs](crates/tower-resilience-retry/examples/retry_example.rs)
 
 ### Router
 
@@ -547,33 +554,26 @@ Key features:
 
 **Full examples:** [router.rs](examples/router.rs)
 
-### Chaos (Testing Only)
+### Time Limiter
 
-Inject failures and latency to test your resilience patterns:
+Enforce timeouts on operations with configurable cancellation:
 
 ```rust
-use tower_resilience::chaos::ChaosLayer;
+use tower_resilience::timelimiter::TimeLimiterLayer;
 use std::time::Duration;
 
-// Types inferred from closure signature - no type parameters needed!
-let chaos = ChaosLayer::builder()
-    .name("test-chaos")
-    .error_rate(0.1)                               // 10% of requests fail
-    .error_fn(|_req: &String| std::io::Error::new(
-        std::io::ErrorKind::Other, "chaos!"
-    ))
-    .latency_rate(0.2)                             // 20% delayed
-    .min_latency(Duration::from_millis(50))
-    .max_latency(Duration::from_millis(200))
-    .seed(42)                                      // Deterministic chaos
+let layer = TimeLimiterLayer::builder()
+    .timeout_duration(Duration::from_secs(30))
+    .cancel_running_future(true)  // Cancel on timeout
+    .on_timeout(|| {
+        println!("Operation timed out!");
+    })
     .build();
 
-let service = chaos.layer(my_service);
+let service = layer.layer(my_service);
 ```
 
-**WARNING**: Only use in development/testing environments. Never in production.
-
-**Full examples:** [chaos.rs](examples/chaos.rs) | [chaos_example.rs](crates/tower-resilience-chaos/examples/chaos_example.rs)
+**Full examples:** [timelimiter.rs](examples/timelimiter.rs) | [timelimiter_example.rs](crates/tower-resilience-timelimiter/examples/timelimiter_example.rs)
 
 ## Error Handling
 

--- a/crates/tower-resilience/Cargo.toml
+++ b/crates/tower-resilience/Cargo.toml
@@ -15,65 +15,65 @@ categories = ["asynchronous", "network-programming"]
 # Core is always included
 tower-resilience-core = { workspace = true }
 
-# Optional pattern dependencies
-tower-resilience-circuitbreaker = { version = "0.9.1", path = "../tower-resilience-circuitbreaker", optional = true }
+# Optional pattern dependencies (alphabetical)
+tower-resilience-adaptive = { version = "0.9.1", path = "../tower-resilience-adaptive", optional = true }
 tower-resilience-bulkhead = { version = "0.9.1", path = "../tower-resilience-bulkhead", optional = true }
-tower-resilience-timelimiter = { version = "0.9.1", path = "../tower-resilience-timelimiter", optional = true }
 tower-resilience-cache = { version = "0.9.1", path = "../tower-resilience-cache", optional = true }
-tower-resilience-retry = { version = "0.9.1", path = "../tower-resilience-retry", optional = true }
-tower-resilience-ratelimiter = { version = "0.9.1", path = "../tower-resilience-ratelimiter", optional = true }
-tower-resilience-reconnect = { version = "0.9.1", path = "../tower-resilience-reconnect", optional = true }
-tower-resilience-healthcheck = { version = "0.9.1", path = "../tower-resilience-healthcheck", optional = true }
+tower-resilience-chaos = { version = "0.9.1", path = "../tower-resilience-chaos", optional = true }
+tower-resilience-circuitbreaker = { version = "0.9.1", path = "../tower-resilience-circuitbreaker", optional = true }
+tower-resilience-coalesce = { version = "0.9.1", path = "../tower-resilience-coalesce", optional = true }
+tower-resilience-executor = { version = "0.9.1", path = "../tower-resilience-executor", optional = true }
 tower-resilience-fallback = { version = "0.9.1", path = "../tower-resilience-fallback", optional = true }
 tower-resilience-hedge = { version = "0.9.1", path = "../tower-resilience-hedge", optional = true }
-tower-resilience-executor = { version = "0.9.1", path = "../tower-resilience-executor", optional = true }
-tower-resilience-adaptive = { version = "0.9.1", path = "../tower-resilience-adaptive", optional = true }
-tower-resilience-coalesce = { version = "0.9.1", path = "../tower-resilience-coalesce", optional = true }
+tower-resilience-healthcheck = { version = "0.9.1", path = "../tower-resilience-healthcheck", optional = true }
 tower-resilience-outlier = { version = "0.9.1", path = "../tower-resilience-outlier", optional = true }
+tower-resilience-ratelimiter = { version = "0.9.1", path = "../tower-resilience-ratelimiter", optional = true }
+tower-resilience-reconnect = { version = "0.9.1", path = "../tower-resilience-reconnect", optional = true }
+tower-resilience-retry = { version = "0.9.1", path = "../tower-resilience-retry", optional = true }
 tower-resilience-router = { version = "0.9.1", path = "../tower-resilience-router", optional = true }
-tower-resilience-chaos = { version = "0.9.1", path = "../tower-resilience-chaos", optional = true }
+tower-resilience-timelimiter = { version = "0.9.1", path = "../tower-resilience-timelimiter", optional = true }
 
 [features]
 default = []
 
-# Resilience patterns - enable the ones you need
-# Circuit breaker: prevent cascading failures by stopping calls to failing services
-circuitbreaker = ["dep:tower-resilience-circuitbreaker"]
+# Resilience patterns - enable the ones you need (alphabetical)
+# Adaptive: dynamic concurrency limiting (AIMD/Vegas algorithms)
+adaptive = ["dep:tower-resilience-adaptive"]
 # Bulkhead: isolate resources with concurrency limits
 bulkhead = ["dep:tower-resilience-bulkhead"]
-# Time limiter: enforce timeouts with cancellation support
-timelimiter = ["dep:tower-resilience-timelimiter"]
 # Cache: response memoization to reduce load
 cache = ["dep:tower-resilience-cache"]
-# Retry: automatic retries with exponential backoff and jitter
-retry = ["dep:tower-resilience-retry"]
-# Rate limiter: control request rate with fixed or sliding windows
-ratelimiter = ["dep:tower-resilience-ratelimiter"]
-# Reconnect: automatic reconnection with configurable backoff
-reconnect = ["dep:tower-resilience-reconnect"]
-# Health check: proactive health monitoring with resource selection
-healthcheck = ["dep:tower-resilience-healthcheck"]
+# Chaos: inject failures and latency for testing resilience
+chaos = ["dep:tower-resilience-chaos"]
+# Circuit breaker: prevent cascading failures by stopping calls to failing services
+circuitbreaker = ["dep:tower-resilience-circuitbreaker"]
+# Coalesce: deduplicate concurrent identical requests (singleflight)
+coalesce = ["dep:tower-resilience-coalesce"]
+# Executor: delegate processing to dedicated thread pools
+executor = ["dep:tower-resilience-executor"]
 # Fallback: provide alternative responses when services fail
 fallback = ["dep:tower-resilience-fallback"]
 # Hedge: reduce tail latency by racing parallel requests
 hedge = ["dep:tower-resilience-hedge"]
-# Executor: delegate processing to dedicated thread pools
-executor = ["dep:tower-resilience-executor"]
-# Adaptive: dynamic concurrency limiting (AIMD/Vegas algorithms)
-adaptive = ["dep:tower-resilience-adaptive"]
-# Coalesce: deduplicate concurrent identical requests (singleflight)
-coalesce = ["dep:tower-resilience-coalesce"]
-# Outlier detection: fleet-aware instance ejection based on health tracking
-outlier = ["dep:tower-resilience-outlier"]
-# Router: weighted traffic routing for canary deployments and progressive rollout
-router = ["dep:tower-resilience-router"]
-# Chaos: inject failures and latency for testing resilience
-chaos = ["dep:tower-resilience-chaos"]
+# Health check: proactive health monitoring with resource selection
+healthcheck = ["dep:tower-resilience-healthcheck"]
 # Unified error layer: compose multiple resilience layers with a single error type
 layer = ["tower-resilience-core/layer"]
+# Outlier detection: fleet-aware instance ejection based on health tracking
+outlier = ["dep:tower-resilience-outlier"]
+# Rate limiter: control request rate with fixed or sliding windows
+ratelimiter = ["dep:tower-resilience-ratelimiter"]
+# Reconnect: automatic reconnection with configurable backoff
+reconnect = ["dep:tower-resilience-reconnect"]
+# Retry: automatic retries with exponential backoff and jitter
+retry = ["dep:tower-resilience-retry"]
+# Router: weighted traffic routing for canary deployments and progressive rollout
+router = ["dep:tower-resilience-router"]
+# Time limiter: enforce timeouts with cancellation support
+timelimiter = ["dep:tower-resilience-timelimiter"]
 
 # Enable all patterns at once
-full = ["circuitbreaker", "bulkhead", "timelimiter", "cache", "retry", "ratelimiter", "reconnect", "healthcheck", "fallback", "hedge", "executor", "adaptive", "coalesce", "outlier", "router", "chaos", "layer"]
+full = ["adaptive", "bulkhead", "cache", "chaos", "circuitbreaker", "coalesce", "executor", "fallback", "hedge", "healthcheck", "layer", "outlier", "ratelimiter", "reconnect", "retry", "router", "timelimiter"]
 
 # Integration: health checks can proactively open/close circuit breakers
 health-circuitbreaker = [

--- a/crates/tower-resilience/src/lib.rs
+++ b/crates/tower-resilience/src/lib.rs
@@ -44,12 +44,12 @@
 //!
 //! | Pattern | Presets |
 //! |---------|---------|
-//! | **Retry** | [`exponential_backoff()`], [`aggressive()`], [`conservative()`] |
-//! | **Circuit Breaker** | [`standard()`], [`fast_fail()`], [`tolerant()`] |
-//! | **Rate Limiter** | [`per_second(n)`], [`per_minute(n)`], [`burst(rate, size)`] |
 //! | **Bulkhead** | [`small()`], [`medium()`], [`large()`] |
-//! | **Time Limiter** | [`fast()`], [`standard()`][tl_standard], [`slow()`], [`streaming()`] |
+//! | **Circuit Breaker** | [`standard()`], [`fast_fail()`], [`tolerant()`] |
 //! | **Hedge** | [`conservative()`][h_conservative], [`standard()`][h_standard], [`aggressive()`][h_aggressive] |
+//! | **Rate Limiter** | [`per_second(n)`], [`per_minute(n)`], [`burst(rate, size)`] |
+//! | **Retry** | [`exponential_backoff()`], [`aggressive()`], [`conservative()`] |
+//! | **Time Limiter** | [`fast()`], [`standard()`][tl_standard], [`slow()`], [`streaming()`] |
 //!
 //! Presets return builders, so you can customize any setting:
 //!
@@ -66,59 +66,59 @@
 //! # }
 //! ```
 //!
-//! [`exponential_backoff()`]: retry::RetryLayer::exponential_backoff
-//! [`aggressive()`]: retry::RetryLayer::aggressive
-//! [`conservative()`]: retry::RetryLayer::conservative
-//! [`standard()`]: circuitbreaker::CircuitBreakerLayer::standard
-//! [`fast_fail()`]: circuitbreaker::CircuitBreakerLayer::fast_fail
-//! [`tolerant()`]: circuitbreaker::CircuitBreakerLayer::tolerant
-//! [`per_second(n)`]: ratelimiter::RateLimiterLayer::per_second
-//! [`per_minute(n)`]: ratelimiter::RateLimiterLayer::per_minute
-//! [`burst(rate, size)`]: ratelimiter::RateLimiterLayer::burst
 //! [`small()`]: bulkhead::BulkheadLayer::small
 //! [`medium()`]: bulkhead::BulkheadLayer::medium
 //! [`large()`]: bulkhead::BulkheadLayer::large
+//! [`standard()`]: circuitbreaker::CircuitBreakerLayer::standard
+//! [`fast_fail()`]: circuitbreaker::CircuitBreakerLayer::fast_fail
+//! [`tolerant()`]: circuitbreaker::CircuitBreakerLayer::tolerant
+//! [h_conservative]: hedge::HedgeLayer::conservative
+//! [h_standard]: hedge::HedgeLayer::standard
+//! [h_aggressive]: hedge::HedgeLayer::aggressive
+//! [`per_second(n)`]: ratelimiter::RateLimiterLayer::per_second
+//! [`per_minute(n)`]: ratelimiter::RateLimiterLayer::per_minute
+//! [`burst(rate, size)`]: ratelimiter::RateLimiterLayer::burst
+//! [`exponential_backoff()`]: retry::RetryLayer::exponential_backoff
+//! [`aggressive()`]: retry::RetryLayer::aggressive
+//! [`conservative()`]: retry::RetryLayer::conservative
 //! [`fast()`]: timelimiter::TimeLimiterLayer::fast
 //! [tl_standard]: timelimiter::TimeLimiterLayer::standard
 //! [`slow()`]: timelimiter::TimeLimiterLayer::slow
 //! [`streaming()`]: timelimiter::TimeLimiterLayer::streaming
-//! [h_conservative]: hedge::HedgeLayer::conservative
-//! [h_standard]: hedge::HedgeLayer::standard
-//! [h_aggressive]: hedge::HedgeLayer::aggressive
 //!
 //! # Resilience Patterns
 //!
-//! - **[Circuit Breaker]** - Prevents cascading failures by stopping calls to failing services
+//! - **[Adaptive]** - Dynamic concurrency limiting using AIMD or Vegas algorithms
 //! - **[Bulkhead]** - Isolates resources to prevent system-wide failures
-//! - **[Time Limiter]** - Advanced timeout handling with cancellation support
-//! - **[Retry]** - Intelligent retry with exponential backoff and jitter
-//! - **[Rate Limiter]** - Controls request rate to protect services
 //! - **[Cache]** - Response memoization to reduce load
-//! - **[Reconnect]** - Automatic reconnection with configurable backoff strategies
-//! - **[Health Check]** - Proactive health monitoring with intelligent resource selection
+//! - **[Circuit Breaker]** - Prevents cascading failures by stopping calls to failing services
+//! - **[Coalesce]** - Deduplicates concurrent identical requests (singleflight)
+//! - **[Executor]** - Delegates request processing to dedicated executors
 //! - **[Fallback]** - Provides alternative responses when services fail
 //! - **[Hedge]** - Reduces tail latency by firing parallel requests
-//! - **[Executor]** - Delegates request processing to dedicated executors
-//! - **[Adaptive]** - Dynamic concurrency limiting using AIMD or Vegas algorithms
-//! - **[Coalesce]** - Deduplicates concurrent identical requests (singleflight)
+//! - **[Health Check]** - Proactive health monitoring with intelligent resource selection
 //! - **[Outlier Detection]** - Fleet-aware instance ejection based on health tracking
+//! - **[Rate Limiter]** - Controls request rate to protect services
+//! - **[Reconnect]** - Automatic reconnection with configurable backoff strategies
+//! - **[Retry]** - Intelligent retry with exponential backoff and jitter
 //! - **[Router]** - Weighted traffic routing for canary deployments and progressive rollout
+//! - **[Time Limiter]** - Advanced timeout handling with cancellation support
 //!
-//! [Circuit Breaker]: https://docs.rs/tower-resilience-circuitbreaker
+//! [Adaptive]: https://docs.rs/tower-resilience-adaptive
 //! [Bulkhead]: https://docs.rs/tower-resilience-bulkhead
-//! [Time Limiter]: https://docs.rs/tower-resilience-timelimiter
-//! [Retry]: https://docs.rs/tower-resilience-retry
-//! [Rate Limiter]: https://docs.rs/tower-resilience-ratelimiter
 //! [Cache]: https://docs.rs/tower-resilience-cache
-//! [Reconnect]: https://docs.rs/tower-resilience-reconnect
-//! [Health Check]: https://docs.rs/tower-resilience-healthcheck
+//! [Circuit Breaker]: https://docs.rs/tower-resilience-circuitbreaker
+//! [Coalesce]: https://docs.rs/tower-resilience-coalesce
+//! [Executor]: https://docs.rs/tower-resilience-executor
 //! [Fallback]: https://docs.rs/tower-resilience-fallback
 //! [Hedge]: https://docs.rs/tower-resilience-hedge
-//! [Executor]: https://docs.rs/tower-resilience-executor
-//! [Adaptive]: https://docs.rs/tower-resilience-adaptive
-//! [Coalesce]: https://docs.rs/tower-resilience-coalesce
+//! [Health Check]: https://docs.rs/tower-resilience-healthcheck
 //! [Outlier Detection]: https://docs.rs/tower-resilience-outlier
+//! [Rate Limiter]: https://docs.rs/tower-resilience-ratelimiter
+//! [Reconnect]: https://docs.rs/tower-resilience-reconnect
+//! [Retry]: https://docs.rs/tower-resilience-retry
 //! [Router]: https://docs.rs/tower-resilience-router
+//! [Time Limiter]: https://docs.rs/tower-resilience-timelimiter
 //!
 //! # Documentation Guides
 //!
@@ -295,30 +295,27 @@ pub mod use_cases;
 // Re-export core (always available)
 pub use tower_resilience_core as core;
 
-// Re-export patterns based on features
-#[cfg(feature = "circuitbreaker")]
-pub use tower_resilience_circuitbreaker as circuitbreaker;
+// Re-export patterns based on features (alphabetical)
+#[cfg(feature = "adaptive")]
+pub use tower_resilience_adaptive as adaptive;
 
 #[cfg(feature = "bulkhead")]
 pub use tower_resilience_bulkhead as bulkhead;
 
-#[cfg(feature = "timelimiter")]
-pub use tower_resilience_timelimiter as timelimiter;
-
 #[cfg(feature = "cache")]
 pub use tower_resilience_cache as cache;
 
-#[cfg(feature = "retry")]
-pub use tower_resilience_retry as retry;
+#[cfg(feature = "chaos")]
+pub use tower_resilience_chaos as chaos;
 
-#[cfg(feature = "ratelimiter")]
-pub use tower_resilience_ratelimiter as ratelimiter;
+#[cfg(feature = "circuitbreaker")]
+pub use tower_resilience_circuitbreaker as circuitbreaker;
 
-#[cfg(feature = "reconnect")]
-pub use tower_resilience_reconnect as reconnect;
+#[cfg(feature = "coalesce")]
+pub use tower_resilience_coalesce as coalesce;
 
-#[cfg(feature = "healthcheck")]
-pub use tower_resilience_healthcheck as healthcheck;
+#[cfg(feature = "executor")]
+pub use tower_resilience_executor as executor;
 
 #[cfg(feature = "fallback")]
 pub use tower_resilience_fallback as fallback;
@@ -326,23 +323,26 @@ pub use tower_resilience_fallback as fallback;
 #[cfg(feature = "hedge")]
 pub use tower_resilience_hedge as hedge;
 
-#[cfg(feature = "executor")]
-pub use tower_resilience_executor as executor;
-
-#[cfg(feature = "adaptive")]
-pub use tower_resilience_adaptive as adaptive;
-
-#[cfg(feature = "coalesce")]
-pub use tower_resilience_coalesce as coalesce;
+#[cfg(feature = "healthcheck")]
+pub use tower_resilience_healthcheck as healthcheck;
 
 #[cfg(feature = "outlier")]
 pub use tower_resilience_outlier as outlier;
 
+#[cfg(feature = "ratelimiter")]
+pub use tower_resilience_ratelimiter as ratelimiter;
+
+#[cfg(feature = "reconnect")]
+pub use tower_resilience_reconnect as reconnect;
+
+#[cfg(feature = "retry")]
+pub use tower_resilience_retry as retry;
+
 #[cfg(feature = "router")]
 pub use tower_resilience_router as router;
 
-#[cfg(feature = "chaos")]
-pub use tower_resilience_chaos as chaos;
+#[cfg(feature = "timelimiter")]
+pub use tower_resilience_timelimiter as timelimiter;
 
 // Re-export unified error layer types
 #[cfg(feature = "layer")]

--- a/crates/tower-resilience/src/patterns.rs
+++ b/crates/tower-resilience/src/patterns.rs
@@ -5,350 +5,181 @@
 //!
 //! ## Available Patterns
 //!
-//! - [Circuit Breaker](circuit_breaker) - Stop calling failing services
+//! - [Adaptive Concurrency](adaptive) - Dynamic concurrency limiting with AIMD/Vegas
 //! - [Bulkhead](bulkhead) - Isolate resources with concurrency limits
-//! - [Time Limiter](time_limiter) - Enforce operation timeouts
-//! - [Retry](retry) - Retry transient failures with backoff
-//! - [Rate Limiter](rate_limiter) - Control request throughput
 //! - [Cache](cache) - Memoize expensive operations
-//! - [Reconnect](reconnect) - Auto-reconnect persistent connections
-//! - [Health Check](healthcheck) - Proactive resource health monitoring
+//! - [Circuit Breaker](circuit_breaker) - Stop calling failing services
+//! - [Coalesce](coalesce) - Deduplicate concurrent identical requests (singleflight)
+//! - [Executor](executor) - Delegate request processing to dedicated executors
 //! - [Fallback](fallback) - Provide alternative responses on failure
 //! - [Hedge](hedge) - Reduce tail latency with parallel requests
-//! - [Executor](executor) - Delegate request processing to dedicated executors
-//! - [Adaptive Concurrency](adaptive) - Dynamic concurrency limiting with AIMD/Vegas
-//! - [Coalesce](coalesce) - Deduplicate concurrent identical requests (singleflight)
+//! - [Health Check](healthcheck) - Proactive resource health monitoring
 //! - [Outlier Detection](outlier_detection) - Fleet-aware instance ejection based on health tracking
+//! - [Rate Limiter](rate_limiter) - Control request throughput
+//! - [Reconnect](reconnect) - Auto-reconnect persistent connections
+//! - [Retry](retry) - Retry transient failures with backoff
 //! - [Router](router) - Weighted traffic routing for canary deployments
+//! - [Time Limiter](time_limiter) - Enforce operation timeouts
 
-pub mod circuit_breaker {
-    //! # Circuit Breaker
+pub mod adaptive {
+    //! # Adaptive Concurrency
     //!
-    //! Automatically stops calling a failing service to prevent cascading failures and give it
-    //! time to recover.
+    //! Dynamically adjusts concurrency limits based on observed latency and error rates.
+    //! Unlike static concurrency limits (like Bulkhead), adaptive limiters automatically
+    //! find the optimal concurrency for your downstream services.
+    //!
+    //! ## Adaptive vs Bulkhead
+    //!
+    //! **Key distinction**: Adaptive is **self-tuning**, Bulkhead is **statically configured**.
+    //!
+    //! - **Adaptive**: Automatically finds optimal concurrency based on feedback
+    //! - **Bulkhead**: Fixed limit you configure upfront
+    //!
+    //! Use Adaptive when you don't know the right limit or when capacity varies.
+    //! Use Bulkhead when you have a known, fixed resource pool.
+    //!
+    //! ## Algorithms
+    //!
+    //! ### AIMD (Additive Increase Multiplicative Decrease)
+    //!
+    //! Classic TCP-style congestion control:
+    //! - On success with low latency: increase limit by a fixed amount (e.g., +1)
+    //! - On failure or high latency: decrease limit by a factor (e.g., halve it)
+    //!
+    //! Creates a "sawtooth" pattern as it continuously probes for capacity.
+    //! Simple, well-understood, works in most scenarios.
+    //!
+    //! ### Vegas
+    //!
+    //! More sophisticated algorithm using RTT measurements:
+    //! - Estimates queue depth from RTT variations
+    //! - Increases limit when queue is small (under-utilized)
+    //! - Decreases limit when queue is large (congested)
+    //!
+    //! More stable than AIMD, avoids sawtooth pattern, better for latency-sensitive
+    //! applications.
     //!
     //! ## When to Use
     //!
-    //! - **Failing downstream services**: When a dependency is experiencing issues
-    //! - **Cascading failure prevention**: Stop failures from propagating through your system
-    //! - **Graceful degradation**: Provide fallbacks when services are unavailable
-    //! - **Load shedding**: Reduce load on struggling services
+    //! - **Unknown capacity**: Don't know optimal concurrency for downstream
+    //! - **Variable backends**: Capacity changes due to autoscaling, load, etc.
+    //! - **Auto-tuning**: Want "set it and forget it" concurrency management
+    //! - **Latency optimization**: Need to keep latency low while maximizing throughput
     //!
     //! ## Trade-offs
     //!
-    //! - **Fail fast vs retry**: Circuit breaker fails immediately when open (combine with retry for best results)
-    //! - **State overhead**: Requires tracking call history (~100-1000 calls)
-    //! - **Tuning complexity**: Requires careful threshold configuration
-    //! - **False positives**: May trip during legitimate traffic spikes
+    //! - **Warm-up time**: Takes time to find optimal limit
+    //! - **Oscillation**: AIMD continuously probes, causing limit fluctuations
+    //! - **Shared fate**: All callers share the same limit
+    //! - **Algorithm choice**: AIMD vs Vegas requires understanding your workload
     //!
     //! ## Real-World Scenarios
     //!
     //! ```text
-    //! Database Replica Failover
-    //! ├─ Primary database becomes slow/unresponsive
-    //! ├─ Circuit breaker opens after 50% failure rate
-    //! ├─ Application switches to read replica
-    //! └─ Periodic health checks test primary recovery
+    //! Auto-scaling Backend
+    //! ├─ Backend starts with 2 pods (low capacity)
+    //! ├─ Adaptive limiter finds limit ~20
+    //! ├─ Backend scales to 10 pods
+    //! ├─ Latency drops, limiter increases to ~100
+    //! └─ Throughput automatically maximized
     //!
-    //! External API Integration
-    //! ├─ Third-party API rate limits or goes down
-    //! ├─ Circuit opens to prevent timeout pile-up
-    //! ├─ Fallback to cached data or degraded experience
-    //! └─ Automatic recovery when API stabilizes
-    //! ```
-    //!
-    //! ## Anti-Patterns
-    //!
-    //! ❌ **Too aggressive thresholds**: Tripping on temporary blips
-    //! ✅ Use minimum call counts and reasonable windows (e.g., 50% over 100 calls)
-    //!
-    //! ❌ **No fallback strategy**: Users see errors when circuit opens
-    //! ✅ Provide cached data, default values, or graceful degradation
-    //!
-    //! ❌ **Using alone for retries**: Circuit breaker doesn't retry
-    //! ✅ Combine with retry layer for transient failures
-    //!
-    //! ## Example
-    //!
-    //! ```rust,no_run
-    //! # #[cfg(feature = "circuitbreaker")]
-    //! # {
-    //! use tower_resilience::circuitbreaker::CircuitBreakerLayer;
-    //! use tower::Layer;
-    //! use std::time::Duration;
-    //!
-    //! # async fn example() {
-    //! # let database_client = tower::service_fn(|_req: ()| async { Ok::<_, std::io::Error>(()) });
-    //! let circuit_breaker = CircuitBreakerLayer::builder()
-    //!     .failure_rate_threshold(0.5)      // Open at 50% failures
-    //!     .sliding_window_size(100)         // Over last 100 calls
-    //!     .minimum_number_of_calls(10)      // Need at least 10 calls
-    //!     .wait_duration_in_open(Duration::from_secs(30))  // Stay open 30s
-    //!     .build();
-    //!
-    //! let service = circuit_breaker.layer(database_client);
-    //! # }
-    //! # }
-    //! ```
-}
-
-pub mod healthcheck {
-    //! # Health Check
-    //!
-    //! Proactive health monitoring for resources with intelligent selection strategies.
-    //! Continuously checks resource health in the background and provides access to
-    //! healthy resources on demand.
-    //!
-    //! ## Health Check vs Circuit Breaker
-    //!
-    //! **Key distinction**: Health Check is **proactive**, Circuit Breaker is **reactive**.
-    //!
-    //! - **Health Check**: Monitors resources *before* use, prevents failures
-    //! - **Circuit Breaker**: Responds *after* failures happen, limits damage
-    //!
-    //! These patterns **complement each other perfectly**:
-    //! - Health Check layer selects healthy resources
-    //! - Circuit Breaker layer protects against cascading failures
-    //!
-    //! ## When to Use
-    //!
-    //! ✅ **Multiple resource instances**: Primary/secondary databases, regional endpoints
-    //! ✅ **Automatic failover**: Switch to healthy resources without manual intervention
-    //! ✅ **Load distribution**: Round-robin or weighted selection across healthy instances
-    //! ✅ **Kubernetes readiness**: Export health status for K8s probes
-    //!
-    //! ❌ **Single resource**: Use Circuit Breaker instead
-    //! ❌ **Request-level failures**: Use Retry layer
-    //! ❌ **Middleware composition**: Health Check is not a Tower layer
-    //!
-    //! ## Design Philosophy
-    //!
-    //! Health Check is **not a Tower layer** - it's a wrapper pattern that manages multiple
-    //! resources:
-    //!
-    //! ```text
-    //! Tower Layers (middleware):        Health Check (resource manager):
-    //!   Request → Retry →                  ┌─────────────────┐
-    //!             CircuitBreaker →         │  Health Wrapper │
-    //!             Service                  │  - primary ✓    │
-    //!                                      │  - secondary ✓  │
-    //!                                      │  - tertiary ✗   │
-    //!                                      └─────────────────┘
-    //!                                            ↓
-    //!                                      Select healthy resource
-    //! ```
-    //!
-    //! ## Selection Strategies
-    //!
-    //! ### FirstAvailable (Default)
-    //! Returns the first healthy resource. Best for primary/secondary failover.
-    //!
-    //! ### RoundRobin
-    //! Distributes load evenly across healthy resources.
-    //!
-    //! ### Random
-    //! Randomly selects from healthy resources (requires `random` feature).
-    //!
-    //! ### PreferHealthy
-    //! Prefers fully healthy resources, falls back to degraded if needed.
-    //!
-    //! ### Custom
-    //! Implement custom logic (latency-based, geographic proximity, weighted, etc.).
-    //!
-    //! ## Health Status States
-    //!
-    //! - **Healthy**: Resource is fully operational
-    //! - **Degraded**: Resource is slow but functional (high latency)
-    //! - **Unhealthy**: Resource should not be used
-    //! - **Unknown**: Not yet checked or check failed
-    //!
-    //! ## Trade-offs
-    //!
-    //! ### Advantages
-    //! - **Proactive**: Catches issues before use
-    //! - **Automatic failover**: No manual intervention needed
-    //! - **Flexible selection**: Multiple strategies for different use cases
-    //! - **Observable**: Export health status for monitoring
-    //!
-    //! ### Limitations
-    //! - **Not a layer**: Cannot compose with Tower middleware
-    //! - **Resource overhead**: Background health checks consume resources
-    //! - **Complexity**: Requires managing multiple resource instances
-    //! - **Health check design**: Poor health checks give false positives/negatives
-    //!
-    //! ## Real-World Scenarios
-    //!
-    //! ```text
-    //! Database Failover
-    //! ├─ Primary database: healthy
-    //! ├─ Secondary database: healthy
-    //! ├─ Primary fails → automatic switch to secondary
-    //! └─ Primary recovers → can switch back
-    //!
-    //! Regional API Endpoints
-    //! ├─ us-west: healthy (50ms latency)
-    //! ├─ us-east: healthy (120ms latency)
-    //! ├─ eu-west: degraded (300ms latency)
-    //! └─ Round-robin between us-west and us-east (eu-west used only if needed)
-    //!
-    //! Redis Cluster
-    //! ├─ Node 1: healthy
-    //! ├─ Node 2: healthy
-    //! ├─ Node 3: unhealthy (connection refused)
-    //! └─ Distribute load across nodes 1 and 2
-    //! ```
-    //!
-    //! ## Anti-Patterns
-    //!
-    //! ❌ **Too frequent checks**: Health checks every 100ms waste resources
-    //! ✅ Check every 5-30 seconds for most use cases
-    //!
-    //! ❌ **Expensive health checks**: Full database query takes 2 seconds
-    //! ✅ Simple ping/SELECT 1 takes milliseconds
-    //!
-    //! ❌ **No threshold**: One failure marks as unhealthy
-    //! ✅ Require 2-3 consecutive failures to prevent flapping
-    //!
-    //! ❌ **Ignoring degraded state**: Treat slow as failed
-    //! ✅ Use degraded resources when all healthy ones are down
-    //!
-    //! ## Example
-    //!
-    //! ```rust,ignore
-    //! use tower_resilience_healthcheck::{
-    //!     HealthCheckWrapper, HealthStatus, SelectionStrategy
-    //! };
-    //! use std::time::Duration;
-    //!
-    //! # #[derive(Clone)]
-    //! # struct Database { name: String }
-    //! # impl Database {
-    //! #     async fn ping(&self) -> Result<(), std::io::Error> { Ok(()) }
-    //! # }
-    //! # async fn example() {
-    //! # let primary_db = Database { name: "primary".into() };
-    //! # let secondary_db = Database { name: "secondary".into() };
-    //! // Create wrapper with multiple databases
-    //! let wrapper = HealthCheckWrapper::builder()
-    //!     .with_context(primary_db, "primary")
-    //!     .with_context(secondary_db, "secondary")
-    //!     .with_checker(|db| async move {
-    //!         match db.ping().await {
-    //!             Ok(_) => HealthStatus::Healthy,
-    //!             Err(_) => HealthStatus::Unhealthy,
-    //!         }
-    //!     })
-    //!     .with_interval(Duration::from_secs(10))
-    //!     .with_failure_threshold(3)  // 3 failures before marking unhealthy
-    //!     .with_success_threshold(2)  // 2 successes to recover
-    //!     .with_selection_strategy(SelectionStrategy::RoundRobin)
-    //!     .build();
-    //!
-    //! // Start background health checking
-    //! wrapper.start().await;
-    //!
-    //! // Get a healthy database
-    //! if let Some(db) = wrapper.get_healthy().await {
-    //!     // Use healthy database
-    //! }
-    //!
-    //! // Get health status for monitoring
-    //! let details = wrapper.get_health_details().await;
-    //! for detail in details {
-    //!     println!("{}: {:?}", detail.name, detail.status);
-    //! }
-    //! # }
-    //! ```
-}
-
-pub mod reconnect {
-    //! # Reconnect
-    //!
-    //! Automatically reconnects to services with configurable backoff strategies when
-    //! connection failures occur. Designed for **persistent connections** where the connection
-    //! state matters (databases, Redis, message queues, WebSockets).
-    //!
-    //! ## Reconnect vs Retry
-    //!
-    //! **Key distinction**: Reconnect manages **connection lifecycle**, Retry manages **operation resilience**.
-    //!
-    //! - **Reconnect**: Use for persistent connections that can break (Redis, databases, gRPC streams)
-    //! - **Retry**: Use for transient request failures on working connections (timeouts, rate limits)
-    //!
-    //! For persistent connection services, you often want BOTH:
-    //! - Reconnect layer handles connection-level errors (BrokenPipe, ConnectionReset)
-    //! - Retry layer handles application-level errors (RateLimited, Busy, Timeout)
-    //!
-    //! ## When to Use
-    //!
-    //! - **Persistent connections**: Redis, databases, message queues, WebSockets
-    //! - **Unstable connections**: Network issues, transient failures
-    //! - **Service restarts**: Backend services that periodically restart
-    //! - **Connection pooling**: Reconnect stale or broken connections
-    //! - **Distributed systems**: Handle network partitions gracefully
-    //!
-    //! ## Trade-offs
-    //!
-    //! - **Latency impact**: Reconnection attempts add delay to requests
-    //! - **Resource usage**: Failed connections consume resources during backoff
-    //! - **Complexity**: Adds state management for connection tracking
-    //! - **Thundering herd**: Multiple clients reconnecting simultaneously
-    //!
-    //! ## Real-World Scenarios
-    //!
-    //! ```text
     //! Database Connection Pool
-    //! ├─ Connection closed by server after idle timeout
-    //! ├─ Reconnect with exponential backoff (100ms -> 5s)
-    //! ├─ Retry original query after successful reconnection
-    //! └─ Application remains resilient to connection drops
+    //! ├─ Unknown optimal connection count
+    //! ├─ Vegas algorithm monitors query latency
+    //! ├─ Limit increases until queue builds up
+    //! ├─ Settles at optimal ~50 connections
+    //! └─ Adapts as query patterns change
     //!
-    //! Message Queue Consumer
-    //! ├─ Broker temporarily unavailable during deployment
-    //! ├─ Reconnect with fixed 1s intervals, unlimited attempts
-    //! ├─ Resume consuming messages when broker returns
-    //! └─ No message loss or manual intervention
+    //! External API with Variable Rate Limits
+    //! ├─ API has undocumented rate limits
+    //! ├─ AIMD probes for capacity
+    //! ├─ Backs off when 429s are returned
+    //! └─ Finds sustainable request rate
     //! ```
     //!
     //! ## Anti-Patterns
     //!
-    //! ❌ **Immediate retry**: Overwhelming failing service
-    //! ✅ Use exponential backoff to give service time to recover
+    //! ❌ **Too aggressive decrease factor**: Limit drops too fast, under-utilizes
+    //! ✅ Start with 0.5-0.9 decrease factor
     //!
-    //! ❌ **Unlimited attempts without monitoring**: Silent failures pile up
-    //! ✅ Set max attempts for user-facing operations, monitor reconnection rates
+    //! ❌ **No minimum limit**: Can drop to 0 and never recover
+    //! ✅ Always set min_limit >= 1
     //!
-    //! ❌ **No connection state tracking**: Can't determine system health
-    //! ✅ Expose connection state for health checks and observability
+    //! ❌ **Latency threshold too low**: Normal variance triggers decreases
+    //! ✅ Set threshold to P90-P99 latency, not P50
     //!
-    //! ❌ **Reconnecting on non-retryable errors**: Permanent failures waste resources
-    //! ✅ Distinguish transient (network) from permanent (auth) errors
+    //! ❌ **Using for isolation**: Adaptive shares limit across all callers
+    //! ✅ Use Bulkhead for tenant/resource isolation
     //!
-    //! ## Example
+    //! ## Example: AIMD Algorithm
     //!
     //! ```rust,no_run
-    //! # #[cfg(feature = "reconnect")]
+    //! # #[cfg(feature = "adaptive")]
     //! # {
-    //! use tower_resilience_reconnect::{ReconnectLayer, ReconnectConfig, ReconnectPolicy};
-    //! use tower::Layer;
+    //! use tower_resilience::adaptive::{AdaptiveLimiterLayer, Aimd};
+    //! use tower::ServiceBuilder;
     //! use std::time::Duration;
     //!
     //! # async fn example() {
-    //! # let database_service = tower::service_fn(|_req: ()| async { Ok::<_, std::io::Error>(()) });
-    //! let reconnect = ReconnectLayer::new(
-    //!     ReconnectConfig::builder()
-    //!         .policy(ReconnectPolicy::exponential(
-    //!             Duration::from_millis(100),  // Start at 100ms
-    //!             Duration::from_secs(5),      // Max 5 seconds
-    //!         ))
-    //!         .max_attempts(10)
-    //!         .retry_on_reconnect(true)  // Retry original request
+    //! # let my_service = tower::service_fn(|_req: ()| async { Ok::<_, std::io::Error>(()) });
+    //! let layer = AdaptiveLimiterLayer::new(
+    //!     Aimd::builder()
+    //!         .initial_limit(10)
+    //!         .min_limit(1)
+    //!         .max_limit(100)
+    //!         .increase_by(1)
+    //!         .decrease_factor(0.5)
+    //!         .latency_threshold(Duration::from_millis(100))
     //!         .build()
     //! );
     //!
-    //! let service = reconnect.layer(database_service);
+    //! let service = ServiceBuilder::new()
+    //!     .layer(layer)
+    //!     .service(my_service);
     //! # }
     //! # }
+    //! ```
+    //!
+    //! ## Example: Vegas Algorithm
+    //!
+    //! ```rust,no_run
+    //! # #[cfg(feature = "adaptive")]
+    //! # {
+    //! use tower_resilience::adaptive::{AdaptiveLimiterLayer, Vegas};
+    //! use tower::ServiceBuilder;
+    //!
+    //! # async fn example() {
+    //! # let my_service = tower::service_fn(|_req: ()| async { Ok::<_, std::io::Error>(()) });
+    //! let layer = AdaptiveLimiterLayer::new(
+    //!     Vegas::builder()
+    //!         .initial_limit(10)
+    //!         .min_limit(1)
+    //!         .max_limit(100)
+    //!         .alpha(3)   // Increase when queue < 3
+    //!         .beta(6)    // Decrease when queue > 6
+    //!         .build()
+    //! );
+    //!
+    //! let service = ServiceBuilder::new()
+    //!     .layer(layer)
+    //!     .service(my_service);
+    //! # }
+    //! # }
+    //! ```
+    //!
+    //! ## Example: Composition with Circuit Breaker
+    //!
+    //! ```rust,ignore
+    //! use tower_resilience::adaptive::{AdaptiveLimiterLayer, Aimd};
+    //! use tower_resilience::circuitbreaker::CircuitBreakerLayer;
+    //! use tower::ServiceBuilder;
+    //!
+    //! // Circuit breaker catches catastrophic failures
+    //! // Adaptive limiter optimizes throughput
+    //! let service = ServiceBuilder::new()
+    //!     .layer(CircuitBreakerLayer::builder().build())
+    //!     .layer(AdaptiveLimiterLayer::new(Aimd::builder().build()))
+    //!     .service(my_service);
     //! ```
 }
 
@@ -425,243 +256,6 @@ pub mod bulkhead {
     //! ```
 }
 
-pub mod time_limiter {
-    //! # Time Limiter
-    //!
-    //! Enforces timeouts on operations with optional future cancellation.
-    //!
-    //! ## When to Use
-    //!
-    //! - **Unbounded operations**: Database queries, external APIs
-    //! - **SLA enforcement**: Guarantee response times
-    //! - **Resource protection**: Prevent long-running tasks from accumulating
-    //! - **Circuit breaker complement**: Timeouts count as failures
-    //!
-    //! ## Trade-offs
-    //!
-    //! - **Cancellation semantics**: Dropping futures may not cancel underlying work
-    //! - **Partial work cleanup**: Need to handle incomplete operations
-    //! - **Timeout selection**: Too short causes false failures, too long defeats purpose
-    //! - **Overhead**: Timer overhead for every call (~100ns)
-    //!
-    //! ## Real-World Scenarios
-    //!
-    //! ```text
-    //! Database Query Timeout
-    //! ├─ Query has 5s timeout
-    //! ├─ Slow query triggers timeout
-    //! ├─ Connection returned to pool (if cancel_running_future=true)
-    //! └─ User sees timeout error instead of hanging
-    //!
-    //! External API Call
-    //! ├─ API call has 10s timeout
-    //! ├─ Network issue causes hang
-    //! ├─ Timeout fires, request fails fast
-    //! └─ Circuit breaker may open if timeouts are frequent
-    //! ```
-    //!
-    //! ## Anti-Patterns
-    //!
-    //! ❌ **Timeout too short**: Legitimate slow operations fail
-    //! ✅ Set timeout to P99 latency + buffer
-    //!
-    //! ❌ **No cleanup on timeout**: Resources leak
-    //! ✅ Use `cancel_running_future=true` when appropriate
-    //!
-    //! ❌ **Same timeout everywhere**: Different operations need different limits
-    //! ✅ Configure per-endpoint or per-operation
-    //!
-    //! ## Presets
-    //!
-    //! ```rust,no_run
-    //! # #[cfg(feature = "timelimiter")]
-    //! # {
-    //! use tower_resilience::timelimiter::TimeLimiterLayer;
-    //!
-    //! let fast = TimeLimiterLayer::fast().build();        // 1s, cancel on timeout
-    //! let standard = TimeLimiterLayer::standard().build(); // 5s, cancel on timeout
-    //! let slow = TimeLimiterLayer::slow().build();         // 30s, cancel on timeout
-    //! let stream = TimeLimiterLayer::streaming().build();  // 60s, no cancellation
-    //! # }
-    //! ```
-    //!
-    //! ## Example
-    //!
-    //! ```rust,no_run
-    //! # #[cfg(feature = "timelimiter")]
-    //! # {
-    //! use tower_resilience::timelimiter::TimeLimiterLayer;
-    //! use tower::Layer;
-    //! use std::time::Duration;
-    //!
-    //! # async fn example() {
-    //! # let database_query = tower::service_fn(|_req: ()| async { Ok::<_, std::io::Error>(()) });
-    //! let time_limiter = TimeLimiterLayer::builder()
-    //!     .timeout_duration(Duration::from_secs(5))
-    //!     .cancel_running_future(true)
-    //!     .on_timeout(|| {
-    //!         eprintln!("Query timeout");
-    //!     })
-    //!     .build();
-    //!
-    //! let service = tower::ServiceBuilder::new()
-    //!     .layer(time_limiter)
-    //!     .service(database_query);
-    //! # }
-    //! # }
-    //! ```
-}
-
-pub mod retry {
-    //! # Retry
-    //!
-    //! Automatically retries failed operations with configurable backoff strategies.
-    //!
-    //! ## When to Use
-    //!
-    //! - **Transient failures**: Network blips, temporary resource unavailability
-    //! - **Rate limiting**: 429 responses with retry-after
-    //! - **Database deadlocks**: Transient conflicts
-    //! - **Eventually consistent systems**: Retry until data is available
-    //!
-    //! ## Trade-offs
-    //!
-    //! - **Latency vs success rate**: Retries add latency but improve success
-    //! - **Amplification effects**: Retries multiply load on failing services
-    //! - **Idempotency requirements**: Safe retries require idempotent operations
-    //! - **Jitter importance**: Without jitter, retries create thundering herd
-    //!
-    //! ## Real-World Scenarios
-    //!
-    //! ```text
-    //! Network Transient Errors
-    //! ├─ Connection reset by peer
-    //! ├─ Retry with 100ms exponential backoff
-    //! ├─ Success on 2nd attempt
-    //! └─ User doesn't see error
-    //!
-    //! API Rate Limiting
-    //! ├─ Receive 429 Too Many Requests
-    //! ├─ Retry-After: 1s header
-    //! ├─ Wait 1s + jitter
-    //! └─ Retry succeeds
-    //! ```
-    //!
-    //! ## Anti-Patterns
-    //!
-    //! ❌ **Retrying non-idempotent operations**: Duplicate charges, double-sends
-    //! ✅ Only retry GET, HEAD, PUT, DELETE; use idempotency keys for POST
-    //!
-    //! ❌ **No jitter**: All clients retry at same time (thundering herd)
-    //! ✅ Use `exponential_backoff` with randomization
-    //!
-    //! ❌ **Infinite retries**: Never give up
-    //! ✅ Set reasonable `max_attempts` (3-5)
-    //!
-    //! ❌ **Retrying 4xx errors**: Client errors won't succeed on retry
-    //! ✅ Use retry predicate to only retry 5xx, network errors
-    //!
-    //! ## Example
-    //!
-    //! ```rust,no_run
-    //! # #[cfg(feature = "retry")]
-    //! # {
-    //! use tower_resilience::retry::RetryLayer;
-    //! use tower::Layer;
-    //! use std::time::Duration;
-    //!
-    //! # #[derive(Debug, Clone)]
-    //! # struct MyError;
-    //! # async fn example() {
-    //! # let http_client = tower::service_fn(|_req: ()| async { Ok::<_, MyError>(()) });
-    //! let retry = RetryLayer::<(), (), MyError>::builder()
-    //!     .max_attempts(3)
-    //!     .exponential_backoff(Duration::from_millis(100))
-    //!     .retry_on(|err: &MyError| {
-    //!         // Only retry transient errors
-    //!         true  // Check if error is retryable
-    //!     })
-    //!     .build();
-    //!
-    //! let service = tower::ServiceBuilder::new()
-    //!     .layer(retry)
-    //!     .service(http_client);
-    //! # }
-    //! # }
-    //! ```
-}
-
-pub mod rate_limiter {
-    //! # Rate Limiter
-    //!
-    //! Controls the rate of requests to protect downstream services and enforce quotas.
-    //!
-    //! ## When to Use
-    //!
-    //! - **Quota enforcement**: Per-user, per-tenant API limits
-    //! - **Protecting resources**: Prevent overwhelming databases or APIs
-    //! - **Fairness**: Ensure fair access to shared resources
-    //! - **Cost control**: Limit expensive operations
-    //!
-    //! ## Trade-offs
-    //!
-    //! - **Throughput vs fairness**: Token bucket allows bursts
-    //! - **Burst handling**: Should you allow temporary spikes?
-    //! - **Rejection strategy**: Drop, queue, or return error?
-    //! - **Distributed coordination**: Single-node vs multi-node limits
-    //!
-    //! ## Real-World Scenarios
-    //!
-    //! ```text
-    //! Per-User API Limits
-    //! ├─ Free tier: 100 req/min
-    //! ├─ Pro tier: 1000 req/min
-    //! ├─ Burst allowance for good UX
-    //! └─ Return 429 when exceeded
-    //!
-    //! Downstream Protection
-    //! ├─ Database has 1000 QPS limit
-    //! ├─ Rate limit to 800 QPS (80% capacity)
-    //! ├─ Prevents database overload
-    //! └─ Predictable performance
-    //! ```
-    //!
-    //! ## Anti-Patterns
-    //!
-    //! ❌ **Global limits only**: One tenant can exhaust quota for all
-    //! ✅ Per-tenant/per-user limits with global backstop
-    //!
-    //! ❌ **No burst allowance**: Poor user experience for spiky traffic
-    //! ✅ Allow some burst (e.g., 2x rate for 1 second)
-    //!
-    //! ❌ **Using for concurrency limits**: Rate ≠ concurrency
-    //! ✅ Use bulkhead for concurrency, rate limiter for throughput
-    //!
-    //! ## Example
-    //!
-    //! ```rust,no_run
-    //! # #[cfg(feature = "ratelimiter")]
-    //! # {
-    //! use tower_resilience::ratelimiter::RateLimiterLayer;
-    //! use tower::Layer;
-    //! use std::time::Duration;
-    //!
-    //! # async fn example() {
-    //! # let api_handler = tower::service_fn(|_req: ()| async { Ok::<_, std::io::Error>(()) });
-    //! let rate_limiter = RateLimiterLayer::builder()
-    //!     .limit_for_period(100)                    // 100 requests
-    //!     .refresh_period(Duration::from_secs(1))   // per second
-    //!     .timeout_duration(Duration::from_millis(100))  // Wait up to 100ms
-    //!     .build();
-    //!
-    //! let service = tower::ServiceBuilder::new()
-    //!     .layer(rate_limiter)
-    //!     .service(api_handler);
-    //! # }
-    //! # }
-    //! ```
-}
-
 pub mod cache {
     //! # Cache
     //!
@@ -733,6 +327,362 @@ pub mod cache {
     //! let service = tower::ServiceBuilder::new()
     //!     .layer(cache)
     //!     .service(expensive_operation);
+    //! # }
+    //! # }
+    //! ```
+}
+
+pub mod circuit_breaker {
+    //! # Circuit Breaker
+    //!
+    //! Automatically stops calling a failing service to prevent cascading failures and give it
+    //! time to recover.
+    //!
+    //! ## When to Use
+    //!
+    //! - **Failing downstream services**: When a dependency is experiencing issues
+    //! - **Cascading failure prevention**: Stop failures from propagating through your system
+    //! - **Graceful degradation**: Provide fallbacks when services are unavailable
+    //! - **Load shedding**: Reduce load on struggling services
+    //!
+    //! ## Trade-offs
+    //!
+    //! - **Fail fast vs retry**: Circuit breaker fails immediately when open (combine with retry for best results)
+    //! - **State overhead**: Requires tracking call history (~100-1000 calls)
+    //! - **Tuning complexity**: Requires careful threshold configuration
+    //! - **False positives**: May trip during legitimate traffic spikes
+    //!
+    //! ## Real-World Scenarios
+    //!
+    //! ```text
+    //! Database Replica Failover
+    //! ├─ Primary database becomes slow/unresponsive
+    //! ├─ Circuit breaker opens after 50% failure rate
+    //! ├─ Application switches to read replica
+    //! └─ Periodic health checks test primary recovery
+    //!
+    //! External API Integration
+    //! ├─ Third-party API rate limits or goes down
+    //! ├─ Circuit opens to prevent timeout pile-up
+    //! ├─ Fallback to cached data or degraded experience
+    //! └─ Automatic recovery when API stabilizes
+    //! ```
+    //!
+    //! ## Anti-Patterns
+    //!
+    //! ❌ **Too aggressive thresholds**: Tripping on temporary blips
+    //! ✅ Use minimum call counts and reasonable windows (e.g., 50% over 100 calls)
+    //!
+    //! ❌ **No fallback strategy**: Users see errors when circuit opens
+    //! ✅ Provide cached data, default values, or graceful degradation
+    //!
+    //! ❌ **Using alone for retries**: Circuit breaker doesn't retry
+    //! ✅ Combine with retry layer for transient failures
+    //!
+    //! ## Example
+    //!
+    //! ```rust,no_run
+    //! # #[cfg(feature = "circuitbreaker")]
+    //! # {
+    //! use tower_resilience::circuitbreaker::CircuitBreakerLayer;
+    //! use tower::Layer;
+    //! use std::time::Duration;
+    //!
+    //! # async fn example() {
+    //! # let database_client = tower::service_fn(|_req: ()| async { Ok::<_, std::io::Error>(()) });
+    //! let circuit_breaker = CircuitBreakerLayer::builder()
+    //!     .failure_rate_threshold(0.5)      // Open at 50% failures
+    //!     .sliding_window_size(100)         // Over last 100 calls
+    //!     .minimum_number_of_calls(10)      // Need at least 10 calls
+    //!     .wait_duration_in_open(Duration::from_secs(30))  // Stay open 30s
+    //!     .build();
+    //!
+    //! let service = circuit_breaker.layer(database_client);
+    //! # }
+    //! # }
+    //! ```
+}
+
+pub mod coalesce {
+    //! # Coalesce (Singleflight)
+    //!
+    //! Deduplicates concurrent identical requests, ensuring only one request executes
+    //! while others wait for its result. All callers receive a clone of the result.
+    //! This prevents "cache stampede" or "thundering herd" problems.
+    //!
+    //! ## Coalesce vs Cache
+    //!
+    //! **Key distinction**: Coalesce deduplicates **in-flight requests**, Cache stores **completed results**.
+    //!
+    //! - **Coalesce**: Multiple concurrent requests for same key share ONE execution
+    //! - **Cache**: Stores results after completion for future requests
+    //!
+    //! These patterns **complement each other perfectly**:
+    //! - Cache layer stores completed results
+    //! - Coalesce layer prevents stampede on cache miss
+    //!
+    //! ## How It Works
+    //!
+    //! ```text
+    //! Without Coalesce:                With Coalesce:
+    //! ─────────────────                ──────────────
+    //! Request A ──→ Backend            Request A ──→ Backend
+    //! Request B ──→ Backend            Request B ──┐
+    //! Request C ──→ Backend            Request C ──┤ Wait for A
+    //! (3 backend calls)                Request D ──┘
+    //!                                  (1 backend call, 4 responses)
+    //! ```
+    //!
+    //! ## When to Use
+    //!
+    //! - **Cache refresh protection**: When cached value expires, multiple requests may
+    //!   try to refresh simultaneously. Coalescing ensures only one refresh happens.
+    //!
+    //! - **Expensive computations**: Deduplicate requests for the same expensive operation
+    //!   (e.g., report generation, ML inference, complex queries).
+    //!
+    //! - **Rate-limited APIs**: Reduce calls to external APIs that have rate limits by
+    //!   coalescing identical requests within a time window.
+    //!
+    //! - **Database queries**: Combine identical queries that arrive within a short window
+    //!   to reduce database load.
+    //!
+    //! - **Microservice fanout**: When multiple internal services request the same data,
+    //!   coalesce to avoid redundant downstream calls.
+    //!
+    //! ## Requirements
+    //!
+    //! - **Key type**: Must implement `Hash + Eq + Clone + Send + Sync`
+    //! - **Response type**: Must implement `Clone` (to distribute to all waiters)
+    //! - **Error type**: Must implement `Clone` (errors are also distributed)
+    //!
+    //! ## Trade-offs
+    //!
+    //! - **Latency coupling**: All waiters blocked on slowest request
+    //! - **Error propagation**: One failure affects all waiters
+    //! - **Clone overhead**: Response cloned for each waiter
+    //! - **Memory**: In-flight tracking consumes memory
+    //!
+    //! ## Real-World Scenarios
+    //!
+    //! ```text
+    //! Cache Stampede Prevention
+    //! ├─ Popular item cache expires
+    //! ├─ 1000 requests arrive simultaneously
+    //! ├─ Without coalescing: 1000 database queries
+    //! ├─ With coalescing: 1 database query, 1000 cloned responses
+    //! └─ Database load reduced by 99.9%
+    //!
+    //! Report Generation
+    //! ├─ User A requests monthly report
+    //! ├─ User B requests same report while A's is generating
+    //! ├─ Only one report generated
+    //! └─ Both users receive the same result
+    //!
+    //! External API Protection
+    //! ├─ Multiple services need weather data for same city
+    //! ├─ External API has 100 req/min limit
+    //! ├─ Coalescing reduces calls from 50/sec to 1/sec
+    //! └─ Stay well under rate limit
+    //! ```
+    //!
+    //! ## Anti-Patterns
+    //!
+    //! ❌ **Coalescing non-idempotent operations**: Side effects may be skipped
+    //! ✅ Only coalesce read operations or truly idempotent writes
+    //!
+    //! ❌ **Large response objects**: Clone overhead exceeds savings
+    //! ✅ Return `Arc<Response>` or small response types
+    //!
+    //! ❌ **Long-running requests**: Waiters blocked for extended time
+    //! ✅ Combine with time limiter to bound wait time
+    //!
+    //! ❌ **Unique request keys**: Every request has different key
+    //! ✅ Design keys to maximize coalescing opportunities
+    //!
+    //! ## Example: Basic Usage
+    //!
+    //! ```rust,no_run
+    //! # #[cfg(feature = "coalesce")]
+    //! # {
+    //! use tower_resilience::coalesce::CoalesceLayer;
+    //! use tower::ServiceBuilder;
+    //!
+    //! # #[derive(Clone, Hash, Eq, PartialEq)]
+    //! # struct Request { user_id: u64 }
+    //! # #[derive(Clone)]
+    //! # struct Response;
+    //! # #[derive(Debug, Clone)]
+    //! # struct MyError;
+    //! # async fn example() {
+    //! # let user_service = tower::service_fn(|_req: Request| async { Ok::<_, MyError>(Response) });
+    //! // Coalesce by user_id - concurrent requests for same user share execution
+    //! let layer = CoalesceLayer::new(|req: &Request| req.user_id);
+    //!
+    //! let service = ServiceBuilder::new()
+    //!     .layer(layer)
+    //!     .service(user_service);
+    //! # }
+    //! # }
+    //! ```
+    //!
+    //! ## Example: With Cache Layer
+    //!
+    //! ```rust,no_run
+    //! # #[cfg(all(feature = "coalesce", feature = "cache"))]
+    //! # {
+    //! use tower_resilience::coalesce::CoalesceLayer;
+    //! use tower_resilience::cache::CacheLayer;
+    //! use tower::ServiceBuilder;
+    //! use std::time::Duration;
+    //!
+    //! # #[derive(Clone, Hash, Eq, PartialEq)]
+    //! # struct Request { id: String }
+    //! # #[derive(Clone)]
+    //! # struct Response;
+    //! # #[derive(Debug, Clone)]
+    //! # struct MyError;
+    //! # async fn example() {
+    //! # let backend = tower::service_fn(|_req: Request| async { Ok::<_, MyError>(Response) });
+    //! // Cache stores results, Coalesce prevents stampede on cache miss
+    //! let cache = CacheLayer::builder()
+    //!     .max_size(1000)
+    //!     .ttl(Duration::from_secs(300))
+    //!     .key_extractor(|req: &Request| req.id.clone())
+    //!     .build();
+    //!
+    //! let coalesce = CoalesceLayer::new(|req: &Request| req.id.clone());
+    //!
+    //! let service = ServiceBuilder::new()
+    //!     .layer(cache)      // Check cache first
+    //!     .layer(coalesce)   // Coalesce cache misses
+    //!     .service(backend);
+    //! # }
+    //! # }
+    //! ```
+    //!
+    //! ## Example: Named Instance
+    //!
+    //! ```rust,no_run
+    //! # #[cfg(feature = "coalesce")]
+    //! # {
+    //! use tower_resilience::coalesce::CoalesceLayer;
+    //! use tower::ServiceBuilder;
+    //!
+    //! # #[derive(Debug, Clone)]
+    //! # struct MyError;
+    //! # async fn example() {
+    //! # let report_generator = tower::service_fn(|_req: String| async { Ok::<_, MyError>("report".to_string()) });
+    //! let layer = CoalesceLayer::builder(|req: &String| req.clone())
+    //!     .name("report-coalesce")
+    //!     .build();
+    //!
+    //! let service = ServiceBuilder::new()
+    //!     .layer(layer)
+    //!     .service(report_generator);
+    //! # }
+    //! # }
+    //! ```
+    //!
+    //! ## Prior Art
+    //!
+    //! This pattern is also known as:
+    //! - **Singleflight** (Go's `golang.org/x/sync/singleflight`)
+    //! - **Request deduplication**
+    //! - **Request collapsing**
+}
+
+/// Outlier Detection pattern guide
+
+pub mod executor {
+    //! # Executor
+    //!
+    //! Delegates request processing to dedicated executors for parallel execution,
+    //! runtime isolation, or thread pool delegation.
+    //!
+    //! ## When to Use
+    //!
+    //! - **CPU-bound processing**: Parallelize CPU-intensive request handling
+    //! - **Runtime isolation**: Process requests on a dedicated runtime
+    //! - **Thread pool delegation**: Use specific thread pools for certain workloads
+    //! - **Work stealing**: Distribute work across multiple worker threads
+    //!
+    //! ## Trade-offs
+    //!
+    //! - **Overhead**: Spawning tasks adds scheduling overhead
+    //! - **Context switching**: Work on different runtimes incurs switching costs
+    //! - **Complexity**: Managing multiple runtimes adds operational complexity
+    //! - **Resource usage**: Additional runtimes consume memory and threads
+    //!
+    //! ## Real-World Scenarios
+    //!
+    //! ```text
+    //! CPU-Heavy Image Processing
+    //! ├─ Main runtime handles HTTP requests
+    //! ├─ Executor delegates to compute runtime (8 workers)
+    //! ├─ Image processing runs in parallel
+    //! └─ Main runtime stays responsive for other requests
+    //!
+    //! Mixed Workload API
+    //! ├─ I/O-bound endpoints: default runtime
+    //! ├─ CPU-bound endpoints: compute runtime
+    //! ├─ Background jobs: background runtime
+    //! └─ Each workload gets appropriate resources
+    //! ```
+    //!
+    //! ## Anti-Patterns
+    //!
+    //! ❌ **Executor for simple I/O**: Overhead exceeds benefit
+    //! ✅ Only use executor for CPU-bound or isolation requirements
+    //!
+    //! ❌ **Too many runtimes**: Resource fragmentation
+    //! ✅ Use 2-3 runtimes max, sized appropriately
+    //!
+    //! ❌ **Blocking in executor**: Starves worker threads
+    //! ✅ Use spawn_blocking for blocking operations
+    //!
+    //! ## Example
+    //!
+    //! ```rust,no_run
+    //! # #[cfg(feature = "executor")]
+    //! # {
+    //! use tower_resilience::executor::ExecutorLayer;
+    //! use tower::ServiceBuilder;
+    //!
+    //! # async fn example() {
+    //! # let my_service = tower::service_fn(|_req: ()| async { Ok::<_, std::io::Error>(()) });
+    //! // Create a dedicated compute runtime
+    //! let compute_runtime = tokio::runtime::Builder::new_multi_thread()
+    //!     .worker_threads(8)
+    //!     .thread_name("compute")
+    //!     .build()
+    //!     .unwrap();
+    //!
+    //! let layer = ExecutorLayer::new(compute_runtime.handle().clone());
+    //!
+    //! let service = ServiceBuilder::new()
+    //!     .layer(layer)
+    //!     .service(my_service);
+    //! # }
+    //! # }
+    //! ```
+    //!
+    //! ## Example: Current Runtime
+    //!
+    //! ```rust,no_run
+    //! # #[cfg(feature = "executor")]
+    //! # {
+    //! use tower_resilience::executor::ExecutorLayer;
+    //! use tower::ServiceBuilder;
+    //!
+    //! # async fn example() {
+    //! # let my_service = tower::service_fn(|_req: ()| async { Ok::<_, std::io::Error>(()) });
+    //! // Use the current tokio runtime
+    //! let layer = ExecutorLayer::current();
+    //!
+    //! let service = ServiceBuilder::new()
+    //!     .layer(layer)
+    //!     .service(my_service);
     //! # }
     //! # }
     //! ```
@@ -917,96 +867,171 @@ pub mod fallback {
     //! ```
 }
 
-pub mod executor {
-    //! # Executor
+pub mod healthcheck {
+    //! # Health Check
     //!
-    //! Delegates request processing to dedicated executors for parallel execution,
-    //! runtime isolation, or thread pool delegation.
+    //! Proactive health monitoring for resources with intelligent selection strategies.
+    //! Continuously checks resource health in the background and provides access to
+    //! healthy resources on demand.
+    //!
+    //! ## Health Check vs Circuit Breaker
+    //!
+    //! **Key distinction**: Health Check is **proactive**, Circuit Breaker is **reactive**.
+    //!
+    //! - **Health Check**: Monitors resources *before* use, prevents failures
+    //! - **Circuit Breaker**: Responds *after* failures happen, limits damage
+    //!
+    //! These patterns **complement each other perfectly**:
+    //! - Health Check layer selects healthy resources
+    //! - Circuit Breaker layer protects against cascading failures
     //!
     //! ## When to Use
     //!
-    //! - **CPU-bound processing**: Parallelize CPU-intensive request handling
-    //! - **Runtime isolation**: Process requests on a dedicated runtime
-    //! - **Thread pool delegation**: Use specific thread pools for certain workloads
-    //! - **Work stealing**: Distribute work across multiple worker threads
+    //! ✅ **Multiple resource instances**: Primary/secondary databases, regional endpoints
+    //! ✅ **Automatic failover**: Switch to healthy resources without manual intervention
+    //! ✅ **Load distribution**: Round-robin or weighted selection across healthy instances
+    //! ✅ **Kubernetes readiness**: Export health status for K8s probes
+    //!
+    //! ❌ **Single resource**: Use Circuit Breaker instead
+    //! ❌ **Request-level failures**: Use Retry layer
+    //! ❌ **Middleware composition**: Health Check is not a Tower layer
+    //!
+    //! ## Design Philosophy
+    //!
+    //! Health Check is **not a Tower layer** - it's a wrapper pattern that manages multiple
+    //! resources:
+    //!
+    //! ```text
+    //! Tower Layers (middleware):        Health Check (resource manager):
+    //!   Request → Retry →                  ┌─────────────────┐
+    //!             CircuitBreaker →         │  Health Wrapper │
+    //!             Service                  │  - primary ✓    │
+    //!                                      │  - secondary ✓  │
+    //!                                      │  - tertiary ✗   │
+    //!                                      └─────────────────┘
+    //!                                            ↓
+    //!                                      Select healthy resource
+    //! ```
+    //!
+    //! ## Selection Strategies
+    //!
+    //! ### FirstAvailable (Default)
+    //! Returns the first healthy resource. Best for primary/secondary failover.
+    //!
+    //! ### RoundRobin
+    //! Distributes load evenly across healthy resources.
+    //!
+    //! ### Random
+    //! Randomly selects from healthy resources (requires `random` feature).
+    //!
+    //! ### PreferHealthy
+    //! Prefers fully healthy resources, falls back to degraded if needed.
+    //!
+    //! ### Custom
+    //! Implement custom logic (latency-based, geographic proximity, weighted, etc.).
+    //!
+    //! ## Health Status States
+    //!
+    //! - **Healthy**: Resource is fully operational
+    //! - **Degraded**: Resource is slow but functional (high latency)
+    //! - **Unhealthy**: Resource should not be used
+    //! - **Unknown**: Not yet checked or check failed
     //!
     //! ## Trade-offs
     //!
-    //! - **Overhead**: Spawning tasks adds scheduling overhead
-    //! - **Context switching**: Work on different runtimes incurs switching costs
-    //! - **Complexity**: Managing multiple runtimes adds operational complexity
-    //! - **Resource usage**: Additional runtimes consume memory and threads
+    //! ### Advantages
+    //! - **Proactive**: Catches issues before use
+    //! - **Automatic failover**: No manual intervention needed
+    //! - **Flexible selection**: Multiple strategies for different use cases
+    //! - **Observable**: Export health status for monitoring
+    //!
+    //! ### Limitations
+    //! - **Not a layer**: Cannot compose with Tower middleware
+    //! - **Resource overhead**: Background health checks consume resources
+    //! - **Complexity**: Requires managing multiple resource instances
+    //! - **Health check design**: Poor health checks give false positives/negatives
     //!
     //! ## Real-World Scenarios
     //!
     //! ```text
-    //! CPU-Heavy Image Processing
-    //! ├─ Main runtime handles HTTP requests
-    //! ├─ Executor delegates to compute runtime (8 workers)
-    //! ├─ Image processing runs in parallel
-    //! └─ Main runtime stays responsive for other requests
+    //! Database Failover
+    //! ├─ Primary database: healthy
+    //! ├─ Secondary database: healthy
+    //! ├─ Primary fails → automatic switch to secondary
+    //! └─ Primary recovers → can switch back
     //!
-    //! Mixed Workload API
-    //! ├─ I/O-bound endpoints: default runtime
-    //! ├─ CPU-bound endpoints: compute runtime
-    //! ├─ Background jobs: background runtime
-    //! └─ Each workload gets appropriate resources
+    //! Regional API Endpoints
+    //! ├─ us-west: healthy (50ms latency)
+    //! ├─ us-east: healthy (120ms latency)
+    //! ├─ eu-west: degraded (300ms latency)
+    //! └─ Round-robin between us-west and us-east (eu-west used only if needed)
+    //!
+    //! Redis Cluster
+    //! ├─ Node 1: healthy
+    //! ├─ Node 2: healthy
+    //! ├─ Node 3: unhealthy (connection refused)
+    //! └─ Distribute load across nodes 1 and 2
     //! ```
     //!
     //! ## Anti-Patterns
     //!
-    //! ❌ **Executor for simple I/O**: Overhead exceeds benefit
-    //! ✅ Only use executor for CPU-bound or isolation requirements
+    //! ❌ **Too frequent checks**: Health checks every 100ms waste resources
+    //! ✅ Check every 5-30 seconds for most use cases
     //!
-    //! ❌ **Too many runtimes**: Resource fragmentation
-    //! ✅ Use 2-3 runtimes max, sized appropriately
+    //! ❌ **Expensive health checks**: Full database query takes 2 seconds
+    //! ✅ Simple ping/SELECT 1 takes milliseconds
     //!
-    //! ❌ **Blocking in executor**: Starves worker threads
-    //! ✅ Use spawn_blocking for blocking operations
+    //! ❌ **No threshold**: One failure marks as unhealthy
+    //! ✅ Require 2-3 consecutive failures to prevent flapping
+    //!
+    //! ❌ **Ignoring degraded state**: Treat slow as failed
+    //! ✅ Use degraded resources when all healthy ones are down
     //!
     //! ## Example
     //!
-    //! ```rust,no_run
-    //! # #[cfg(feature = "executor")]
-    //! # {
-    //! use tower_resilience::executor::ExecutorLayer;
-    //! use tower::ServiceBuilder;
+    //! ```rust,ignore
+    //! use tower_resilience_healthcheck::{
+    //!     HealthCheckWrapper, HealthStatus, SelectionStrategy
+    //! };
+    //! use std::time::Duration;
     //!
+    //! # #[derive(Clone)]
+    //! # struct Database { name: String }
+    //! # impl Database {
+    //! #     async fn ping(&self) -> Result<(), std::io::Error> { Ok(()) }
+    //! # }
     //! # async fn example() {
-    //! # let my_service = tower::service_fn(|_req: ()| async { Ok::<_, std::io::Error>(()) });
-    //! // Create a dedicated compute runtime
-    //! let compute_runtime = tokio::runtime::Builder::new_multi_thread()
-    //!     .worker_threads(8)
-    //!     .thread_name("compute")
-    //!     .build()
-    //!     .unwrap();
+    //! # let primary_db = Database { name: "primary".into() };
+    //! # let secondary_db = Database { name: "secondary".into() };
+    //! // Create wrapper with multiple databases
+    //! let wrapper = HealthCheckWrapper::builder()
+    //!     .with_context(primary_db, "primary")
+    //!     .with_context(secondary_db, "secondary")
+    //!     .with_checker(|db| async move {
+    //!         match db.ping().await {
+    //!             Ok(_) => HealthStatus::Healthy,
+    //!             Err(_) => HealthStatus::Unhealthy,
+    //!         }
+    //!     })
+    //!     .with_interval(Duration::from_secs(10))
+    //!     .with_failure_threshold(3)  // 3 failures before marking unhealthy
+    //!     .with_success_threshold(2)  // 2 successes to recover
+    //!     .with_selection_strategy(SelectionStrategy::RoundRobin)
+    //!     .build();
     //!
-    //! let layer = ExecutorLayer::new(compute_runtime.handle().clone());
+    //! // Start background health checking
+    //! wrapper.start().await;
     //!
-    //! let service = ServiceBuilder::new()
-    //!     .layer(layer)
-    //!     .service(my_service);
-    //! # }
-    //! # }
-    //! ```
+    //! // Get a healthy database
+    //! if let Some(db) = wrapper.get_healthy().await {
+    //!     // Use healthy database
+    //! }
     //!
-    //! ## Example: Current Runtime
-    //!
-    //! ```rust,no_run
-    //! # #[cfg(feature = "executor")]
-    //! # {
-    //! use tower_resilience::executor::ExecutorLayer;
-    //! use tower::ServiceBuilder;
-    //!
-    //! # async fn example() {
-    //! # let my_service = tower::service_fn(|_req: ()| async { Ok::<_, std::io::Error>(()) });
-    //! // Use the current tokio runtime
-    //! let layer = ExecutorLayer::current();
-    //!
-    //! let service = ServiceBuilder::new()
-    //!     .layer(layer)
-    //!     .service(my_service);
-    //! # }
+    //! // Get health status for monitoring
+    //! let details = wrapper.get_health_details().await;
+    //! for detail in details {
+    //!     println!("{}: {:?}", detail.name, detail.status);
+    //! }
     //! # }
     //! ```
 }
@@ -1242,358 +1267,6 @@ pub mod hedge {
     //! ```
 }
 
-pub mod adaptive {
-    //! # Adaptive Concurrency
-    //!
-    //! Dynamically adjusts concurrency limits based on observed latency and error rates.
-    //! Unlike static concurrency limits (like Bulkhead), adaptive limiters automatically
-    //! find the optimal concurrency for your downstream services.
-    //!
-    //! ## Adaptive vs Bulkhead
-    //!
-    //! **Key distinction**: Adaptive is **self-tuning**, Bulkhead is **statically configured**.
-    //!
-    //! - **Adaptive**: Automatically finds optimal concurrency based on feedback
-    //! - **Bulkhead**: Fixed limit you configure upfront
-    //!
-    //! Use Adaptive when you don't know the right limit or when capacity varies.
-    //! Use Bulkhead when you have a known, fixed resource pool.
-    //!
-    //! ## Algorithms
-    //!
-    //! ### AIMD (Additive Increase Multiplicative Decrease)
-    //!
-    //! Classic TCP-style congestion control:
-    //! - On success with low latency: increase limit by a fixed amount (e.g., +1)
-    //! - On failure or high latency: decrease limit by a factor (e.g., halve it)
-    //!
-    //! Creates a "sawtooth" pattern as it continuously probes for capacity.
-    //! Simple, well-understood, works in most scenarios.
-    //!
-    //! ### Vegas
-    //!
-    //! More sophisticated algorithm using RTT measurements:
-    //! - Estimates queue depth from RTT variations
-    //! - Increases limit when queue is small (under-utilized)
-    //! - Decreases limit when queue is large (congested)
-    //!
-    //! More stable than AIMD, avoids sawtooth pattern, better for latency-sensitive
-    //! applications.
-    //!
-    //! ## When to Use
-    //!
-    //! - **Unknown capacity**: Don't know optimal concurrency for downstream
-    //! - **Variable backends**: Capacity changes due to autoscaling, load, etc.
-    //! - **Auto-tuning**: Want "set it and forget it" concurrency management
-    //! - **Latency optimization**: Need to keep latency low while maximizing throughput
-    //!
-    //! ## Trade-offs
-    //!
-    //! - **Warm-up time**: Takes time to find optimal limit
-    //! - **Oscillation**: AIMD continuously probes, causing limit fluctuations
-    //! - **Shared fate**: All callers share the same limit
-    //! - **Algorithm choice**: AIMD vs Vegas requires understanding your workload
-    //!
-    //! ## Real-World Scenarios
-    //!
-    //! ```text
-    //! Auto-scaling Backend
-    //! ├─ Backend starts with 2 pods (low capacity)
-    //! ├─ Adaptive limiter finds limit ~20
-    //! ├─ Backend scales to 10 pods
-    //! ├─ Latency drops, limiter increases to ~100
-    //! └─ Throughput automatically maximized
-    //!
-    //! Database Connection Pool
-    //! ├─ Unknown optimal connection count
-    //! ├─ Vegas algorithm monitors query latency
-    //! ├─ Limit increases until queue builds up
-    //! ├─ Settles at optimal ~50 connections
-    //! └─ Adapts as query patterns change
-    //!
-    //! External API with Variable Rate Limits
-    //! ├─ API has undocumented rate limits
-    //! ├─ AIMD probes for capacity
-    //! ├─ Backs off when 429s are returned
-    //! └─ Finds sustainable request rate
-    //! ```
-    //!
-    //! ## Anti-Patterns
-    //!
-    //! ❌ **Too aggressive decrease factor**: Limit drops too fast, under-utilizes
-    //! ✅ Start with 0.5-0.9 decrease factor
-    //!
-    //! ❌ **No minimum limit**: Can drop to 0 and never recover
-    //! ✅ Always set min_limit >= 1
-    //!
-    //! ❌ **Latency threshold too low**: Normal variance triggers decreases
-    //! ✅ Set threshold to P90-P99 latency, not P50
-    //!
-    //! ❌ **Using for isolation**: Adaptive shares limit across all callers
-    //! ✅ Use Bulkhead for tenant/resource isolation
-    //!
-    //! ## Example: AIMD Algorithm
-    //!
-    //! ```rust,no_run
-    //! # #[cfg(feature = "adaptive")]
-    //! # {
-    //! use tower_resilience::adaptive::{AdaptiveLimiterLayer, Aimd};
-    //! use tower::ServiceBuilder;
-    //! use std::time::Duration;
-    //!
-    //! # async fn example() {
-    //! # let my_service = tower::service_fn(|_req: ()| async { Ok::<_, std::io::Error>(()) });
-    //! let layer = AdaptiveLimiterLayer::new(
-    //!     Aimd::builder()
-    //!         .initial_limit(10)
-    //!         .min_limit(1)
-    //!         .max_limit(100)
-    //!         .increase_by(1)
-    //!         .decrease_factor(0.5)
-    //!         .latency_threshold(Duration::from_millis(100))
-    //!         .build()
-    //! );
-    //!
-    //! let service = ServiceBuilder::new()
-    //!     .layer(layer)
-    //!     .service(my_service);
-    //! # }
-    //! # }
-    //! ```
-    //!
-    //! ## Example: Vegas Algorithm
-    //!
-    //! ```rust,no_run
-    //! # #[cfg(feature = "adaptive")]
-    //! # {
-    //! use tower_resilience::adaptive::{AdaptiveLimiterLayer, Vegas};
-    //! use tower::ServiceBuilder;
-    //!
-    //! # async fn example() {
-    //! # let my_service = tower::service_fn(|_req: ()| async { Ok::<_, std::io::Error>(()) });
-    //! let layer = AdaptiveLimiterLayer::new(
-    //!     Vegas::builder()
-    //!         .initial_limit(10)
-    //!         .min_limit(1)
-    //!         .max_limit(100)
-    //!         .alpha(3)   // Increase when queue < 3
-    //!         .beta(6)    // Decrease when queue > 6
-    //!         .build()
-    //! );
-    //!
-    //! let service = ServiceBuilder::new()
-    //!     .layer(layer)
-    //!     .service(my_service);
-    //! # }
-    //! # }
-    //! ```
-    //!
-    //! ## Example: Composition with Circuit Breaker
-    //!
-    //! ```rust,ignore
-    //! use tower_resilience::adaptive::{AdaptiveLimiterLayer, Aimd};
-    //! use tower_resilience::circuitbreaker::CircuitBreakerLayer;
-    //! use tower::ServiceBuilder;
-    //!
-    //! // Circuit breaker catches catastrophic failures
-    //! // Adaptive limiter optimizes throughput
-    //! let service = ServiceBuilder::new()
-    //!     .layer(CircuitBreakerLayer::builder().build())
-    //!     .layer(AdaptiveLimiterLayer::new(Aimd::builder().build()))
-    //!     .service(my_service);
-    //! ```
-}
-
-pub mod coalesce {
-    //! # Coalesce (Singleflight)
-    //!
-    //! Deduplicates concurrent identical requests, ensuring only one request executes
-    //! while others wait for its result. All callers receive a clone of the result.
-    //! This prevents "cache stampede" or "thundering herd" problems.
-    //!
-    //! ## Coalesce vs Cache
-    //!
-    //! **Key distinction**: Coalesce deduplicates **in-flight requests**, Cache stores **completed results**.
-    //!
-    //! - **Coalesce**: Multiple concurrent requests for same key share ONE execution
-    //! - **Cache**: Stores results after completion for future requests
-    //!
-    //! These patterns **complement each other perfectly**:
-    //! - Cache layer stores completed results
-    //! - Coalesce layer prevents stampede on cache miss
-    //!
-    //! ## How It Works
-    //!
-    //! ```text
-    //! Without Coalesce:                With Coalesce:
-    //! ─────────────────                ──────────────
-    //! Request A ──→ Backend            Request A ──→ Backend
-    //! Request B ──→ Backend            Request B ──┐
-    //! Request C ──→ Backend            Request C ──┤ Wait for A
-    //! (3 backend calls)                Request D ──┘
-    //!                                  (1 backend call, 4 responses)
-    //! ```
-    //!
-    //! ## When to Use
-    //!
-    //! - **Cache refresh protection**: When cached value expires, multiple requests may
-    //!   try to refresh simultaneously. Coalescing ensures only one refresh happens.
-    //!
-    //! - **Expensive computations**: Deduplicate requests for the same expensive operation
-    //!   (e.g., report generation, ML inference, complex queries).
-    //!
-    //! - **Rate-limited APIs**: Reduce calls to external APIs that have rate limits by
-    //!   coalescing identical requests within a time window.
-    //!
-    //! - **Database queries**: Combine identical queries that arrive within a short window
-    //!   to reduce database load.
-    //!
-    //! - **Microservice fanout**: When multiple internal services request the same data,
-    //!   coalesce to avoid redundant downstream calls.
-    //!
-    //! ## Requirements
-    //!
-    //! - **Key type**: Must implement `Hash + Eq + Clone + Send + Sync`
-    //! - **Response type**: Must implement `Clone` (to distribute to all waiters)
-    //! - **Error type**: Must implement `Clone` (errors are also distributed)
-    //!
-    //! ## Trade-offs
-    //!
-    //! - **Latency coupling**: All waiters blocked on slowest request
-    //! - **Error propagation**: One failure affects all waiters
-    //! - **Clone overhead**: Response cloned for each waiter
-    //! - **Memory**: In-flight tracking consumes memory
-    //!
-    //! ## Real-World Scenarios
-    //!
-    //! ```text
-    //! Cache Stampede Prevention
-    //! ├─ Popular item cache expires
-    //! ├─ 1000 requests arrive simultaneously
-    //! ├─ Without coalescing: 1000 database queries
-    //! ├─ With coalescing: 1 database query, 1000 cloned responses
-    //! └─ Database load reduced by 99.9%
-    //!
-    //! Report Generation
-    //! ├─ User A requests monthly report
-    //! ├─ User B requests same report while A's is generating
-    //! ├─ Only one report generated
-    //! └─ Both users receive the same result
-    //!
-    //! External API Protection
-    //! ├─ Multiple services need weather data for same city
-    //! ├─ External API has 100 req/min limit
-    //! ├─ Coalescing reduces calls from 50/sec to 1/sec
-    //! └─ Stay well under rate limit
-    //! ```
-    //!
-    //! ## Anti-Patterns
-    //!
-    //! ❌ **Coalescing non-idempotent operations**: Side effects may be skipped
-    //! ✅ Only coalesce read operations or truly idempotent writes
-    //!
-    //! ❌ **Large response objects**: Clone overhead exceeds savings
-    //! ✅ Return `Arc<Response>` or small response types
-    //!
-    //! ❌ **Long-running requests**: Waiters blocked for extended time
-    //! ✅ Combine with time limiter to bound wait time
-    //!
-    //! ❌ **Unique request keys**: Every request has different key
-    //! ✅ Design keys to maximize coalescing opportunities
-    //!
-    //! ## Example: Basic Usage
-    //!
-    //! ```rust,no_run
-    //! # #[cfg(feature = "coalesce")]
-    //! # {
-    //! use tower_resilience::coalesce::CoalesceLayer;
-    //! use tower::ServiceBuilder;
-    //!
-    //! # #[derive(Clone, Hash, Eq, PartialEq)]
-    //! # struct Request { user_id: u64 }
-    //! # #[derive(Clone)]
-    //! # struct Response;
-    //! # #[derive(Debug, Clone)]
-    //! # struct MyError;
-    //! # async fn example() {
-    //! # let user_service = tower::service_fn(|_req: Request| async { Ok::<_, MyError>(Response) });
-    //! // Coalesce by user_id - concurrent requests for same user share execution
-    //! let layer = CoalesceLayer::new(|req: &Request| req.user_id);
-    //!
-    //! let service = ServiceBuilder::new()
-    //!     .layer(layer)
-    //!     .service(user_service);
-    //! # }
-    //! # }
-    //! ```
-    //!
-    //! ## Example: With Cache Layer
-    //!
-    //! ```rust,no_run
-    //! # #[cfg(all(feature = "coalesce", feature = "cache"))]
-    //! # {
-    //! use tower_resilience::coalesce::CoalesceLayer;
-    //! use tower_resilience::cache::CacheLayer;
-    //! use tower::ServiceBuilder;
-    //! use std::time::Duration;
-    //!
-    //! # #[derive(Clone, Hash, Eq, PartialEq)]
-    //! # struct Request { id: String }
-    //! # #[derive(Clone)]
-    //! # struct Response;
-    //! # #[derive(Debug, Clone)]
-    //! # struct MyError;
-    //! # async fn example() {
-    //! # let backend = tower::service_fn(|_req: Request| async { Ok::<_, MyError>(Response) });
-    //! // Cache stores results, Coalesce prevents stampede on cache miss
-    //! let cache = CacheLayer::builder()
-    //!     .max_size(1000)
-    //!     .ttl(Duration::from_secs(300))
-    //!     .key_extractor(|req: &Request| req.id.clone())
-    //!     .build();
-    //!
-    //! let coalesce = CoalesceLayer::new(|req: &Request| req.id.clone());
-    //!
-    //! let service = ServiceBuilder::new()
-    //!     .layer(cache)      // Check cache first
-    //!     .layer(coalesce)   // Coalesce cache misses
-    //!     .service(backend);
-    //! # }
-    //! # }
-    //! ```
-    //!
-    //! ## Example: Named Instance
-    //!
-    //! ```rust,no_run
-    //! # #[cfg(feature = "coalesce")]
-    //! # {
-    //! use tower_resilience::coalesce::CoalesceLayer;
-    //! use tower::ServiceBuilder;
-    //!
-    //! # #[derive(Debug, Clone)]
-    //! # struct MyError;
-    //! # async fn example() {
-    //! # let report_generator = tower::service_fn(|_req: String| async { Ok::<_, MyError>("report".to_string()) });
-    //! let layer = CoalesceLayer::builder(|req: &String| req.clone())
-    //!     .name("report-coalesce")
-    //!     .build();
-    //!
-    //! let service = ServiceBuilder::new()
-    //!     .layer(layer)
-    //!     .service(report_generator);
-    //! # }
-    //! # }
-    //! ```
-    //!
-    //! ## Prior Art
-    //!
-    //! This pattern is also known as:
-    //! - **Singleflight** (Go's `golang.org/x/sync/singleflight`)
-    //! - **Request deduplication**
-    //! - **Request collapsing**
-}
-
-/// Outlier Detection pattern guide
 pub mod outlier_detection {
     //! # Outlier Detection
     //!
@@ -1701,6 +1374,247 @@ pub mod outlier_detection {
     //! - **Linkerd**: Failure accrual
 }
 
+pub mod rate_limiter {
+    //! # Rate Limiter
+    //!
+    //! Controls the rate of requests to protect downstream services and enforce quotas.
+    //!
+    //! ## When to Use
+    //!
+    //! - **Quota enforcement**: Per-user, per-tenant API limits
+    //! - **Protecting resources**: Prevent overwhelming databases or APIs
+    //! - **Fairness**: Ensure fair access to shared resources
+    //! - **Cost control**: Limit expensive operations
+    //!
+    //! ## Trade-offs
+    //!
+    //! - **Throughput vs fairness**: Token bucket allows bursts
+    //! - **Burst handling**: Should you allow temporary spikes?
+    //! - **Rejection strategy**: Drop, queue, or return error?
+    //! - **Distributed coordination**: Single-node vs multi-node limits
+    //!
+    //! ## Real-World Scenarios
+    //!
+    //! ```text
+    //! Per-User API Limits
+    //! ├─ Free tier: 100 req/min
+    //! ├─ Pro tier: 1000 req/min
+    //! ├─ Burst allowance for good UX
+    //! └─ Return 429 when exceeded
+    //!
+    //! Downstream Protection
+    //! ├─ Database has 1000 QPS limit
+    //! ├─ Rate limit to 800 QPS (80% capacity)
+    //! ├─ Prevents database overload
+    //! └─ Predictable performance
+    //! ```
+    //!
+    //! ## Anti-Patterns
+    //!
+    //! ❌ **Global limits only**: One tenant can exhaust quota for all
+    //! ✅ Per-tenant/per-user limits with global backstop
+    //!
+    //! ❌ **No burst allowance**: Poor user experience for spiky traffic
+    //! ✅ Allow some burst (e.g., 2x rate for 1 second)
+    //!
+    //! ❌ **Using for concurrency limits**: Rate ≠ concurrency
+    //! ✅ Use bulkhead for concurrency, rate limiter for throughput
+    //!
+    //! ## Example
+    //!
+    //! ```rust,no_run
+    //! # #[cfg(feature = "ratelimiter")]
+    //! # {
+    //! use tower_resilience::ratelimiter::RateLimiterLayer;
+    //! use tower::Layer;
+    //! use std::time::Duration;
+    //!
+    //! # async fn example() {
+    //! # let api_handler = tower::service_fn(|_req: ()| async { Ok::<_, std::io::Error>(()) });
+    //! let rate_limiter = RateLimiterLayer::builder()
+    //!     .limit_for_period(100)                    // 100 requests
+    //!     .refresh_period(Duration::from_secs(1))   // per second
+    //!     .timeout_duration(Duration::from_millis(100))  // Wait up to 100ms
+    //!     .build();
+    //!
+    //! let service = tower::ServiceBuilder::new()
+    //!     .layer(rate_limiter)
+    //!     .service(api_handler);
+    //! # }
+    //! # }
+    //! ```
+}
+
+pub mod reconnect {
+    //! # Reconnect
+    //!
+    //! Automatically reconnects to services with configurable backoff strategies when
+    //! connection failures occur. Designed for **persistent connections** where the connection
+    //! state matters (databases, Redis, message queues, WebSockets).
+    //!
+    //! ## Reconnect vs Retry
+    //!
+    //! **Key distinction**: Reconnect manages **connection lifecycle**, Retry manages **operation resilience**.
+    //!
+    //! - **Reconnect**: Use for persistent connections that can break (Redis, databases, gRPC streams)
+    //! - **Retry**: Use for transient request failures on working connections (timeouts, rate limits)
+    //!
+    //! For persistent connection services, you often want BOTH:
+    //! - Reconnect layer handles connection-level errors (BrokenPipe, ConnectionReset)
+    //! - Retry layer handles application-level errors (RateLimited, Busy, Timeout)
+    //!
+    //! ## When to Use
+    //!
+    //! - **Persistent connections**: Redis, databases, message queues, WebSockets
+    //! - **Unstable connections**: Network issues, transient failures
+    //! - **Service restarts**: Backend services that periodically restart
+    //! - **Connection pooling**: Reconnect stale or broken connections
+    //! - **Distributed systems**: Handle network partitions gracefully
+    //!
+    //! ## Trade-offs
+    //!
+    //! - **Latency impact**: Reconnection attempts add delay to requests
+    //! - **Resource usage**: Failed connections consume resources during backoff
+    //! - **Complexity**: Adds state management for connection tracking
+    //! - **Thundering herd**: Multiple clients reconnecting simultaneously
+    //!
+    //! ## Real-World Scenarios
+    //!
+    //! ```text
+    //! Database Connection Pool
+    //! ├─ Connection closed by server after idle timeout
+    //! ├─ Reconnect with exponential backoff (100ms -> 5s)
+    //! ├─ Retry original query after successful reconnection
+    //! └─ Application remains resilient to connection drops
+    //!
+    //! Message Queue Consumer
+    //! ├─ Broker temporarily unavailable during deployment
+    //! ├─ Reconnect with fixed 1s intervals, unlimited attempts
+    //! ├─ Resume consuming messages when broker returns
+    //! └─ No message loss or manual intervention
+    //! ```
+    //!
+    //! ## Anti-Patterns
+    //!
+    //! ❌ **Immediate retry**: Overwhelming failing service
+    //! ✅ Use exponential backoff to give service time to recover
+    //!
+    //! ❌ **Unlimited attempts without monitoring**: Silent failures pile up
+    //! ✅ Set max attempts for user-facing operations, monitor reconnection rates
+    //!
+    //! ❌ **No connection state tracking**: Can't determine system health
+    //! ✅ Expose connection state for health checks and observability
+    //!
+    //! ❌ **Reconnecting on non-retryable errors**: Permanent failures waste resources
+    //! ✅ Distinguish transient (network) from permanent (auth) errors
+    //!
+    //! ## Example
+    //!
+    //! ```rust,no_run
+    //! # #[cfg(feature = "reconnect")]
+    //! # {
+    //! use tower_resilience_reconnect::{ReconnectLayer, ReconnectConfig, ReconnectPolicy};
+    //! use tower::Layer;
+    //! use std::time::Duration;
+    //!
+    //! # async fn example() {
+    //! # let database_service = tower::service_fn(|_req: ()| async { Ok::<_, std::io::Error>(()) });
+    //! let reconnect = ReconnectLayer::new(
+    //!     ReconnectConfig::builder()
+    //!         .policy(ReconnectPolicy::exponential(
+    //!             Duration::from_millis(100),  // Start at 100ms
+    //!             Duration::from_secs(5),      // Max 5 seconds
+    //!         ))
+    //!         .max_attempts(10)
+    //!         .retry_on_reconnect(true)  // Retry original request
+    //!         .build()
+    //! );
+    //!
+    //! let service = reconnect.layer(database_service);
+    //! # }
+    //! # }
+    //! ```
+}
+
+pub mod retry {
+    //! # Retry
+    //!
+    //! Automatically retries failed operations with configurable backoff strategies.
+    //!
+    //! ## When to Use
+    //!
+    //! - **Transient failures**: Network blips, temporary resource unavailability
+    //! - **Rate limiting**: 429 responses with retry-after
+    //! - **Database deadlocks**: Transient conflicts
+    //! - **Eventually consistent systems**: Retry until data is available
+    //!
+    //! ## Trade-offs
+    //!
+    //! - **Latency vs success rate**: Retries add latency but improve success
+    //! - **Amplification effects**: Retries multiply load on failing services
+    //! - **Idempotency requirements**: Safe retries require idempotent operations
+    //! - **Jitter importance**: Without jitter, retries create thundering herd
+    //!
+    //! ## Real-World Scenarios
+    //!
+    //! ```text
+    //! Network Transient Errors
+    //! ├─ Connection reset by peer
+    //! ├─ Retry with 100ms exponential backoff
+    //! ├─ Success on 2nd attempt
+    //! └─ User doesn't see error
+    //!
+    //! API Rate Limiting
+    //! ├─ Receive 429 Too Many Requests
+    //! ├─ Retry-After: 1s header
+    //! ├─ Wait 1s + jitter
+    //! └─ Retry succeeds
+    //! ```
+    //!
+    //! ## Anti-Patterns
+    //!
+    //! ❌ **Retrying non-idempotent operations**: Duplicate charges, double-sends
+    //! ✅ Only retry GET, HEAD, PUT, DELETE; use idempotency keys for POST
+    //!
+    //! ❌ **No jitter**: All clients retry at same time (thundering herd)
+    //! ✅ Use `exponential_backoff` with randomization
+    //!
+    //! ❌ **Infinite retries**: Never give up
+    //! ✅ Set reasonable `max_attempts` (3-5)
+    //!
+    //! ❌ **Retrying 4xx errors**: Client errors won't succeed on retry
+    //! ✅ Use retry predicate to only retry 5xx, network errors
+    //!
+    //! ## Example
+    //!
+    //! ```rust,no_run
+    //! # #[cfg(feature = "retry")]
+    //! # {
+    //! use tower_resilience::retry::RetryLayer;
+    //! use tower::Layer;
+    //! use std::time::Duration;
+    //!
+    //! # #[derive(Debug, Clone)]
+    //! # struct MyError;
+    //! # async fn example() {
+    //! # let http_client = tower::service_fn(|_req: ()| async { Ok::<_, MyError>(()) });
+    //! let retry = RetryLayer::<(), (), MyError>::builder()
+    //!     .max_attempts(3)
+    //!     .exponential_backoff(Duration::from_millis(100))
+    //!     .retry_on(|err: &MyError| {
+    //!         // Only retry transient errors
+    //!         true  // Check if error is retryable
+    //!     })
+    //!     .build();
+    //!
+    //! let service = tower::ServiceBuilder::new()
+    //!     .layer(retry)
+    //!     .service(http_client);
+    //! # }
+    //! # }
+    //! ```
+}
+
 pub mod router {
     //! # Weighted Router
     //!
@@ -1768,4 +1682,91 @@ pub mod router {
     //! - **Envoy**: Weighted clusters with traffic shifting for canary deployments
     //! - **Istio**: VirtualService with weighted routing rules
     //! - **Linkerd**: Traffic split via TrafficSplit CRD
+}
+
+pub mod time_limiter {
+    //! # Time Limiter
+    //!
+    //! Enforces timeouts on operations with optional future cancellation.
+    //!
+    //! ## When to Use
+    //!
+    //! - **Unbounded operations**: Database queries, external APIs
+    //! - **SLA enforcement**: Guarantee response times
+    //! - **Resource protection**: Prevent long-running tasks from accumulating
+    //! - **Circuit breaker complement**: Timeouts count as failures
+    //!
+    //! ## Trade-offs
+    //!
+    //! - **Cancellation semantics**: Dropping futures may not cancel underlying work
+    //! - **Partial work cleanup**: Need to handle incomplete operations
+    //! - **Timeout selection**: Too short causes false failures, too long defeats purpose
+    //! - **Overhead**: Timer overhead for every call (~100ns)
+    //!
+    //! ## Real-World Scenarios
+    //!
+    //! ```text
+    //! Database Query Timeout
+    //! ├─ Query has 5s timeout
+    //! ├─ Slow query triggers timeout
+    //! ├─ Connection returned to pool (if cancel_running_future=true)
+    //! └─ User sees timeout error instead of hanging
+    //!
+    //! External API Call
+    //! ├─ API call has 10s timeout
+    //! ├─ Network issue causes hang
+    //! ├─ Timeout fires, request fails fast
+    //! └─ Circuit breaker may open if timeouts are frequent
+    //! ```
+    //!
+    //! ## Anti-Patterns
+    //!
+    //! ❌ **Timeout too short**: Legitimate slow operations fail
+    //! ✅ Set timeout to P99 latency + buffer
+    //!
+    //! ❌ **No cleanup on timeout**: Resources leak
+    //! ✅ Use `cancel_running_future=true` when appropriate
+    //!
+    //! ❌ **Same timeout everywhere**: Different operations need different limits
+    //! ✅ Configure per-endpoint or per-operation
+    //!
+    //! ## Presets
+    //!
+    //! ```rust,no_run
+    //! # #[cfg(feature = "timelimiter")]
+    //! # {
+    //! use tower_resilience::timelimiter::TimeLimiterLayer;
+    //!
+    //! let fast = TimeLimiterLayer::fast().build();        // 1s, cancel on timeout
+    //! let standard = TimeLimiterLayer::standard().build(); // 5s, cancel on timeout
+    //! let slow = TimeLimiterLayer::slow().build();         // 30s, cancel on timeout
+    //! let stream = TimeLimiterLayer::streaming().build();  // 60s, no cancellation
+    //! # }
+    //! ```
+    //!
+    //! ## Example
+    //!
+    //! ```rust,no_run
+    //! # #[cfg(feature = "timelimiter")]
+    //! # {
+    //! use tower_resilience::timelimiter::TimeLimiterLayer;
+    //! use tower::Layer;
+    //! use std::time::Duration;
+    //!
+    //! # async fn example() {
+    //! # let database_query = tower::service_fn(|_req: ()| async { Ok::<_, std::io::Error>(()) });
+    //! let time_limiter = TimeLimiterLayer::builder()
+    //!     .timeout_duration(Duration::from_secs(5))
+    //!     .cancel_running_future(true)
+    //!     .on_timeout(|| {
+    //!         eprintln!("Query timeout");
+    //!     })
+    //!     .build();
+    //!
+    //! let service = tower::ServiceBuilder::new()
+    //!     .layer(time_limiter)
+    //!     .service(database_query);
+    //! # }
+    //! # }
+    //! ```
 }


### PR DESCRIPTION
## Summary

- Reorders all pattern lists to alphabetical order across 4 files:
  - **README.md**: bullet list, presets table, all 16 example sections
  - **lib.rs**: rustdoc pattern list, link references, presets table, `pub use` re-exports
  - **Cargo.toml**: dependencies, feature flags, `full` feature list
  - **patterns.rs**: module index list, all 15 `pub mod` declarations

No functional changes -- purely reordering for consistency.

Closes #268

## Test plan

- [x] `cargo test --doc -p tower-resilience --all-features` passes (43 tests)
- [x] `cargo test --lib --all-features --workspace` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean