### PR TITLE
feat: add CircuitBreakerHandle for observable circuit state

### DIFF
--- a/crates/tower-resilience-circuitbreaker/src/config.rs
+++ b/crates/tower-resilience-circuitbreaker/src/config.rs
@@ -1,7 +1,15 @@
+use std::sync::atomic::AtomicU8;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::Mutex;
+use tower_resilience_core::EventListeners;
+
+use crate::circuit::{Circuit, CircuitState};
 use crate::classifier::{DefaultClassifier, FnClassifier};
 use crate::events::CircuitBreakerEvent;
-use std::time::Duration;
-use tower_resilience_core::EventListeners;
+use crate::handle::CircuitBreakerHandle;
+use crate::layer::SharedCircuit;
 
 /// Type of sliding window used for tracking calls.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -621,6 +629,58 @@ impl<C> CircuitBreakerConfigBuilder<C> {
 
     /// Builds the configuration and returns a CircuitBreakerLayer.
     pub fn build(self) -> crate::layer::CircuitBreakerLayer<C> {
+        let config = self.into_config();
+        crate::layer::CircuitBreakerLayer::new(config)
+    }
+
+    /// Builds the configuration, returning both a layer and an observable handle.
+    ///
+    /// All services produced by the returned layer share the same circuit state,
+    /// and the handle can observe that state from outside the service.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_resilience_circuitbreaker::CircuitBreakerLayer;
+    ///
+    /// let (layer, handle) = CircuitBreakerLayer::builder()
+    ///     .failure_rate_threshold(0.5)
+    ///     .build_with_handle();
+    ///
+    /// // Apply the layer normally...
+    ///
+    /// // Query state from the handle:
+    /// assert_eq!(handle.health_status(), "healthy");
+    /// ```
+    pub fn build_with_handle(
+        self,
+    ) -> (
+        crate::layer::CircuitBreakerLayer<C>,
+        CircuitBreakerHandle<C>,
+    ) {
+        let config = Arc::new(self.into_config());
+        let state_atomic = Arc::new(AtomicU8::new(CircuitState::Closed as u8));
+        let circuit = Arc::new(Mutex::new(Circuit::new_with_atomic(Arc::clone(
+            &state_atomic,
+        ))));
+
+        let shared = SharedCircuit {
+            circuit: Arc::clone(&circuit),
+            state_atomic: Arc::clone(&state_atomic),
+        };
+
+        let handle = CircuitBreakerHandle {
+            circuit,
+            state_atomic,
+            config: Arc::clone(&config),
+        };
+
+        let layer = crate::layer::CircuitBreakerLayer::new_with_shared(config, shared);
+
+        (layer, handle)
+    }
+
+    fn into_config(self) -> CircuitBreakerConfig<C> {
         // Validate time-based window configuration
         if self.sliding_window_type == SlidingWindowType::TimeBased
             && self.sliding_window_duration.is_none()
@@ -628,7 +688,7 @@ impl<C> CircuitBreakerConfigBuilder<C> {
             panic!("sliding_window_duration must be set when using TimeBased sliding window");
         }
 
-        let config = CircuitBreakerConfig {
+        CircuitBreakerConfig {
             failure_rate_threshold: self.failure_rate_threshold,
             sliding_window_type: self.sliding_window_type,
             sliding_window_size: self.sliding_window_size,
@@ -644,8 +704,6 @@ impl<C> CircuitBreakerConfigBuilder<C> {
             event_listeners: self.event_listeners,
             name: self.name,
             backpressure: self.backpressure,
-        };
-
-        crate::layer::CircuitBreakerLayer::new(config)
+        }
     }
 }

--- a/crates/tower-resilience-circuitbreaker/src/handle.rs
+++ b/crates/tower-resilience-circuitbreaker/src/handle.rs
@@ -8,7 +8,7 @@ use crate::config::CircuitBreakerConfig;
 
 /// A read-only handle for observing circuit breaker state.
 ///
-/// Obtained from [`CircuitBreakerConfigBuilder::build_with_handle()`]. The handle
+/// Obtained from [`crate::CircuitBreakerConfigBuilder::build_with_handle()`]. The handle
 /// is cheap to clone and safe to share across threads (`Clone + Send + Sync`).
 ///
 /// This is useful when the circuit breaker service is consumed by middleware

--- a/crates/tower-resilience-circuitbreaker/src/handle.rs
+++ b/crates/tower-resilience-circuitbreaker/src/handle.rs
@@ -1,0 +1,223 @@
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use crate::circuit::{Circuit, CircuitMetrics, CircuitState};
+use crate::config::CircuitBreakerConfig;
+
+/// A read-only handle for observing circuit breaker state.
+///
+/// Obtained from [`CircuitBreakerConfigBuilder::build_with_handle()`]. The handle
+/// is cheap to clone and safe to share across threads (`Clone + Send + Sync`).
+///
+/// This is useful when the circuit breaker service is consumed by middleware
+/// (e.g., wrapped in `BoxCloneService`) and direct access to state inspection
+/// methods on [`CircuitBreaker`](crate::CircuitBreaker) is no longer available.
+///
+/// # Example
+///
+/// ```rust
+/// use tower_resilience_circuitbreaker::CircuitBreakerLayer;
+///
+/// let (layer, handle) = CircuitBreakerLayer::builder()
+///     .failure_rate_threshold(0.5)
+///     .build_with_handle();
+///
+/// // Apply the layer to a service (consumes into BoxCloneService, etc.)
+/// // ...
+///
+/// // Later, query state from the handle:
+/// let state = handle.state();
+/// let health = handle.health_status();
+/// assert_eq!(health, "healthy");
+/// ```
+#[derive(Clone)]
+pub struct CircuitBreakerHandle<C = crate::classifier::DefaultClassifier> {
+    pub(crate) circuit: Arc<Mutex<Circuit>>,
+    pub(crate) state_atomic: Arc<std::sync::atomic::AtomicU8>,
+    pub(crate) config: Arc<CircuitBreakerConfig<C>>,
+}
+
+impl<C> CircuitBreakerHandle<C> {
+    /// Returns the current state of the circuit without requiring async context.
+    ///
+    /// Uses an atomic load (Acquire ordering) for lock-free access.
+    pub fn state(&self) -> CircuitState {
+        CircuitState::from_u8(self.state_atomic.load(Ordering::Acquire))
+    }
+
+    /// Returns whether the circuit is currently open.
+    pub fn is_open(&self) -> bool {
+        self.state() == CircuitState::Open
+    }
+
+    /// Returns a simple health status string.
+    ///
+    /// - `"healthy"` when circuit is closed
+    /// - `"degraded"` when half-open
+    /// - `"unhealthy"` when open
+    pub fn health_status(&self) -> &'static str {
+        match self.state() {
+            CircuitState::Closed => "healthy",
+            CircuitState::HalfOpen => "degraded",
+            CircuitState::Open => "unhealthy",
+        }
+    }
+
+    /// Returns an HTTP status code based on circuit state.
+    ///
+    /// - Closed: 200 (OK)
+    /// - HalfOpen: 200 (OK) - accepting limited traffic
+    /// - Open: 503 (Service Unavailable)
+    pub fn http_status(&self) -> u16 {
+        match self.state() {
+            CircuitState::Closed | CircuitState::HalfOpen => 200,
+            CircuitState::Open => 503,
+        }
+    }
+
+    /// Returns a snapshot of the current circuit breaker metrics.
+    ///
+    /// Requires an async context because it locks the internal circuit state.
+    pub async fn metrics(&self) -> CircuitMetrics {
+        let circuit = self.circuit.lock().await;
+        circuit.metrics(&self.config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CircuitBreakerLayer;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::Poll;
+    use tower::{Layer, Service, ServiceExt};
+
+    #[derive(Clone)]
+    struct OkService;
+
+    impl Service<String> for OkService {
+        type Response = String;
+        type Error = String;
+        type Future = Pin<Box<dyn Future<Output = Result<String, String>> + Send>>;
+
+        fn poll_ready(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, req: String) -> Self::Future {
+            Box::pin(async move { Ok(req) })
+        }
+    }
+
+    #[derive(Clone)]
+    struct ErrService;
+
+    impl Service<String> for ErrService {
+        type Response = String;
+        type Error = String;
+        type Future = Pin<Box<dyn Future<Output = Result<String, String>> + Send>>;
+
+        fn poll_ready(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _req: String) -> Self::Future {
+            Box::pin(async move { Err("fail".to_string()) })
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_initial_state() {
+        let (_layer, handle) = CircuitBreakerLayer::builder()
+            .failure_rate_threshold(0.5)
+            .build_with_handle();
+
+        assert_eq!(handle.state(), CircuitState::Closed);
+        assert_eq!(handle.health_status(), "healthy");
+        assert!(!handle.is_open());
+        assert_eq!(handle.http_status(), 200);
+    }
+
+    #[tokio::test]
+    async fn test_handle_observes_state_changes() {
+        let (layer, handle) = CircuitBreakerLayer::builder()
+            .failure_rate_threshold(0.5)
+            .sliding_window_size(4)
+            .minimum_number_of_calls(4)
+            .build_with_handle();
+
+        let mut svc = layer.layer(ErrService);
+
+        // Send enough failures to trip the breaker (50% threshold, 4 call window)
+        // Need all 4 to fail so failure rate = 100% > 50%
+        for _ in 0..4 {
+            let _ = svc.call("test".to_string()).await;
+        }
+
+        assert_eq!(handle.state(), CircuitState::Open);
+        assert_eq!(handle.health_status(), "unhealthy");
+        assert!(handle.is_open());
+        assert_eq!(handle.http_status(), 503);
+    }
+
+    #[tokio::test]
+    async fn test_handle_metrics() {
+        let (layer, handle) = CircuitBreakerLayer::builder()
+            .failure_rate_threshold(0.5)
+            .sliding_window_size(10)
+            .build_with_handle();
+
+        let svc = layer.layer(OkService);
+        let _ = svc.oneshot("test".to_string()).await;
+
+        let metrics = handle.metrics().await;
+        assert_eq!(metrics.state, CircuitState::Closed);
+        assert_eq!(metrics.total_calls, 1);
+        assert_eq!(metrics.success_count, 1);
+        assert_eq!(metrics.failure_count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_handle_shared_across_cloned_services() {
+        let (layer, handle) = CircuitBreakerLayer::builder()
+            .failure_rate_threshold(0.5)
+            .sliding_window_size(4)
+            .minimum_number_of_calls(4)
+            .build_with_handle();
+
+        // Create two services from the same layer -- they share state
+        let mut svc1 = layer.layer(ErrService);
+        let mut svc2 = layer.layer(ErrService);
+
+        // Failures across both services accumulate in the same circuit
+        let _ = svc1.call("a".to_string()).await;
+        let _ = svc2.call("b".to_string()).await;
+        let _ = svc1.call("c".to_string()).await;
+        let _ = svc2.call("d".to_string()).await;
+
+        // The shared circuit should be open now -- failures from both
+        // services accumulated in the same circuit
+        assert_eq!(handle.state(), CircuitState::Open);
+        assert!(handle.is_open());
+    }
+
+    #[tokio::test]
+    async fn test_handle_clone_is_independent() {
+        let (_layer, handle) = CircuitBreakerLayer::builder().build_with_handle();
+
+        let handle2 = handle.clone();
+
+        // Both observe the same state
+        assert_eq!(handle.state(), handle2.state());
+        assert_eq!(handle.health_status(), handle2.health_status());
+    }
+}

--- a/crates/tower-resilience-circuitbreaker/src/layer.rs
+++ b/crates/tower-resilience-circuitbreaker/src/layer.rs
@@ -1,7 +1,9 @@
+use crate::circuit::Circuit;
 use crate::classifier::{DefaultClassifier, FnClassifier};
 use crate::config::CircuitBreakerConfig;
 use crate::CircuitBreaker;
 use std::sync::Arc;
+use tokio::sync::Mutex;
 use tower::Layer;
 
 /// A Tower Layer that applies circuit breaker behavior to an inner service.
@@ -55,9 +57,23 @@ use tower::Layer;
 ///     .layer(layer)
 ///     .service(service_fn(|req: String| async move { Ok::<_, Error>(req) }));
 /// ```
+/// Shared circuit state created by `build_with_handle()`.
+///
+/// When present, all services produced by this layer share the same circuit
+/// state, and the external [`CircuitBreakerHandle`](crate::CircuitBreakerHandle)
+/// can observe it.
+#[derive(Clone)]
+pub(crate) struct SharedCircuit {
+    pub(crate) circuit: Arc<Mutex<Circuit>>,
+    pub(crate) state_atomic: Arc<std::sync::atomic::AtomicU8>,
+}
+
 #[derive(Clone)]
 pub struct CircuitBreakerLayer<C = DefaultClassifier> {
     config: Arc<CircuitBreakerConfig<C>>,
+    /// Pre-created shared state (set by `build_with_handle()`).
+    /// When `Some`, all services produced by this layer share this state.
+    pub(crate) shared: Option<SharedCircuit>,
 }
 
 impl<C> CircuitBreakerLayer<C> {
@@ -65,6 +81,32 @@ impl<C> CircuitBreakerLayer<C> {
     pub(crate) fn new(config: impl Into<Arc<CircuitBreakerConfig<C>>>) -> Self {
         Self {
             config: config.into(),
+            shared: None,
+        }
+    }
+
+    /// Creates a new `CircuitBreakerLayer` with pre-created shared state.
+    pub(crate) fn new_with_shared(
+        config: impl Into<Arc<CircuitBreakerConfig<C>>>,
+        shared: SharedCircuit,
+    ) -> Self {
+        Self {
+            config: config.into(),
+            shared: Some(shared),
+        }
+    }
+
+    /// Creates a service from this layer, using shared state if available.
+    fn make_service<S>(&self, service: S) -> CircuitBreaker<S, C> {
+        if let Some(shared) = &self.shared {
+            CircuitBreaker::from_shared(
+                service,
+                Arc::clone(&shared.circuit),
+                Arc::clone(&shared.state_atomic),
+                Arc::clone(&self.config),
+            )
+        } else {
+            CircuitBreaker::new(service, Arc::clone(&self.config))
         }
     }
 
@@ -94,7 +136,7 @@ impl<C> CircuitBreakerLayer<C> {
     where
         C: Clone,
     {
-        CircuitBreaker::new(service, Arc::clone(&self.config))
+        self.make_service(service)
     }
 }
 
@@ -217,7 +259,7 @@ impl<S> Layer<S> for CircuitBreakerLayer<DefaultClassifier> {
     type Service = CircuitBreaker<S, DefaultClassifier>;
 
     fn layer(&self, service: S) -> Self::Service {
-        CircuitBreaker::new(service, Arc::clone(&self.config))
+        self.make_service(service)
     }
 }
 
@@ -226,6 +268,6 @@ impl<S, F> Layer<S> for CircuitBreakerLayer<FnClassifier<F>> {
     type Service = CircuitBreaker<S, FnClassifier<F>>;
 
     fn layer(&self, service: S) -> Self::Service {
-        CircuitBreaker::new(service, Arc::clone(&self.config))
+        self.make_service(service)
     }
 }

--- a/crates/tower-resilience-circuitbreaker/src/lib.rs
+++ b/crates/tower-resilience-circuitbreaker/src/lib.rs
@@ -307,6 +307,7 @@ pub use classifier::{DefaultClassifier, FailureClassifier, FnClassifier};
 pub use config::{CircuitBreakerConfig, CircuitBreakerConfigBuilder, SlidingWindowType};
 pub use error::CircuitBreakerError;
 pub use events::CircuitBreakerEvent;
+pub use handle::CircuitBreakerHandle;
 pub use layer::CircuitBreakerLayer;
 
 mod circuit;
@@ -315,6 +316,7 @@ pub mod classifier;
 mod config;
 mod error;
 mod events;
+mod handle;
 #[cfg(feature = "health-integration")]
 mod health_integration;
 mod layer;
@@ -400,6 +402,26 @@ impl<S, C> CircuitBreaker<S, C> {
             circuit: Arc::new(Mutex::new(Circuit::new_with_atomic(Arc::clone(
                 &state_atomic,
             )))),
+            state_atomic,
+            config,
+            sleep: None,
+        }
+    }
+
+    /// Creates a new `CircuitBreaker` using pre-created shared state.
+    ///
+    /// Used by `CircuitBreakerLayer` when built with `build_with_handle()` so that
+    /// all services produced by the layer share the same circuit state, and the
+    /// external handle can observe it.
+    pub(crate) fn from_shared(
+        inner: S,
+        circuit: Arc<Mutex<Circuit>>,
+        state_atomic: Arc<std::sync::atomic::AtomicU8>,
+        config: Arc<CircuitBreakerConfig<C>>,
+    ) -> Self {
+        Self {
+            inner,
+            circuit,
             state_atomic,
             config,
             sleep: None,


### PR DESCRIPTION
## Summary
- Add `CircuitBreakerHandle<C>` type for read-only observation of circuit breaker state
- Add `build_with_handle()` to `CircuitBreakerConfigBuilder` that returns `(CircuitBreakerLayer<C>, CircuitBreakerHandle<C>)`
- When built with handle, all services produced by the layer share the same circuit state
- `build()` continues to work exactly as before (backward compatible)

## Handle API

```rust
let (layer, handle) = CircuitBreakerLayer::builder()
    .failure_rate_threshold(0.5)
    .build_with_handle();

// Sync (lock-free):
handle.state()          // CircuitState::Closed | Open | HalfOpen
handle.health_status()  // "healthy" | "degraded" | "unhealthy"
handle.is_open()        // bool
handle.http_status()    // 200 | 503

// Async (requires lock):
handle.metrics().await  // CircuitMetrics snapshot
```

## Implementation

- `CircuitBreakerLayer` gains an optional `SharedCircuit` field (pre-created `Arc<Mutex<Circuit>>` + `Arc<AtomicU8>`)
- When shared state is present, `layer()` uses `CircuitBreaker::from_shared()` instead of `CircuitBreaker::new()`
- Extracted `into_config()` from builder to share config-building logic between `build()` and `build_with_handle()`

## Test plan
- [x] `test_handle_initial_state` - starts Closed/healthy
- [x] `test_handle_observes_state_changes` - sees Open after failures
- [x] `test_handle_metrics` - metrics reflect calls through service
- [x] `test_handle_shared_across_cloned_services` - multiple `layer()` calls share state
- [x] `test_handle_clone_is_independent` - cloned handles observe same state
- [x] Doc tests pass for handle and `build_with_handle()`
- [x] All 23 unit tests + 33 doc tests pass
- [x] Clippy clean

Closes #275