### PR TITLE
fix: extend clone-in-call fix to fallback, retry, executor

### DIFF
--- a/crates/tower-resilience-executor/src/service.rs
+++ b/crates/tower-resilience-executor/src/service.rs
@@ -74,8 +74,10 @@ where
     }
 
     fn call(&mut self, req: Req) -> Self::Future {
-        // Clone the service for the spawned task
-        let mut service = self.inner.clone();
+        // Take the readied service for the spawned task, leaving a fresh
+        // clone behind for the next poll_ready cycle. See #286.
+        let clone = self.inner.clone();
+        let mut service = std::mem::replace(&mut self.inner, clone);
         let (tx, rx) = oneshot::channel();
 
         // Spawn the request processing on the executor

--- a/crates/tower-resilience-fallback/src/lib.rs
+++ b/crates/tower-resilience-fallback/src/lib.rs
@@ -278,7 +278,8 @@ where
     }
 
     fn call(&mut self, req: Req) -> Self::Future {
-        let mut service = self.inner.clone();
+        let clone = self.inner.clone();
+        let mut service = std::mem::replace(&mut self.inner, clone);
         let config = Arc::clone(&self.config);
         let req_clone = req.clone();
 

--- a/crates/tower-resilience-retry/src/lib.rs
+++ b/crates/tower-resilience-retry/src/lib.rs
@@ -251,7 +251,8 @@ where
     }
 
     fn call(&mut self, req: Req) -> Self::Future {
-        let mut service = self.inner.clone();
+        let clone = self.inner.clone();
+        let mut service = std::mem::replace(&mut self.inner, clone);
         let config = Arc::clone(&self.config);
 
         // Extract max_attempts from request before moving it

--- a/tests/clone_in_call_contract.rs
+++ b/tests/clone_in_call_contract.rs
@@ -179,3 +179,49 @@ async fn chaos_drives_readied_instance() {
         let _ = svc.ready().await.unwrap().call(()).await;
     }
 }
+
+#[tokio::test]
+async fn fallback_drives_readied_instance() {
+    use tower_resilience_fallback::FallbackLayer;
+
+    // value() strategy returns a fixed Res when inner errors. We only care
+    // that the inner is invoked on the readied instance.
+    let layer = FallbackLayer::<(), (), std::convert::Infallible>::value(());
+    let mut svc = tower::ServiceBuilder::new()
+        .layer(layer)
+        .service(StatefulInner::new());
+
+    for _ in 0..3 {
+        let _ = svc.ready().await.unwrap().call(()).await;
+    }
+}
+
+#[tokio::test]
+async fn retry_drives_readied_instance() {
+    use tower_resilience_retry::RetryLayer;
+
+    let layer: tower_resilience_retry::RetryLayer<(), (), std::convert::Infallible> =
+        RetryLayer::builder().max_attempts(1).build();
+    let mut svc = tower::ServiceBuilder::new()
+        .layer(layer)
+        .service(StatefulInner::new());
+
+    // Multiple calls force the contract over the retry boundary as well.
+    for _ in 0..3 {
+        let _ = svc.ready().await.unwrap().call(()).await;
+    }
+}
+
+#[tokio::test]
+async fn executor_drives_readied_instance() {
+    use tower_resilience_executor::ExecutorLayer;
+
+    let layer = ExecutorLayer::current();
+    let mut svc = tower::ServiceBuilder::new()
+        .layer(layer)
+        .service(StatefulInner::new());
+
+    for _ in 0..3 {
+        let _ = svc.ready().await.unwrap().call(()).await;
+    }
+}


### PR DESCRIPTION
## Summary

Three additional sites had the same tower contract violation as #286 but used `let mut service =` instead of `let mut inner =`, escaping the original grep:

- `crates/tower-resilience-fallback/src/lib.rs:281`
- `crates/tower-resilience-retry/src/lib.rs:254`
- `crates/tower-resilience-executor/src/service.rs:78`

Each moved a fresh, unreadied clone of `self.inner` into the returned future (or spawned task), violating the [documented Service contract](https://docs.rs/tower-service/0.3.3/tower_service/trait.Service.html#be-careful-when-cloning-inner-services).

Apply the `std::mem::replace` idiom at each site -- same fix as #288.

Each crate's `Clone` impl already produces a safe clone (no per-instance readiness state to reset), so the fresh clone left on `&mut self` is ready for the next `poll_ready` cycle.

## Regression tests

Extends `tests/clone_in_call_contract.rs` with three new cases against the existing `StatefulInner` probe:

- `fallback_drives_readied_instance`
- `retry_drives_readied_instance` (multiple calls to exercise the retry boundary as well)
- `executor_drives_readied_instance`

Verified the `retry` test fails against the pre-fix code (panics with the contract-violation message) and passes after the fix.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` -- full suite green, all 10 contract tests pass
- [x] Verified pre-fix failure for retry

Closes #294.