### PR TITLE
fix(bulkhead): store acquire task as JoinHandle so Bulkhead is Sync

### DIFF
--- a/crates/tower-resilience-bulkhead/Cargo.toml
+++ b/crates/tower-resilience-bulkhead/Cargo.toml
@@ -16,7 +16,7 @@ tower-resilience-core = { workspace = true }
 tower = { workspace = true }
 tower-layer = { workspace = true }
 tower-service = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt"] }
 futures = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/tower-resilience-bulkhead/src/service.rs
+++ b/crates/tower-resilience-bulkhead/src/service.rs
@@ -10,13 +10,33 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Instant;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::task::JoinHandle;
 use tower::Service;
 
 #[cfg(feature = "metrics")]
 use metrics::{counter, gauge, histogram};
 
-type AcquireFuture =
-    Pin<Box<dyn Future<Output = Result<OwnedSemaphorePermit, tokio::sync::AcquireError>> + Send>>;
+/// Wraps a `JoinHandle` so the task is aborted when the handle is dropped.
+///
+/// Used for the in-flight `Semaphore::acquire_owned` task in backpressure mode.
+/// Without this, dropping a `Bulkhead` while a permit acquisition is pending
+/// would leak the spawned task (it would keep running, holding an `Arc` to the
+/// semaphore, until either the permit was acquired and immediately discarded
+/// or the semaphore was closed).
+///
+/// Storing a `JoinHandle` rather than a `Pin<Box<dyn Future + Send>>` also
+/// keeps `Bulkhead: Sync` -- `JoinHandle` implements `Sync` whereas a boxed
+/// trait-object future does not (#287). This is what unblocks composition with
+/// tonic's gRPC servers and other `Arc`-shared service holders.
+struct AbortOnDrop<T> {
+    handle: JoinHandle<T>,
+}
+
+impl<T> Drop for AbortOnDrop<T> {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
 
 /// Bulkhead service that limits concurrent calls.
 pub struct Bulkhead<S> {
@@ -25,8 +45,11 @@ pub struct Bulkhead<S> {
     config: Arc<BulkheadConfig>,
     /// Permit reserved in `poll_ready` (backpressure mode only).
     permit: Option<OwnedSemaphorePermit>,
-    /// In-flight semaphore acquire future (backpressure mode only).
-    acquire_future: Option<AcquireFuture>,
+    /// In-flight semaphore acquire task (backpressure mode only).
+    ///
+    /// Stored as a `JoinHandle` rather than a boxed future so that `Bulkhead`
+    /// remains `Sync` (a `dyn Future + Send` is not `Sync`). See #287.
+    acquire_task: Option<AbortOnDrop<Result<OwnedSemaphorePermit, tokio::sync::AcquireError>>>,
 }
 
 impl<S: Clone> Clone for Bulkhead<S> {
@@ -36,7 +59,7 @@ impl<S: Clone> Clone for Bulkhead<S> {
             semaphore: Arc::clone(&self.semaphore),
             config: Arc::clone(&self.config),
             permit: None,
-            acquire_future: None,
+            acquire_task: None,
         }
     }
 }
@@ -50,7 +73,7 @@ impl<S> Bulkhead<S> {
             semaphore,
             config: Arc::new(config),
             permit: None,
-            acquire_future: None,
+            acquire_task: None,
         }
     }
 
@@ -65,7 +88,7 @@ impl<S> Bulkhead<S> {
             semaphore,
             config,
             permit: None,
-            acquire_future: None,
+            acquire_task: None,
         }
     }
 }
@@ -99,21 +122,47 @@ where
             return Poll::Ready(Ok(()));
         }
 
-        // Create or poll the acquire future
-        let fut = self.acquire_future.get_or_insert_with(|| {
-            let sem = Arc::clone(&self.semaphore);
-            Box::pin(async move { sem.acquire_owned().await })
-        });
+        // Fast path on first poll: try to acquire without queueing.
+        if self.acquire_task.is_none() {
+            match Arc::clone(&self.semaphore).try_acquire_owned() {
+                Ok(permit) => {
+                    self.permit = Some(permit);
+                    return Poll::Ready(Ok(()));
+                }
+                Err(tokio::sync::TryAcquireError::NoPermits) => {
+                    // Spawn a task to wait in the semaphore's FIFO queue.
+                    let sem = Arc::clone(&self.semaphore);
+                    let handle = tokio::spawn(async move { sem.acquire_owned().await });
+                    self.acquire_task = Some(AbortOnDrop { handle });
+                }
+                Err(tokio::sync::TryAcquireError::Closed) => {
+                    // Semaphore closed -- should not happen in normal operation.
+                    return Poll::Ready(Ok(()));
+                }
+            }
+        }
 
-        match fut.as_mut().poll(cx) {
-            Poll::Ready(Ok(permit)) => {
-                self.acquire_future = None;
+        // Poll the in-flight acquire task.
+        let task = self
+            .acquire_task
+            .as_mut()
+            .expect("acquire_task set above when None");
+        match Pin::new(&mut task.handle).poll(cx) {
+            Poll::Ready(Ok(Ok(permit))) => {
+                self.acquire_task = None;
                 self.permit = Some(permit);
                 Poll::Ready(Ok(()))
             }
+            Poll::Ready(Ok(Err(_))) => {
+                // Semaphore closed -- should not happen in normal operation.
+                self.acquire_task = None;
+                Poll::Ready(Ok(()))
+            }
             Poll::Ready(Err(_)) => {
-                // Semaphore closed -- should not happen in normal operation
-                self.acquire_future = None;
+                // JoinError -- task was aborted or panicked. Treat like a
+                // closed semaphore: clear the slot and let the caller
+                // re-attempt on the next poll cycle.
+                self.acquire_task = None;
                 Poll::Ready(Ok(()))
             }
             Poll::Pending => Poll::Pending,

--- a/tests/auto_traits.rs
+++ b/tests/auto_traits.rs
@@ -1,0 +1,147 @@
+//! Auto-trait assertions for every layer service.
+//!
+//! These tests are compile-time checks. They ensure that every layer in the
+//! crate produces a `Send + Sync + 'static` service when wrapped around a
+//! `Send + Sync + 'static` inner. This is the surface that tonic, axum,
+//! tower::buffer, and other `Arc`-shared service holders require.
+//!
+//! A regression that drops `Sync` (e.g., by storing a `Pin<Box<dyn Future +
+//! Send>>` field without `+ Sync`) will fail to compile here.
+//!
+//! See #287 for the motivating bug.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+use tower::{Layer, Service};
+
+/// Inner service that is `Send + Sync + 'static` and whose future is
+/// `Send + Sync + 'static`. Any auto-trait loss in the wrapping layer is
+/// attributable to the layer itself, not the inner.
+#[derive(Clone)]
+struct SyncInner;
+
+impl Service<()> for SyncInner {
+    type Response = ();
+    type Error = std::convert::Infallible;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<(), std::convert::Infallible>> + Send + Sync + 'static>>;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _: ()) -> Self::Future {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+fn assert_send_sync_static<T: Send + Sync + 'static>(_: &T) {}
+
+#[test]
+fn bulkhead_is_send_sync() {
+    use tower_resilience_bulkhead::BulkheadLayer;
+    let svc = BulkheadLayer::builder()
+        .max_concurrent_calls(2)
+        .build()
+        .layer(SyncInner);
+    assert_send_sync_static(&svc);
+}
+
+#[test]
+fn bulkhead_backpressure_is_send_sync() {
+    use tower_resilience_bulkhead::BulkheadLayer;
+    let svc = BulkheadLayer::builder()
+        .max_concurrent_calls(2)
+        .backpressure()
+        .build()
+        .layer(SyncInner);
+    assert_send_sync_static(&svc);
+}
+
+#[test]
+fn circuitbreaker_is_send_sync() {
+    use tower_resilience_circuitbreaker::CircuitBreakerLayer;
+    let svc = CircuitBreakerLayer::builder().build().layer(SyncInner);
+    assert_send_sync_static(&svc);
+}
+
+#[test]
+fn ratelimiter_is_send_sync() {
+    use tower_resilience_ratelimiter::RateLimiterLayer;
+    let svc = RateLimiterLayer::builder()
+        .limit_for_period(100)
+        .refresh_period(Duration::from_secs(1))
+        .build()
+        .layer(SyncInner);
+    assert_send_sync_static(&svc);
+}
+
+#[test]
+fn ratelimiter_backpressure_is_send_sync() {
+    use tower_resilience_ratelimiter::RateLimiterLayer;
+    let svc = RateLimiterLayer::builder()
+        .limit_for_period(100)
+        .refresh_period(Duration::from_secs(1))
+        .backpressure()
+        .build()
+        .layer(SyncInner);
+    assert_send_sync_static(&svc);
+}
+
+#[test]
+fn timelimiter_is_send_sync() {
+    use tower_resilience_timelimiter::TimeLimiterLayer;
+    let svc = TimeLimiterLayer::builder()
+        .timeout_duration(Duration::from_secs(1))
+        .build()
+        .layer(SyncInner);
+    assert_send_sync_static(&svc);
+}
+
+#[test]
+fn chaos_is_send_sync() {
+    use tower_resilience_chaos::ChaosLayer;
+    let svc = ChaosLayer::builder().build().layer(SyncInner);
+    assert_send_sync_static(&svc);
+}
+
+/// Simulates the tonic / `Arc<T>` server holder pattern from #287. tonic
+/// stores `inner: Arc<T>` and dispatches via `Arc::clone` across `.await`
+/// points, which requires `T: Send + Sync + 'static`. Before the fix, this
+/// did not compile because `Bulkhead<S>: !Sync`.
+#[tokio::test]
+async fn bulkhead_composes_under_arc_like_tonic() {
+    use std::sync::Arc;
+    use tower_resilience_bulkhead::BulkheadLayer;
+
+    let svc = BulkheadLayer::builder()
+        .max_concurrent_calls(2)
+        .backpressure()
+        .build()
+        .layer(SyncInner);
+
+    // The shape tonic generates: Arc<MyService>, where MyService holds the
+    // composed tower stack. Captured across `.await` -- requires Sync.
+    struct Server<S> {
+        inner: S,
+    }
+
+    let server = Arc::new(Server { inner: svc });
+
+    fn requires_send_sync_static<T: Send + Sync + 'static>(_: &T) {}
+    requires_send_sync_static(&server);
+
+    // Spawn two tasks sharing the Arc -- mirrors how tonic dispatches.
+    let s1 = Arc::clone(&server);
+    let s2 = Arc::clone(&server);
+    let t1 = tokio::spawn(async move {
+        let _ = &s1.inner;
+    });
+    let t2 = tokio::spawn(async move {
+        let _ = &s2.inner;
+    });
+    t1.await.unwrap();
+    t2.await.unwrap();
+}


### PR DESCRIPTION
## Summary

`tower_resilience_bulkhead::Bulkhead` was `!Sync` regardless of `S`, because it stored its in-flight semaphore acquire as a `Pin<Box<dyn Future<...> + Send>>`. The `+ Send` without `+ Sync` cascaded:

```
dyn Future + Send: !Sync
  -> Box<...>: !Sync
    -> Pin<Box<...>>: !Sync
      -> Option<...>: !Sync
        -> Bulkhead<S>: !Sync
```

This broke composition with tonic's generated gRPC servers and any other `Arc<T>`-shared service holder that requires `T: Send + Sync + 'static`.

This PR adopts Option 2 from #287: replace the boxed trait-object future with a `tokio::task::JoinHandle`. `JoinHandle` implements `Sync` (tokio marks it `unsafe impl Sync`), so the cascade breaks and `Bulkhead<S>: Sync` iff `S: Sync`.

## Implementation notes

- **`AbortOnDrop` wrapper** around the stored `JoinHandle`. Without it, dropping a `Bulkhead` mid-acquire would leak the spawned task -- the task would keep running, holding an `Arc<Semaphore>`, and either acquire-then-discard a permit or hang until the semaphore was closed. With it, the task is aborted when the `Bulkhead` drops, and tokio cleans up any acquired permit via `OwnedSemaphorePermit::Drop`.
- **Fast path preserved.** `poll_ready` now calls `Semaphore::try_acquire_owned` before spawning. The spawn only happens on contention (when the request actually needs to queue). The uncontended hot path takes zero task spawns and zero heap allocations beyond what already existed.
- **Tokio `rt` feature added** to `tower-resilience-bulkhead`'s dependency on tokio. Already required transitively in practice -- the crate cannot function without a tokio runtime -- but `rt` is now explicit.

## Why Option 2 over Option 1

The reporter recommended Option 1 (hand-rolled `parking_lot::Mutex<VecDeque<Waker>>` queue, drops the tokio dependency entirely). I went with Option 2 instead:

1. **Risk profile.** Option 2 is a surgical type change. Option 1 is ~75 LOC of hand-tuned waker management that warrants loom testing -- we don't have loom infrastructure yet.
2. **Tonic users (the reporter's blocker) already require tokio.** Runtime neutrality is a worthwhile larger conversation, but it would also affect `circuitbreaker`, `ratelimiter`, `timelimiter`, and `chaos` (all of which use `tokio::time`). Bulkhead isn't the only tokio-coupled service.
3. **The "deeper tokio coupling" objection cuts both ways.** We already required `tokio::sync::Semaphore`; adding `tokio::spawn` is a marginal increase.

Filed #295 to track Option 1 (runtime-neutral bulkhead) as a future improvement, scoped to the broader runtime-neutrality question.

## Regression tests

`tests/auto_traits.rs` adds compile-time `Send + Sync + 'static` assertions for every layer service:

- `bulkhead_is_send_sync` (rejection mode)
- `bulkhead_backpressure_is_send_sync`
- `circuitbreaker_is_send_sync`
- `ratelimiter_is_send_sync` (rejection mode)
- `ratelimiter_backpressure_is_send_sync`
- `timelimiter_is_send_sync`
- `chaos_is_send_sync`
- `bulkhead_composes_under_arc_like_tonic` -- mirrors the tonic-generated `Arc<Server { inner: T }>` shape from the bug report, captured across `.await` in two spawned tasks.

A regression that drops `Sync` from any service (e.g., by storing a boxed trait-object future field without `+ Sync`) will fail to compile here. This also covers item J of #293.

I verified the diagnosis upstream with a throwaway probe -- pre-fix, the Bulkhead assertions failed with the exact cascade described in #287.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` -- all 47 bulkhead tests pass; full workspace suite green
- [x] `cargo test --doc --workspace --all-features`
- [x] `cargo build -p tonic-resilient-greeter --all-features` -- the in-tree tonic example still builds
- [x] Diagnosis verified with a throwaway compile probe before applying the fix

Closes #287.
Partial: #293 (item J -- auto-trait sweep).