### PR TITLE
fix: preserve readied inner service across call (tower contract)

### DIFF
--- a/crates/tower-resilience-bulkhead/src/service.rs
+++ b/crates/tower-resilience-bulkhead/src/service.rs
@@ -125,7 +125,8 @@ where
             // Backpressure mode: permit already acquired in poll_ready
             let semaphore_for_check = Arc::clone(&self.semaphore);
             let config = Arc::clone(&self.config);
-            let mut inner = self.inner.clone();
+            let clone = self.inner.clone();
+            let mut inner = std::mem::replace(&mut self.inner, clone);
             let start_time = Instant::now();
 
             // Emit call permitted event
@@ -204,7 +205,8 @@ where
         let semaphore = Arc::clone(&self.semaphore);
         let semaphore_for_check = Arc::clone(&self.semaphore);
         let config = Arc::clone(&self.config);
-        let mut inner = self.inner.clone();
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
         let start_time = Instant::now();
 
         #[cfg(feature = "metrics")]

--- a/crates/tower-resilience-chaos/src/service.rs
+++ b/crates/tower-resilience-chaos/src/service.rs
@@ -52,7 +52,8 @@ where
     }
 
     fn call(&mut self, req: Req) -> Self::Future {
-        let mut inner = self.inner.clone();
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
         let config = Arc::clone(&self.config);
         let rng = Arc::clone(&self.rng);
 

--- a/crates/tower-resilience-circuitbreaker/src/lib.rs
+++ b/crates/tower-resilience-circuitbreaker/src/lib.rs
@@ -628,7 +628,8 @@ where
     fn call(&mut self, req: Req) -> Self::Future {
         let config = Arc::clone(&self.config);
         let circuit = Arc::clone(&self.circuit);
-        let mut inner = self.inner.clone();
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
 
         Box::pin(async move {
             #[cfg(feature = "tracing")]
@@ -836,7 +837,8 @@ where
     fn call(&mut self, req: Req) -> Self::Future {
         let config = Arc::clone(&self.config);
         let circuit = Arc::clone(&self.circuit);
-        let mut inner = self.inner.clone();
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
         let fallback = Arc::clone(&self.fallback);
 
         Box::pin(async move {

--- a/crates/tower-resilience-ratelimiter/src/lib.rs
+++ b/crates/tower-resilience-ratelimiter/src/lib.rs
@@ -400,7 +400,8 @@ where
             // Backpressure mode: permit already acquired in poll_ready
             self.permit_acquired = false;
             let config = Arc::clone(&self.config);
-            let mut inner = self.inner.clone();
+            let clone = self.inner.clone();
+            let mut inner = std::mem::replace(&mut self.inner, clone);
 
             let event = RateLimiterEvent::PermitAcquired {
                 pattern_name: config.name.clone(),
@@ -430,7 +431,8 @@ where
         // Rejection mode: acquire permit in call
         let limiter = self.limiter.clone();
         let config = Arc::clone(&self.config);
-        let mut inner = self.inner.clone();
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
 
         Box::pin(async move {
             match limiter.acquire().await {

--- a/crates/tower-resilience-timelimiter/src/lib.rs
+++ b/crates/tower-resilience-timelimiter/src/lib.rs
@@ -189,7 +189,8 @@ where
     }
 
     fn call(&mut self, req: Req) -> Self::Future {
-        let mut inner = self.inner.clone();
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
         let config = Arc::clone(&self.config);
 
         // Extract timeout from request before moving it

--- a/tests/clone_in_call_contract.rs
+++ b/tests/clone_in_call_contract.rs
@@ -1,0 +1,181 @@
+//! Regression tests for #286.
+//!
+//! Tower's `Service` contract permits `call` to panic if the receiver was not
+//! first driven to `Poll::Ready(Ok(()))` via `poll_ready`. Earlier versions of
+//! every layer in this crate that wraps a clonable inner service moved a fresh
+//! clone of `self.inner` (rather than the readied original) into the returned
+//! future, violating the contract for any inner service whose `Clone` resets
+//! per-instance readiness state.
+//!
+//! These tests wrap a `StatefulInner` whose `Clone` impl deliberately resets
+//! its `ready` flag (matching the documented behavior of
+//! `tower::limit::ConcurrencyLimit`, `tower::buffer::Buffer`, etc.) so that any
+//! regression to the clone-in-call anti-pattern panics here.
+//!
+//! See: https://docs.rs/tower-service/0.3.3/tower_service/trait.Service.html#be-careful-when-cloning-inner-services
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use tower::{Service, ServiceExt};
+
+/// Service whose `Clone` resets `ready: false`, panicking on `call` until
+/// `poll_ready` is observed on that specific instance.
+struct StatefulInner {
+    ready: bool,
+}
+
+impl Clone for StatefulInner {
+    fn clone(&self) -> Self {
+        // Resets readiness state, matching the documented behavior of stateful
+        // tower middleware (ConcurrencyLimit, Buffer, Batch, LoadShed).
+        Self { ready: false }
+    }
+}
+
+impl StatefulInner {
+    fn new() -> Self {
+        Self { ready: false }
+    }
+}
+
+impl Service<()> for StatefulInner {
+    type Response = ();
+    type Error = std::convert::Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.ready = true;
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: ()) -> Self::Future {
+        assert!(
+            self.ready,
+            "Service::call invoked without prior poll_ready -- tower contract violation (#286)"
+        );
+        // The contract: call consumes the readiness. Next call must re-poll.
+        self.ready = false;
+        Box::pin(async { Ok(()) })
+    }
+}
+
+#[tokio::test]
+async fn circuitbreaker_drives_readied_instance() {
+    use tower_resilience_circuitbreaker::CircuitBreakerLayer;
+
+    let layer = CircuitBreakerLayer::builder()
+        .failure_rate_threshold(50.0)
+        .build();
+    let mut svc = tower::ServiceBuilder::new()
+        .layer(layer)
+        .service(StatefulInner::new());
+
+    for _ in 0..3 {
+        let _ = svc.ready().await.unwrap().call(()).await;
+    }
+}
+
+#[tokio::test]
+async fn bulkhead_rejection_drives_readied_instance() {
+    use tower_resilience_bulkhead::BulkheadLayer;
+
+    // Rejection mode: poll_ready returns Ready immediately, permit acquired in call.
+    let layer = BulkheadLayer::builder()
+        .max_concurrent_calls(4)
+        .reject_when_full()
+        .build();
+    let mut svc = tower::ServiceBuilder::new()
+        .layer(layer)
+        .service(StatefulInner::new());
+
+    for _ in 0..3 {
+        let _ = svc.ready().await.unwrap().call(()).await;
+    }
+}
+
+#[tokio::test]
+async fn bulkhead_backpressure_drives_readied_instance() {
+    use tower_resilience_bulkhead::BulkheadLayer;
+
+    // Backpressure mode: permit acquired in poll_ready.
+    let layer = BulkheadLayer::builder()
+        .max_concurrent_calls(4)
+        .backpressure()
+        .build();
+    let mut svc = tower::ServiceBuilder::new()
+        .layer(layer)
+        .service(StatefulInner::new());
+
+    for _ in 0..3 {
+        let _ = svc.ready().await.unwrap().call(()).await;
+    }
+}
+
+#[tokio::test]
+async fn timelimiter_drives_readied_instance() {
+    use tower_resilience_timelimiter::TimeLimiterLayer;
+
+    let layer = TimeLimiterLayer::builder()
+        .timeout_duration(Duration::from_secs(1))
+        .build();
+    let mut svc = tower::ServiceBuilder::new()
+        .layer(layer)
+        .service(StatefulInner::new());
+
+    for _ in 0..3 {
+        let _ = svc.ready().await.unwrap().call(()).await;
+    }
+}
+
+#[tokio::test]
+async fn ratelimiter_rejection_drives_readied_instance() {
+    use tower_resilience_ratelimiter::RateLimiterLayer;
+
+    let layer = RateLimiterLayer::builder()
+        .limit_for_period(1000)
+        .refresh_period(Duration::from_secs(1))
+        .build();
+    let mut svc = tower::ServiceBuilder::new()
+        .layer(layer)
+        .service(StatefulInner::new());
+
+    for _ in 0..3 {
+        let _ = svc.ready().await.unwrap().call(()).await;
+    }
+}
+
+#[tokio::test]
+async fn ratelimiter_backpressure_drives_readied_instance() {
+    use tower_resilience_ratelimiter::RateLimiterLayer;
+
+    let layer = RateLimiterLayer::builder()
+        .limit_for_period(1000)
+        .refresh_period(Duration::from_secs(1))
+        .backpressure()
+        .build();
+    let mut svc = tower::ServiceBuilder::new()
+        .layer(layer)
+        .service(StatefulInner::new());
+
+    for _ in 0..3 {
+        let _ = svc.ready().await.unwrap().call(()).await;
+    }
+}
+
+#[tokio::test]
+async fn chaos_drives_readied_instance() {
+    use tower_resilience_chaos::ChaosLayer;
+
+    // No chaos injection -- we only care about the readiness contract.
+    let layer = ChaosLayer::builder().build();
+    let mut svc = tower::ServiceBuilder::new()
+        .layer(layer)
+        .service(StatefulInner::new());
+
+    for _ in 0..3 {
+        let _ = svc.ready().await.unwrap().call(()).await;
+    }
+}


### PR DESCRIPTION
## Summary

Every layer in this crate that wraps a clonable inner service used the pattern:

```rust
fn call(&mut self, req: Req) -> Self::Future {
    let mut inner = self.inner.clone(); // <-- unreadied clone
    Box::pin(async move { inner.call(req).await })
}
```

[Tower's `Service` docs](https://docs.rs/tower-service/0.3.3/tower_service/trait.Service.html#be-careful-when-cloning-inner-services) flag this exact pattern as wrong: `call` may panic if invoked on an instance that was never driven to readiness via `poll_ready`. The bug surfaces deterministically whenever the inner middleware resets per-instance readiness state on `Clone` -- which is what tower's own `ConcurrencyLimit`, `Buffer`, `LoadShed`, and `tower-batch::Batch` all do (correctly, per the contract).

This PR applies the documented fix at every site -- `std::mem::replace(&mut self.inner, self.inner.clone())` -- so the readied original moves into the future and a fresh clone is left on `&mut self` for the next `poll_ready` cycle. Same allocation count, no behavior change for inner services that lack per-instance readiness state.

Affected services:
- `CircuitBreaker`, `CircuitBreakerWithFallback`
- `Bulkhead` (both backpressure and rejection paths)
- `TimeLimiter`
- `RateLimiter` (both backpressure and rejection paths)
- `Chaos`

`OutlierDetection` already used the equivalent `mem::swap` idiom and is unchanged.

Each affected crate's existing `Clone` impl already resets its per-instance state (`sleep: None`, `permit: None`, `acquire_future: None`), so the fresh clone left on `&mut self` is safe for the next `poll_ready` -- no other changes required.

## Regression test

`tests/clone_in_call_contract.rs` wraps each layer around a `StatefulInner` whose `Clone` impl resets `ready: false`, panicking on `call` until `poll_ready` is observed on that specific instance. Verified the suite fails against the previous code (panic in `call`) and passes after the fix.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (all suites pass, including new contract tests)
- [x] `cargo test --doc --workspace --all-features`
- [x] Regression test confirmed to fail against pre-fix code

Closes #286.