### PR TITLE
fix: drive poll_ready on each hedge clone before call

### DIFF
--- a/crates/tower-resilience-hedge/Cargo.toml
+++ b/crates/tower-resilience-hedge/Cargo.toml
@@ -30,3 +30,5 @@ tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time"] }
+tower-resilience-core = { workspace = true, features = ["testing"] }
+tower = { workspace = true, features = ["util", "limit"] }

--- a/crates/tower-resilience-hedge/src/lib.rs
+++ b/crates/tower-resilience-hedge/src/lib.rs
@@ -127,7 +127,7 @@ use futures::future::BoxFuture;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
-use tower::Service;
+use tower::{Service, ServiceExt};
 
 /// Hedging service that wraps an inner service.
 ///
@@ -214,12 +214,19 @@ where
     // Channel to collect results from all attempts
     let (tx, mut rx) = mpsc::channel::<(usize, Result<S::Response, S::Error>)>(max_attempts);
 
-    // Spawn primary request
-    let mut service_clone = service.clone();
+    // `service` is the readied receiver moved out of `self.inner` by the
+    // calling `Service::call`. Clone for the hedge template *before* moving
+    // it into the primary spawn -- each subsequent hedge spawn must drive
+    // `poll_ready` on its own clone before calling, since `Clone` does not
+    // propagate readiness for stateful services. See #293.
+    let hedge_template = service.clone();
+
+    // Spawn primary request using the readied receiver directly.
+    let mut primary = service;
     let req_clone = req.clone();
     let tx_clone = tx.clone();
     tokio::spawn(async move {
-        let result = service_clone.call(req_clone).await;
+        let result = primary.call(req_clone).await;
         let _ = tx_clone.send((0, result)).await;
     });
 
@@ -297,11 +304,16 @@ where
                                 timestamp: Instant::now(),
                             });
 
-                            let mut svc = service.clone();
+                            let mut svc = hedge_template.clone();
                             let r = req.clone();
                             let tx_c = tx.clone();
                             tokio::spawn(async move {
-                                let result = svc.call(r).await;
+                                // Drive poll_ready on the fresh clone before
+                                // calling; clones do not inherit readiness.
+                                let result = match svc.ready().await {
+                                    Ok(svc) => svc.call(r).await,
+                                    Err(e) => Err(e),
+                                };
                                 let _ = tx_c.send((attempt_num, result)).await;
                             });
 
@@ -363,11 +375,16 @@ where
                         timestamp: Instant::now(),
                     });
 
-                    let mut svc = service.clone();
+                    let mut svc = hedge_template.clone();
                     let r = req.clone();
                     let tx_c = tx.clone();
                     tokio::spawn(async move {
-                        let result = svc.call(r).await;
+                        // Drive poll_ready on the fresh clone before calling;
+                        // clones do not inherit readiness.
+                        let result = match svc.ready().await {
+                            Ok(svc) => svc.call(r).await,
+                            Err(e) => Err(e),
+                        };
                         let _ = tx_c.send((i, result)).await;
                     });
                 }

--- a/crates/tower-resilience-hedge/tests/contract.rs
+++ b/crates/tower-resilience-hedge/tests/contract.rs
@@ -1,0 +1,119 @@
+//! Tower `Service` contract regression for `Hedge`.
+//!
+//! Hedge fans a single request out to N parallel attempts. The primary uses
+//! the caller-readied receiver (correct). Each hedge attempt operates on a
+//! fresh `inner.clone()` whose readiness is not inherited from the original
+//! (per `tower::limit::ConcurrencyLimit` etc.) and therefore must drive its
+//! own `poll_ready` before calling. See #293.
+//!
+//! The probe below has a `Clone` that resets readiness and a `call` that
+//! asserts the inner saw a `poll_ready` since its last `Clone`/call. The
+//! primary sleeps long enough for hedges to fire; without the fix the
+//! hedge spawn calls into a fresh clone whose `ready` is `false`, and the
+//! assert panics.
+//!
+//! See `crates/tower-resilience-bulkhead/tests/contract.rs` for related
+//! contract tests on simpler layer middleware.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+use tower::{Layer, Service, ServiceExt};
+use tower_resilience_hedge::HedgeLayer;
+
+/// An inner [`Service`] whose [`Clone`] resets readiness, and whose first
+/// call sleeps long enough for hedge fan-out to fire (so the hedge spawns
+/// actually issue calls against fresh clones).
+struct StatefulSlowFirst {
+    ready: bool,
+    calls: Arc<AtomicUsize>,
+}
+
+impl StatefulSlowFirst {
+    fn new() -> Self {
+        Self {
+            ready: false,
+            calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
+impl Clone for StatefulSlowFirst {
+    fn clone(&self) -> Self {
+        Self {
+            ready: false,
+            calls: Arc::clone(&self.calls),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ProbeError;
+
+impl std::fmt::Display for ProbeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ProbeError")
+    }
+}
+
+impl std::error::Error for ProbeError {}
+
+impl Service<()> for StatefulSlowFirst {
+    type Response = ();
+    type Error = ProbeError;
+    type Future = Pin<Box<dyn Future<Output = Result<(), ProbeError>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.ready = true;
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: ()) -> Self::Future {
+        assert!(
+            self.ready,
+            "Service::call invoked without prior poll_ready -- tower contract violation (#293)"
+        );
+        self.ready = false;
+        let n = self.calls.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async move {
+            if n == 0 {
+                // Primary sleeps so the hedge has time to fire.
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            }
+            Ok(())
+        })
+    }
+}
+
+// Bounded with `tokio::time::timeout` because a contract regression panics
+// inside a `tokio::spawn`'d hedge task -- without the timeout the main test
+// would hang waiting for a channel message that never arrives.
+
+#[tokio::test]
+async fn hedge_drives_readied_instance_on_attempts() {
+    let layer = HedgeLayer::builder()
+        .delay(Duration::from_millis(20))
+        .max_hedged_attempts(2)
+        .build();
+    let mut svc = layer.layer(StatefulSlowFirst::new());
+
+    let _ = tokio::time::timeout(Duration::from_secs(2), svc.ready().await.unwrap().call(()))
+        .await
+        .expect("hedge call hung -- likely contract regression in a spawned task");
+}
+
+#[tokio::test]
+async fn hedge_parallel_mode_drives_readied_instance_on_attempts() {
+    let layer = HedgeLayer::builder()
+        .no_delay()
+        .max_hedged_attempts(3)
+        .build();
+    let mut svc = layer.layer(StatefulSlowFirst::new());
+
+    let _ = tokio::time::timeout(Duration::from_secs(2), svc.ready().await.unwrap().call(()))
+        .await
+        .expect("hedge call hung -- likely contract regression in a spawned task");
+}


### PR DESCRIPTION
## Summary

\`execute_with_hedging\` was cloning the readied receiver for both the
primary task and each hedge spawn and then calling \`.call(req)\` on the
clone -- but \`Clone\` does not propagate readiness for stateful services
(see how \`tower::limit::ConcurrencyLimit::clone\` resets the permit slot),
so this violates the \`tower::Service\` contract against the inner. The bug
is the same shape as #286 / #294 but spread across the spawned hedge tasks.

Two-part fix:

1. The primary spawn now consumes the readied receiver directly via
   \`let mut primary = service; primary.call(req)\`, instead of going through
   \`service.clone()\`. The caller-driven \`poll_ready\` is now actually used.

2. Each hedge spawn (latency mode and parallel mode) starts from a fresh
   clone of an unreadied \`hedge_template\` and drives
   \`svc.ready().await?.call(r).await\` before issuing the request,
   re-readying the clone per the contract.

Adds a contract regression test in \`tests/contract.rs\` that holds a
Clone-resets-readiness probe with an assert in \`call\`. The probe's primary
sleeps long enough for the hedge to fire, so a regression panics inside a
spawned hedge task. Tests are bounded with \`tokio::time::timeout\` so a
regression fails fast rather than hanging.

Closes #293 (Hedge portion of items I/J).

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`cargo test -p tower-resilience-hedge --all-features\`
- [x] \`cargo test --workspace --lib --all-features\`
- [x] \`cargo test --workspace --test '*' --all-features\`
- [x] \`cargo test --doc --workspace --all-features\`