### PR TITLE
feat: add observable state handles for RateLimiter and Bulkhead

### DIFF
--- a/crates/tower-resilience-bulkhead/src/config.rs
+++ b/crates/tower-resilience-bulkhead/src/config.rs
@@ -296,14 +296,54 @@ impl BulkheadConfigBuilder {
 
     /// Builds the configuration and returns a BulkheadLayer.
     pub fn build(self) -> crate::layer::BulkheadLayer {
-        let config = BulkheadConfig {
+        let config = self.into_config();
+        crate::layer::BulkheadLayer::new(config)
+    }
+
+    /// Builds the configuration, returning both a layer and an observable handle.
+    ///
+    /// All services produced by the returned layer share the same semaphore,
+    /// and the handle can observe concurrency state from outside the service.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_resilience_bulkhead::BulkheadLayer;
+    ///
+    /// let (layer, handle) = BulkheadLayer::builder()
+    ///     .max_concurrent_calls(10)
+    ///     .build_with_handle();
+    ///
+    /// assert_eq!(handle.max_concurrent(), 10);
+    /// assert_eq!(handle.active_calls(), 0);
+    /// ```
+    pub fn build_with_handle(self) -> (crate::layer::BulkheadLayer, crate::handle::BulkheadHandle) {
+        let config = self.into_config();
+        let config = std::sync::Arc::new(config);
+        let semaphore =
+            std::sync::Arc::new(tokio::sync::Semaphore::new(config.max_concurrent_calls));
+
+        let handle = crate::handle::BulkheadHandle {
+            semaphore: std::sync::Arc::clone(&semaphore),
+            config: std::sync::Arc::clone(&config),
+        };
+
+        let layer = crate::layer::BulkheadLayer {
+            config: (*config).clone(),
+            shared: Some((semaphore, config)),
+        };
+
+        (layer, handle)
+    }
+
+    fn into_config(self) -> BulkheadConfig {
+        BulkheadConfig {
             max_concurrent_calls: self.max_concurrent_calls,
             max_wait_duration: self.max_wait_duration,
             backpressure: self.backpressure,
             name: self.name,
             event_listeners: self.event_listeners,
-        };
-        crate::layer::BulkheadLayer::new(config)
+        }
     }
 }
 

--- a/crates/tower-resilience-bulkhead/src/handle.rs
+++ b/crates/tower-resilience-bulkhead/src/handle.rs
@@ -1,0 +1,161 @@
+use crate::config::BulkheadConfig;
+use std::sync::Arc;
+use tokio::sync::Semaphore;
+
+/// A read-only handle for observing bulkhead state.
+///
+/// Obtained from [`crate::BulkheadConfigBuilder::build_with_handle()`]. The handle
+/// is cheap to clone and safe to share across threads (`Clone + Send + Sync`).
+///
+/// This is useful when the bulkhead service is consumed by middleware
+/// (e.g., wrapped in `BoxCloneService`) and direct access to the service
+/// is no longer available.
+///
+/// # Example
+///
+/// ```rust
+/// use tower_resilience_bulkhead::BulkheadLayer;
+///
+/// let (layer, handle) = BulkheadLayer::builder()
+///     .max_concurrent_calls(10)
+///     .build_with_handle();
+///
+/// // Apply the layer to a service...
+///
+/// // Later, query state from the handle:
+/// assert_eq!(handle.active_calls(), 0);
+/// assert_eq!(handle.max_concurrent(), 10);
+/// ```
+#[derive(Clone)]
+pub struct BulkheadHandle {
+    pub(crate) semaphore: Arc<Semaphore>,
+    pub(crate) config: Arc<BulkheadConfig>,
+}
+
+impl BulkheadHandle {
+    /// Returns the number of currently active (in-flight) calls.
+    pub fn active_calls(&self) -> usize {
+        self.config
+            .max_concurrent_calls
+            .saturating_sub(self.semaphore.available_permits())
+    }
+
+    /// Returns the configured maximum concurrent calls.
+    pub fn max_concurrent(&self) -> usize {
+        self.config.max_concurrent_calls
+    }
+
+    /// Returns the utilization ratio (0.0 to 1.0).
+    ///
+    /// A value of 1.0 means all permits are consumed.
+    pub fn utilization(&self) -> f64 {
+        let max = self.config.max_concurrent_calls;
+        if max == 0 {
+            return 0.0;
+        }
+        self.active_calls() as f64 / max as f64
+    }
+
+    /// Returns the number of available permits.
+    pub fn available_permits(&self) -> usize {
+        self.semaphore.available_permits()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::BulkheadLayer;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::Poll;
+    use tower::{Layer, Service};
+
+    #[derive(Clone)]
+    struct SlowService;
+
+    impl Service<String> for SlowService {
+        type Response = String;
+        type Error = String;
+        type Future = Pin<Box<dyn Future<Output = Result<String, String>> + Send>>;
+
+        fn poll_ready(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, req: String) -> Self::Future {
+            Box::pin(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                Ok(req)
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_initial_state() {
+        let (_layer, handle) = BulkheadLayer::builder()
+            .max_concurrent_calls(10)
+            .build_with_handle();
+
+        assert_eq!(handle.active_calls(), 0);
+        assert_eq!(handle.max_concurrent(), 10);
+        assert_eq!(handle.available_permits(), 10);
+        assert_eq!(handle.utilization(), 0.0);
+    }
+
+    #[tokio::test]
+    async fn test_handle_observes_active_calls() {
+        let (layer, handle) = BulkheadLayer::builder()
+            .max_concurrent_calls(5)
+            .build_with_handle();
+
+        let mut svc = layer.layer(SlowService);
+
+        // Spawn the call as a task so it actually runs
+        let task = tokio::spawn(async move { svc.call("test".to_string()).await });
+
+        // Give it a moment to acquire the permit
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert_eq!(handle.active_calls(), 1);
+        assert_eq!(handle.available_permits(), 4);
+
+        // Wait for it to complete
+        let _ = task.await;
+        assert_eq!(handle.active_calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_handle_shared_across_services() {
+        let (layer, handle) = BulkheadLayer::builder()
+            .max_concurrent_calls(10)
+            .build_with_handle();
+
+        let mut svc1 = layer.layer(SlowService);
+        let mut svc2 = layer.layer(SlowService);
+
+        // Spawn as tasks so they actually run concurrently
+        let t1 = tokio::spawn(async move { svc1.call("a".to_string()).await });
+        let t2 = tokio::spawn(async move { svc2.call("b".to_string()).await });
+
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert_eq!(handle.active_calls(), 2);
+        assert_eq!(handle.available_permits(), 8);
+
+        let _ = tokio::join!(t1, t2);
+        assert_eq!(handle.active_calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_handle_clone() {
+        let (_layer, handle) = BulkheadLayer::builder()
+            .max_concurrent_calls(10)
+            .build_with_handle();
+
+        let handle2 = handle.clone();
+        assert_eq!(handle.active_calls(), handle2.active_calls());
+        assert_eq!(handle.max_concurrent(), handle2.max_concurrent());
+    }
+}

--- a/crates/tower-resilience-bulkhead/src/layer.rs
+++ b/crates/tower-resilience-bulkhead/src/layer.rs
@@ -2,6 +2,8 @@
 
 use crate::config::BulkheadConfig;
 use crate::service::Bulkhead;
+use std::sync::Arc;
+use tokio::sync::Semaphore;
 use tower::Layer;
 
 #[cfg(feature = "metrics")]
@@ -15,13 +17,18 @@ static METRICS_INIT: Once = Once::new();
 /// Layer that applies bulkhead concurrency limiting.
 #[derive(Clone)]
 pub struct BulkheadLayer {
-    config: BulkheadConfig,
+    pub(crate) config: BulkheadConfig,
+    /// Pre-created shared state (set by `build_with_handle()`).
+    pub(crate) shared: Option<(Arc<Semaphore>, Arc<BulkheadConfig>)>,
 }
 
 impl BulkheadLayer {
     /// Creates a new bulkhead layer with the given configuration.
     pub fn new(config: BulkheadConfig) -> Self {
-        Self { config }
+        Self {
+            config,
+            shared: None,
+        }
     }
 
     /// Creates a new builder for configuring a bulkhead layer.
@@ -147,6 +154,10 @@ impl<S> Layer<S> for BulkheadLayer {
     type Service = Bulkhead<S>;
 
     fn layer(&self, service: S) -> Self::Service {
-        Bulkhead::new(service, self.config.clone())
+        if let Some((semaphore, config)) = &self.shared {
+            Bulkhead::from_shared(service, Arc::clone(semaphore), Arc::clone(config))
+        } else {
+            Bulkhead::new(service, self.config.clone())
+        }
     }
 }

--- a/crates/tower-resilience-bulkhead/src/lib.rs
+++ b/crates/tower-resilience-bulkhead/src/lib.rs
@@ -259,6 +259,7 @@ pub mod config;
 pub mod error;
 /// Event types emitted by the bulkhead.
 pub mod events;
+mod handle;
 /// Tower `Layer` implementation for the bulkhead.
 pub mod layer;
 /// Tower `Service` implementation for the bulkhead.
@@ -267,6 +268,7 @@ pub mod service;
 pub use config::{BulkheadConfig, BulkheadConfigBuilder};
 pub use error::{BulkheadError, BulkheadServiceError, Result};
 pub use events::BulkheadEvent;
+pub use handle::BulkheadHandle;
 pub use layer::BulkheadLayer;
 pub use service::Bulkhead;
 

--- a/crates/tower-resilience-bulkhead/src/service.rs
+++ b/crates/tower-resilience-bulkhead/src/service.rs
@@ -53,6 +53,21 @@ impl<S> Bulkhead<S> {
             acquire_future: None,
         }
     }
+
+    /// Creates a new bulkhead service using pre-created shared state.
+    pub(crate) fn from_shared(
+        inner: S,
+        semaphore: Arc<Semaphore>,
+        config: Arc<BulkheadConfig>,
+    ) -> Self {
+        Self {
+            inner,
+            semaphore,
+            config,
+            permit: None,
+            acquire_future: None,
+        }
+    }
 }
 
 impl<S, Request> Service<Request> for Bulkhead<S>

--- a/crates/tower-resilience-ratelimiter/src/config.rs
+++ b/crates/tower-resilience-ratelimiter/src/config.rs
@@ -320,7 +320,53 @@ impl RateLimiterConfigBuilder {
 
     /// Builds the rate limiter layer.
     pub fn build(self) -> crate::RateLimiterLayer {
-        let config = RateLimiterConfig {
+        let config = self.into_config();
+        crate::RateLimiterLayer::new(config)
+    }
+
+    /// Builds the rate limiter layer and returns an observable handle.
+    ///
+    /// All services produced by the returned layer share the same rate limiter
+    /// state, and the handle can observe that state from outside the service.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_resilience_ratelimiter::RateLimiterLayer;
+    ///
+    /// let (layer, handle) = RateLimiterLayer::builder()
+    ///     .limit_for_period(100)
+    ///     .build_with_handle();
+    ///
+    /// assert_eq!(handle.available_permits(), 100);
+    /// ```
+    pub fn build_with_handle(self) -> (crate::RateLimiterLayer, crate::RateLimiterHandle) {
+        let config = self.into_config();
+
+        let limiter = crate::limiter::SharedRateLimiter::new(
+            config.window_type,
+            config.limit_for_period,
+            config.refresh_period,
+            config.timeout_duration,
+        );
+
+        let config = std::sync::Arc::new(config);
+
+        let handle = crate::RateLimiterHandle {
+            limiter: limiter.clone(),
+            config: std::sync::Arc::clone(&config),
+        };
+
+        let layer = crate::layer::RateLimiterLayer {
+            config,
+            shared_limiter: Some(limiter),
+        };
+
+        (layer, handle)
+    }
+
+    fn into_config(self) -> RateLimiterConfig {
+        RateLimiterConfig {
             limit_for_period: self.limit_for_period,
             refresh_period: self.refresh_period,
             timeout_duration: self.timeout_duration,
@@ -328,9 +374,7 @@ impl RateLimiterConfigBuilder {
             backpressure: self.backpressure,
             event_listeners: self.event_listeners,
             name: self.name,
-        };
-
-        crate::RateLimiterLayer::new(config)
+        }
     }
 }
 

--- a/crates/tower-resilience-ratelimiter/src/handle.rs
+++ b/crates/tower-resilience-ratelimiter/src/handle.rs
@@ -1,0 +1,147 @@
+use crate::config::RateLimiterConfig;
+use crate::limiter::SharedRateLimiter;
+use std::sync::Arc;
+
+/// A read-only handle for observing rate limiter state.
+///
+/// Obtained from [`crate::RateLimiterConfigBuilder::build_with_handle()`]. The handle
+/// is cheap to clone and safe to share across threads (`Clone + Send + Sync`).
+///
+/// This is useful when the rate limiter service is consumed by middleware
+/// (e.g., wrapped in `BoxCloneService`) and direct access to the service
+/// is no longer available.
+///
+/// # Example
+///
+/// ```rust
+/// use tower_resilience_ratelimiter::RateLimiterLayer;
+///
+/// let (layer, handle) = RateLimiterLayer::builder()
+///     .limit_for_period(100)
+///     .build_with_handle();
+///
+/// // Apply the layer to a service...
+///
+/// // Later, query state from the handle:
+/// let available = handle.available_permits();
+/// ```
+#[derive(Clone)]
+pub struct RateLimiterHandle {
+    pub(crate) limiter: SharedRateLimiter,
+    pub(crate) config: Arc<RateLimiterConfig>,
+}
+
+impl RateLimiterHandle {
+    /// Returns the number of permits currently available.
+    pub fn available_permits(&self) -> usize {
+        self.limiter.available_permits()
+    }
+
+    /// Returns whether the rate limiter has no permits available.
+    pub fn is_throttling(&self) -> bool {
+        self.available_permits() == 0
+    }
+
+    /// Returns the utilization ratio (0.0 to 1.0).
+    ///
+    /// A value of 1.0 means all permits are consumed.
+    pub fn utilization(&self) -> f64 {
+        let limit = self.config.limit_for_period;
+        if limit == 0 {
+            return 0.0;
+        }
+        let available = self.available_permits();
+        let used = limit.saturating_sub(available);
+        used as f64 / limit as f64
+    }
+
+    /// Returns the configured limit per period.
+    pub fn limit_for_period(&self) -> usize {
+        self.config.limit_for_period
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RateLimiterLayer;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::Poll;
+    use tower::{Layer, Service, ServiceExt};
+
+    #[derive(Clone)]
+    struct OkService;
+
+    impl Service<String> for OkService {
+        type Response = String;
+        type Error = String;
+        type Future = Pin<Box<dyn Future<Output = Result<String, String>> + Send>>;
+
+        fn poll_ready(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, req: String) -> Self::Future {
+            Box::pin(async move { Ok(req) })
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_initial_state() {
+        let (_layer, handle) = RateLimiterLayer::builder()
+            .limit_for_period(10)
+            .build_with_handle();
+
+        assert_eq!(handle.available_permits(), 10);
+        assert!(!handle.is_throttling());
+        assert_eq!(handle.utilization(), 0.0);
+        assert_eq!(handle.limit_for_period(), 10);
+    }
+
+    #[tokio::test]
+    async fn test_handle_observes_permit_usage() {
+        let (layer, handle) = RateLimiterLayer::builder()
+            .limit_for_period(3)
+            .build_with_handle();
+
+        let mut svc = layer.layer(OkService);
+
+        // Use one permit
+        let _ = svc.call("a".to_string()).await;
+        assert_eq!(handle.available_permits(), 2);
+
+        // Use another
+        let _ = svc.call("b".to_string()).await;
+        assert_eq!(handle.available_permits(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_handle_shared_across_services() {
+        let (layer, handle) = RateLimiterLayer::builder()
+            .limit_for_period(4)
+            .build_with_handle();
+
+        let mut svc1 = layer.layer(OkService);
+        let mut svc2 = layer.layer(OkService);
+
+        let _ = svc1.call("a".to_string()).await;
+        let _ = svc2.call("b".to_string()).await;
+
+        // Both services consumed from the same pool
+        assert_eq!(handle.available_permits(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_handle_clone() {
+        let (_layer, handle) = RateLimiterLayer::builder()
+            .limit_for_period(10)
+            .build_with_handle();
+
+        let handle2 = handle.clone();
+        assert_eq!(handle.available_permits(), handle2.available_permits());
+    }
+}

--- a/crates/tower-resilience-ratelimiter/src/layer.rs
+++ b/crates/tower-resilience-ratelimiter/src/layer.rs
@@ -1,3 +1,4 @@
+use crate::limiter::SharedRateLimiter;
 use crate::{RateLimiter, RateLimiterConfig};
 use std::sync::Arc;
 use tower::Layer;
@@ -31,7 +32,9 @@ use tower::Layer;
 /// ```
 #[derive(Clone)]
 pub struct RateLimiterLayer {
-    config: Arc<RateLimiterConfig>,
+    pub(crate) config: Arc<RateLimiterConfig>,
+    /// Pre-created shared limiter state (set by `build_with_handle()`).
+    pub(crate) shared_limiter: Option<SharedRateLimiter>,
 }
 
 impl RateLimiterLayer {
@@ -39,6 +42,7 @@ impl RateLimiterLayer {
     pub fn new(config: RateLimiterConfig) -> Self {
         Self {
             config: Arc::new(config),
+            shared_limiter: None,
         }
     }
 
@@ -144,6 +148,10 @@ impl<S> Layer<S> for RateLimiterLayer {
     type Service = RateLimiter<S>;
 
     fn layer(&self, service: S) -> Self::Service {
-        RateLimiter::new(service, Arc::clone(&self.config))
+        if let Some(limiter) = &self.shared_limiter {
+            RateLimiter::from_shared(service, Arc::clone(&self.config), limiter.clone())
+        } else {
+            RateLimiter::new(service, Arc::clone(&self.config))
+        }
     }
 }

--- a/crates/tower-resilience-ratelimiter/src/lib.rs
+++ b/crates/tower-resilience-ratelimiter/src/lib.rs
@@ -215,12 +215,14 @@
 mod config;
 mod error;
 mod events;
+mod handle;
 mod layer;
 mod limiter;
 
 pub use config::{RateLimiterConfig, RateLimiterConfigBuilder, WindowType};
 pub use error::{RateLimiterError, RateLimiterServiceError};
 pub use events::RateLimiterEvent;
+pub use handle::RateLimiterHandle;
 pub use layer::RateLimiterLayer;
 
 use crate::limiter::SharedRateLimiter;
@@ -285,6 +287,33 @@ impl<S> RateLimiter<S> {
             config.refresh_period,
             config.timeout_duration,
         );
+
+        Self {
+            inner,
+            config,
+            limiter,
+            sleep: None,
+            permit_acquired: false,
+        }
+    }
+
+    /// Creates a new `RateLimiter` using pre-created shared limiter state.
+    pub(crate) fn from_shared(
+        inner: S,
+        config: Arc<RateLimiterConfig>,
+        limiter: SharedRateLimiter,
+    ) -> Self {
+        #[cfg(feature = "metrics")]
+        {
+            describe_counter!(
+                "ratelimiter_calls_total",
+                "Total number of rate limiter calls (permitted or rejected)"
+            );
+            describe_histogram!(
+                "ratelimiter_wait_duration_seconds",
+                "Time spent waiting for a permit"
+            );
+        }
 
         Self {
             inner,


### PR DESCRIPTION
## Summary

Add `build_with_handle()` to both `RateLimiterConfigBuilder` and `BulkheadConfigBuilder`, following the same pattern established in #276 for `CircuitBreakerHandle`.

### RateLimiterHandle

```rust
let (layer, handle) = RateLimiterLayer::builder()
    .limit_for_period(100)
    .build_with_handle();

handle.available_permits()   // usize
handle.is_throttling()       // bool
handle.utilization()         // f64 (0.0 to 1.0)
handle.limit_for_period()    // usize
```

### BulkheadHandle

```rust
let (layer, handle) = BulkheadLayer::builder()
    .max_concurrent_calls(10)
    .build_with_handle();

handle.active_calls()        // usize
handle.max_concurrent()      // usize
handle.utilization()         // f64 (0.0 to 1.0)
handle.available_permits()   // usize
```

## Implementation

Same pattern as #276:
- Pre-create shared state in `build_with_handle()` and bake into layer
- All services from that layer share the same state
- Handle holds `Arc` references for observation
- `build()` continues to work as before (backward compatible)

## Test plan
- [x] RateLimiter: initial state, permit usage observation, shared across services, clone
- [x] Bulkhead: initial state, active call observation, shared across services, clone
- [x] All existing tests pass (108 total across both crates)
- [x] Clippy clean, docs build

Closes #277, closes #278