### PR TITLE
fix: drive poll_ready on stored inner before retry call (reconnect)

### DIFF
--- a/crates/tower-resilience-reconnect/Cargo.toml
+++ b/crates/tower-resilience-reconnect/Cargo.toml
@@ -27,6 +27,8 @@ tracing = { workspace = true, optional = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 tokio-test = "0.4"
+tower-resilience-core = { workspace = true, features = ["testing"] }
+tower = { workspace = true, features = ["util", "limit"] }
 
 [features]
 default = []

--- a/crates/tower-resilience-reconnect/src/service.rs
+++ b/crates/tower-resilience-reconnect/src/service.rs
@@ -96,6 +96,11 @@ where
 enum Phase<F> {
     Calling(#[pin] F),
     Sleeping(#[pin] tokio::time::Sleep),
+    /// Driving `poll_ready` on the stored inner clone before issuing a retry
+    /// `call`. The initial call uses the caller-readied receiver; every
+    /// subsequent retry must re-ready the clone we hold here (tower::Service
+    /// contract -- see #293).
+    Readying,
     Failed,
 }
 
@@ -194,9 +199,10 @@ where
                         Poll::Ready(()) => {
                             // Sleep complete - check retry_on_reconnect flag
                             if this.config.retry_on_reconnect {
-                                // Retry the original request (reconnection happens via clone)
-                                let call_future = this.inner.call(this.request.clone());
-                                this.phase.set(Phase::Calling(call_future));
+                                // Drive poll_ready on the stored clone before
+                                // re-issuing the call -- the tower::Service
+                                // contract requires it. See #293.
+                                this.phase.set(Phase::Readying);
                             } else {
                                 // Don't retry - return error to caller
                                 // The backoff succeeded, so mark connected for next request
@@ -211,6 +217,17 @@ where
                         Poll::Pending => return Poll::Pending,
                     }
                 }
+                PhaseProj::Readying => match this.inner.poll_ready(cx) {
+                    Poll::Ready(Ok(())) => {
+                        let call_future = this.inner.call(this.request.clone());
+                        this.phase.set(Phase::Calling(call_future));
+                    }
+                    Poll::Ready(Err(error)) => {
+                        this.phase.set(Phase::Failed);
+                        return Poll::Ready(Err(ReconnectError::ServiceError(error)));
+                    }
+                    Poll::Pending => return Poll::Pending,
+                },
                 PhaseProj::Failed => {
                     panic!("ReconnectFuture polled after completion");
                 }

--- a/crates/tower-resilience-reconnect/tests/contract.rs
+++ b/crates/tower-resilience-reconnect/tests/contract.rs
@@ -1,0 +1,113 @@
+//! Tower `Service` contract regression for `ReconnectService`.
+//!
+//! Reconnect's retry path stores `self.inner.clone()` inside the
+//! `ReconnectFuture` and calls it again after a backoff. The clone's
+//! readiness is *not* inherited from the readied original (per the standard
+//! stateful-service contract -- see `tower::limit::ConcurrencyLimit`), so
+//! every retry must drive `poll_ready` on the stored clone before the
+//! retry's `call`. Otherwise the contract is violated against the inner.
+//!
+//! The first call uses the caller-readied receiver (correct). The probe
+//! below fails that first call to push the future into the retry path, then
+//! succeeds on the retried call. The probe's `call` asserts that the inner
+//! saw a `poll_ready` since its last `Clone`/call -- without the fix this
+//! test panics with the same "tower contract violation" message used by the
+//! `StatefulInner` probe in #286.
+//!
+//! See `crates/tower-resilience-bulkhead/tests/contract.rs` for related
+//! tests that exercise the same contract on layer middleware.
+
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+use tower::{Layer, Service};
+use tower_resilience_reconnect::{ReconnectConfig, ReconnectLayer, ReconnectPolicy};
+
+/// An inner [`Service`] whose [`Clone`] resets readiness and which fails the
+/// first call (forcing the retry path).
+#[derive(Default)]
+struct StatefulFailFirst {
+    ready: bool,
+    calls: Arc<AtomicUsize>,
+}
+
+impl StatefulFailFirst {
+    fn new() -> Self {
+        Self {
+            ready: false,
+            calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
+impl Clone for StatefulFailFirst {
+    fn clone(&self) -> Self {
+        // Mirrors `Clone for ConcurrencyLimit` / `Buffer`: the new instance
+        // does not inherit readiness from the original.
+        Self {
+            ready: false,
+            calls: Arc::clone(&self.calls),
+        }
+    }
+}
+
+impl Service<String> for StatefulFailFirst {
+    type Response = String;
+    type Error = io::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<String, io::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.ready = true;
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: String) -> Self::Future {
+        assert!(
+            self.ready,
+            "Service::call invoked without prior poll_ready -- tower contract violation (#293/H)"
+        );
+        self.ready = false;
+        let n = self.calls.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async move {
+            if n == 0 {
+                Err(io::Error::new(
+                    io::ErrorKind::ConnectionRefused,
+                    "first attempt fails",
+                ))
+            } else {
+                Ok(req)
+            }
+        })
+    }
+}
+
+#[tokio::test]
+async fn reconnect_drives_readied_instance_on_retry() {
+    use tower::ServiceExt;
+
+    let config = ReconnectConfig::builder()
+        .policy(ReconnectPolicy::exponential(
+            Duration::from_millis(5),
+            Duration::from_millis(20),
+        ))
+        .max_attempts(3)
+        .build();
+    let layer = ReconnectLayer::new(config);
+    let mut svc = layer.layer(StatefulFailFirst::new());
+
+    // First attempt fails inside the service; the retry path must re-drive
+    // poll_ready on the stored clone before calling, or the assert in
+    // `StatefulFailFirst::call` panics.
+    let response = svc
+        .ready()
+        .await
+        .unwrap()
+        .call("hello".into())
+        .await
+        .unwrap();
+    assert_eq!(response, "hello");
+}


### PR DESCRIPTION
## Summary

\`ReconnectFuture\` stores \`self.inner.clone()\` to be used after the backoff
sleep for the retried call. Per the standard \`tower::Service\` contract
(see how \`tower::limit::ConcurrencyLimit::clone\` resets the permit slot),
a fresh clone does **not** inherit readiness from the original -- so calling
\`inner.call(...)\` on the stored clone after backoff violates the contract
against the inner service.

Insert a \`Phase::Readying\` state between \`Sleeping\` and \`Calling\` that
drives \`inner.poll_ready\` until it returns Ready, then issues the retry's
\`inner.call\`. The initial call still uses the caller-readied receiver via
\`self.inner.call(...)\` in \`Service::call\`.

Adds a contract regression test (\`tests/contract.rs\`) that holds a
Clone-resets-readiness probe with an assert in \`call\`. Without the
service-side fix the test panics with the same "tower contract violation"
shape introduced by #286.

Closes #293 (item H).

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`cargo test -p tower-resilience-reconnect --all-features\`
- [x] \`cargo test --workspace --lib --all-features\`
- [x] \`cargo test --workspace --test '*' --all-features\`
- [x] \`cargo test --doc --workspace --all-features\`
- [x] Verified the new contract test panics on the pre-fix code (\`git stash; cargo test\`).