### PR TITLE
ci: forbid clone-in-call anti-pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,33 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+  contract-lints:
+    name: Source Contract Lints
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Catches the clone-in-call anti-pattern that violates Tower's Service
+      # contract (#286). The Service contract permits `call` to panic if
+      # invoked on an instance whose `poll_ready` was not driven to
+      # `Poll::Ready(Ok(()))`. Cloning self.inner in call() and moving the
+      # unreadied clone into the future violates this for any compliant
+      # stateful inner middleware (tower::limit::ConcurrencyLimit,
+      # tower::buffer::Buffer, tower::load_shed::LoadShed, etc.). The
+      # contract-compliant form uses `std::mem::replace` so the readied
+      # original moves into the future and a fresh clone stays on &mut self.
+      #
+      # See https://docs.rs/tower-service/0.3.3/tower_service/trait.Service.html#be-careful-when-cloning-inner-services
+      - name: Forbid clone-in-call anti-pattern
+        run: |
+          if git grep -nE 'let mut [a-zA-Z_][a-zA-Z0-9_]* = self\.inner\.clone\(\);' -- 'crates/**/*.rs'; then
+            echo ""
+            echo "Found clone-in-call anti-pattern (#286). Use std::mem::replace instead:"
+            echo "  let clone = self.inner.clone();"
+            echo "  let mut inner = std::mem::replace(&mut self.inner, clone);"
+            exit 1
+          fi
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/crates/tower-resilience-outlier/src/service.rs
+++ b/crates/tower-resilience-outlier/src/service.rs
@@ -97,9 +97,8 @@ where
             });
         }
 
-        let mut inner = self.inner.clone();
-        // Swap so the clone becomes the "pending" one
-        std::mem::swap(&mut self.inner, &mut inner);
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
 
         Box::pin(async move {
             let result = inner.call(request).await;

--- a/tests/clone_in_call_contract.rs
+++ b/tests/clone_in_call_contract.rs
@@ -225,3 +225,23 @@ async fn executor_drives_readied_instance() {
         let _ = svc.ready().await.unwrap().call(()).await;
     }
 }
+
+#[tokio::test]
+async fn outlier_drives_readied_instance() {
+    use tower_resilience_outlier::{OutlierDetectionLayer, OutlierDetector};
+
+    let detector = OutlierDetector::new();
+    detector.register("inner", 5);
+
+    let layer = OutlierDetectionLayer::builder()
+        .detector(detector)
+        .instance_name("inner")
+        .build();
+    let mut svc = tower::ServiceBuilder::new()
+        .layer(layer)
+        .service(StatefulInner::new());
+
+    for _ in 0..3 {
+        let _ = svc.ready().await.unwrap().call(()).await;
+    }
+}


### PR DESCRIPTION
## Summary

Add a CI job (`contract-lints` / "Source Contract Lints") that fails the build if any source file under `crates/` contains the literal Tower `Service` contract violation pattern fixed in #286 / #288 / #297:

```rust
let mut <ident> = self.inner.clone();
```

The regex matches any variable name (`inner`, `service`, etc.), so this catches the same family of escapes that got through the initial fix and required the follow-up PR #297.

## Outlier normalization

The lint flagged `crates/tower-resilience-outlier/src/service.rs:100`, which used the equivalent `clone() + mem::swap` form -- functionally identical to `mem::replace`, but inconsistent with every other layer crate. Normalized to the canonical `mem::replace` idiom.

## Coverage extension

While the outlier code was previously correct (just with a different idiom), it was missing from `tests/clone_in_call_contract.rs`. Added `outlier_drives_readied_instance` so all eight clone-using services are covered uniformly.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` -- full suite green, 11 contract tests pass
- [x] Lint regex tested locally: `git grep -nE 'let mut [a-zA-Z_][a-zA-Z0-9_]* = self\.inner\.clone\(\);' -- 'crates/**/*.rs'` returns no matches on this branch
- [x] Pre-normalization, the lint correctly flagged the outlier `clone() + mem::swap` site

Closes #291.