### PR TITLE
feat: add FailureModel::ConsecutiveFailures to circuit breaker

### DIFF
--- a/crates/tower-resilience-circuitbreaker/src/circuit.rs
+++ b/crates/tower-resilience-circuitbreaker/src/circuit.rs
@@ -1,4 +1,4 @@
-use crate::config::{CircuitBreakerConfig, SlidingWindowType};
+use crate::config::{CircuitBreakerConfig, FailureModel, SlidingWindowType};
 use crate::events::CircuitBreakerEvent;
 #[cfg(feature = "metrics")]
 use metrics::{counter, gauge, histogram};
@@ -75,6 +75,9 @@ pub(crate) struct Circuit {
     slow_call_count: usize,
     // Time-based window tracking
     call_records: VecDeque<CallRecord>,
+    // FailureModel::ConsecutiveFailures tracking. Resets to 0 on every
+    // success and on every state transition to Closed/HalfOpen.
+    consecutive_failures: usize,
 }
 
 impl Default for Circuit {
@@ -101,6 +104,7 @@ impl Circuit {
             total_count: 0,
             slow_call_count: 0,
             call_records: VecDeque::new(),
+            consecutive_failures: 0,
         }
     }
 
@@ -192,6 +196,10 @@ impl Circuit {
             .map(|threshold| duration >= threshold)
             .unwrap_or(false);
 
+        // A success resets the consecutive-failure counter regardless of the
+        // configured FailureModel; see ConsecutiveFailures.
+        self.consecutive_failures = 0;
+
         // Update statistics based on window type
         match config.sliding_window_type {
             SlidingWindowType::CountBased => {
@@ -270,6 +278,11 @@ impl Circuit {
             .slow_call_duration_threshold
             .map(|threshold| duration >= threshold)
             .unwrap_or(false);
+
+        // Track consecutive failures for FailureModel::ConsecutiveFailures.
+        // Maintained regardless of the active model so switching models via
+        // observability or live config is consistent.
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
 
         // Update statistics based on window type
         match config.sliding_window_type {
@@ -486,6 +499,7 @@ impl Circuit {
         self.total_count = 0;
         self.slow_call_count = 0;
         self.call_records.clear();
+        self.consecutive_failures = 0;
     }
 
     fn evaluate_window<C>(&mut self, config: &CircuitBreakerConfig<C>) {
@@ -505,27 +519,37 @@ impl Circuit {
                 }
             };
 
-        // Don't evaluate until minimum calls threshold is met
-        if total_count < config.minimum_number_of_calls {
-            return;
-        }
+        // Slow-call detection runs in both failure models -- a circuit that
+        // is healthy by error rate but degraded by latency should still open.
+        // Sliding-window gating still applies to the slow-call evaluation.
+        let slow_should_open = config.slow_call_duration_threshold.is_some()
+            && total_count >= config.minimum_number_of_calls
+            && !(config.sliding_window_type == SlidingWindowType::CountBased
+                && total_count < config.sliding_window_size)
+            && {
+                let slow_call_rate = slow_call_count as f64 / total_count as f64;
+                slow_call_rate >= config.slow_call_rate_threshold
+            };
 
-        // For count-based window, also check if window is full
-        if config.sliding_window_type == SlidingWindowType::CountBased
-            && total_count < config.sliding_window_size
-        {
-            return;
-        }
+        let failure_should_open = match config.failure_model {
+            FailureModel::SlidingWindow => {
+                // Don't evaluate until minimum calls threshold is met
+                if total_count < config.minimum_number_of_calls {
+                    false
+                } else if config.sliding_window_type == SlidingWindowType::CountBased
+                    && total_count < config.sliding_window_size
+                {
+                    // For count-based window, also wait until window is full
+                    false
+                } else {
+                    let failure_rate = failure_count as f64 / total_count as f64;
+                    failure_rate >= config.failure_rate_threshold
+                }
+            }
+            FailureModel::ConsecutiveFailures { k } => self.consecutive_failures >= k,
+        };
 
-        let failure_rate = failure_count as f64 / total_count as f64;
-        let slow_call_rate = slow_call_count as f64 / total_count as f64;
-
-        // Open if either failure rate or slow call rate exceeds threshold
-        let should_open = failure_rate >= config.failure_rate_threshold
-            || (config.slow_call_duration_threshold.is_some()
-                && slow_call_rate >= config.slow_call_rate_threshold);
-
-        if should_open {
+        if failure_should_open || slow_should_open {
             self.transition_to(CircuitState::Open, config);
         }
         // Don't transition to closed if we're in HalfOpen - that happens via record_success

--- a/crates/tower-resilience-circuitbreaker/src/config.rs
+++ b/crates/tower-resilience-circuitbreaker/src/config.rs
@@ -20,6 +20,65 @@ pub enum SlidingWindowType {
     TimeBased,
 }
 
+/// Trip-condition model used by the circuit breaker.
+///
+/// The default ([`Self::SlidingWindow`]) trips when the failure *rate* over the
+/// configured sliding window exceeds `failure_rate_threshold`. The alternative
+/// [`Self::ConsecutiveFailures`] trips when `k` failures occur in a row with no
+/// successful call between them. The latter matches the default behavior of
+/// `ex_resilience` (the Elixir companion library) and is common in agent /
+/// LLM-retry contexts where an in-a-row burst matters more than the rate.
+///
+/// See the crate-level docs for a table mapping each model to its trip
+/// condition.
+///
+/// # Example
+///
+/// ```rust
+/// use tower_resilience_circuitbreaker::{CircuitBreakerLayer, FailureModel};
+///
+/// // Sliding-window failure rate (default).
+/// let layer = CircuitBreakerLayer::builder()
+///     .failure_rate_threshold(0.5)
+///     .build();
+///
+/// // Trip after 5 consecutive failures.
+/// let layer = CircuitBreakerLayer::builder()
+///     .failure_model(FailureModel::ConsecutiveFailures { k: 5 })
+///     .build();
+///
+/// // Same, via the convenience shortcut.
+/// let layer = CircuitBreakerLayer::builder()
+///     .consecutive_failures(5)
+///     .build();
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FailureModel {
+    /// Trip when the failure rate over the sliding window crosses the
+    /// configured `failure_rate_threshold`. This is the default.
+    ///
+    /// Honors all sliding-window settings: `sliding_window_type`,
+    /// `sliding_window_size`, `sliding_window_duration`, and
+    /// `minimum_number_of_calls`.
+    #[default]
+    SlidingWindow,
+    /// Trip after `k` consecutive failures with no intervening success.
+    ///
+    /// Ignores `failure_rate_threshold`, `sliding_window_type`, and the
+    /// minimum-calls / window-size gating: a single sequence of `k`
+    /// classified failures opens the circuit. A single successful call
+    /// (per the configured failure classifier) resets the counter.
+    ///
+    /// Slow-call detection (`slow_call_duration_threshold` /
+    /// `slow_call_rate_threshold`) continues to evaluate against the
+    /// sliding-window stats and can still open the circuit independently.
+    ConsecutiveFailures {
+        /// The number of consecutive failures required to trip the circuit.
+        /// Must be > 0; a builder with `k == 0` panics on `build()`.
+        k: usize,
+    },
+}
+
 /// Configuration for the circuit breaker pattern.
 ///
 /// The type parameter `C` is the failure classifier type, which determines
@@ -38,6 +97,7 @@ pub struct CircuitBreakerConfig<C> {
     pub(crate) failure_classifier: C,
     pub(crate) slow_call_duration_threshold: Option<Duration>,
     pub(crate) slow_call_rate_threshold: f64,
+    pub(crate) failure_model: FailureModel,
     pub(crate) event_listeners: EventListeners<CircuitBreakerEvent>,
     pub(crate) name: String,
     pub(crate) backpressure: bool,
@@ -88,6 +148,7 @@ pub struct CircuitBreakerConfigBuilder<C = DefaultClassifier> {
     minimum_number_of_calls: Option<usize>,
     slow_call_duration_threshold: Option<Duration>,
     slow_call_rate_threshold: f64,
+    failure_model: FailureModel,
     event_listeners: EventListeners<CircuitBreakerEvent>,
     name: String,
     backpressure: bool,
@@ -116,6 +177,7 @@ impl CircuitBreakerConfigBuilder<DefaultClassifier> {
             minimum_number_of_calls: None,
             slow_call_duration_threshold: None,
             slow_call_rate_threshold: 1.0,
+            failure_model: FailureModel::SlidingWindow,
             event_listeners: EventListeners::new(),
             name: String::from("<unnamed>"),
             backpressure: false,
@@ -204,6 +266,47 @@ impl<C> CircuitBreakerConfigBuilder<C> {
     /// Default: 1.0 (100%, effectively disabled)
     pub fn slow_call_rate_threshold(mut self, rate: f64) -> Self {
         self.slow_call_rate_threshold = rate;
+        self
+    }
+
+    /// Selects the trip-condition model.
+    ///
+    /// See [`FailureModel`] for the available variants and their trip
+    /// conditions. The default is [`FailureModel::SlidingWindow`].
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_resilience_circuitbreaker::{CircuitBreakerLayer, FailureModel};
+    ///
+    /// let layer = CircuitBreakerLayer::builder()
+    ///     .failure_model(FailureModel::ConsecutiveFailures { k: 5 })
+    ///     .build();
+    /// ```
+    pub fn failure_model(mut self, model: FailureModel) -> Self {
+        self.failure_model = model;
+        self
+    }
+
+    /// Shortcut for [`Self::failure_model`] with
+    /// [`FailureModel::ConsecutiveFailures`].
+    ///
+    /// # Panics
+    ///
+    /// The [`build`](Self::build) call panics if `k == 0`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_resilience_circuitbreaker::CircuitBreakerLayer;
+    ///
+    /// // Trip after 3 consecutive failures.
+    /// let layer = CircuitBreakerLayer::builder()
+    ///     .consecutive_failures(3)
+    ///     .build();
+    /// ```
+    pub fn consecutive_failures(mut self, k: usize) -> Self {
+        self.failure_model = FailureModel::ConsecutiveFailures { k };
         self
     }
 
@@ -313,6 +416,7 @@ impl<C> CircuitBreakerConfigBuilder<C> {
             minimum_number_of_calls: self.minimum_number_of_calls,
             slow_call_duration_threshold: self.slow_call_duration_threshold,
             slow_call_rate_threshold: self.slow_call_rate_threshold,
+            failure_model: self.failure_model,
             event_listeners: self.event_listeners,
             name: self.name,
             backpressure: self.backpressure,
@@ -688,6 +792,11 @@ impl<C> CircuitBreakerConfigBuilder<C> {
             panic!("sliding_window_duration must be set when using TimeBased sliding window");
         }
 
+        // Validate failure model configuration
+        if let FailureModel::ConsecutiveFailures { k } = self.failure_model {
+            assert!(k > 0, "ConsecutiveFailures requires k > 0");
+        }
+
         CircuitBreakerConfig {
             failure_rate_threshold: self.failure_rate_threshold,
             sliding_window_type: self.sliding_window_type,
@@ -701,6 +810,7 @@ impl<C> CircuitBreakerConfigBuilder<C> {
                 .unwrap_or(self.sliding_window_size),
             slow_call_duration_threshold: self.slow_call_duration_threshold,
             slow_call_rate_threshold: self.slow_call_rate_threshold,
+            failure_model: self.failure_model,
             event_listeners: self.event_listeners,
             name: self.name,
             backpressure: self.backpressure,

--- a/crates/tower-resilience-circuitbreaker/src/health_integration.rs
+++ b/crates/tower-resilience-circuitbreaker/src/health_integration.rs
@@ -85,6 +85,7 @@ mod tests {
             minimum_number_of_calls: 10,
             slow_call_duration_threshold: None,
             slow_call_rate_threshold: 1.0,
+            failure_model: crate::config::FailureModel::SlidingWindow,
             event_listeners: EventListeners::new(),
             name: "test".into(),
             backpressure: false,

--- a/crates/tower-resilience-circuitbreaker/src/lib.rs
+++ b/crates/tower-resilience-circuitbreaker/src/lib.rs
@@ -110,6 +110,39 @@
 //! This is simpler than `failure_classifier()` because you don't need to handle
 //! the `Err` case (which can never occur with `Error = Infallible`).
 //!
+//! ## Failure Models
+//!
+//! The trip condition is selectable via [`FailureModel`]. The default is
+//! [`FailureModel::SlidingWindow`] (failure rate over a count- or time-based
+//! window). The alternative [`FailureModel::ConsecutiveFailures`] trips
+//! after `k` failures in a row with no intervening success -- this matches
+//! the default behavior of the Elixir `ex_resilience` library and is
+//! common in agent / LLM-retry contexts.
+//!
+//! | Model                              | Trip condition                                                                                            |
+//! |------------------------------------|-----------------------------------------------------------------------------------------------------------|
+//! | `FailureModel::SlidingWindow`      | `failure_count / total_count >= failure_rate_threshold` over the configured window (the default)         |
+//! | `FailureModel::ConsecutiveFailures { k }` | `k` classified failures in a row with no intervening success                                       |
+//!
+//! Slow-call detection (`slow_call_duration_threshold` /
+//! `slow_call_rate_threshold`) continues to evaluate against the
+//! sliding-window stats in both models, and can open the circuit
+//! independently of the failure model.
+//!
+//! ```rust
+//! use tower_resilience_circuitbreaker::{CircuitBreakerLayer, FailureModel};
+//!
+//! // Trip after 5 consecutive failures.
+//! let layer = CircuitBreakerLayer::builder()
+//!     .consecutive_failures(5)
+//!     .build();
+//!
+//! // Equivalent via the general setter.
+//! let layer = CircuitBreakerLayer::builder()
+//!     .failure_model(FailureModel::ConsecutiveFailures { k: 5 })
+//!     .build();
+//! ```
+//!
 //! ## Time-Based Sliding Window
 //!
 //! Use time-based windows instead of count-based:
@@ -304,7 +337,9 @@ use tracing::debug;
 
 pub use circuit::{CircuitMetrics, CircuitState};
 pub use classifier::{DefaultClassifier, FailureClassifier, FnClassifier};
-pub use config::{CircuitBreakerConfig, CircuitBreakerConfigBuilder, SlidingWindowType};
+pub use config::{
+    CircuitBreakerConfig, CircuitBreakerConfigBuilder, FailureModel, SlidingWindowType,
+};
 pub use error::CircuitBreakerError;
 pub use events::CircuitBreakerEvent;
 pub use handle::CircuitBreakerHandle;
@@ -919,6 +954,7 @@ mod tests {
             minimum_number_of_calls: 10,
             slow_call_duration_threshold: None,
             slow_call_rate_threshold: 1.0,
+            failure_model: crate::config::FailureModel::SlidingWindow,
             event_listeners: EventListeners::new(),
             name: "test".into(),
             backpressure: false,
@@ -1006,6 +1042,7 @@ mod tests {
             minimum_number_of_calls: 10,
             slow_call_duration_threshold: None,
             slow_call_rate_threshold: 1.0,
+            failure_model: crate::config::FailureModel::SlidingWindow,
             event_listeners: {
                 let mut listeners = EventListeners::new();
                 listeners.add(tower_resilience_core::FnListener::new(
@@ -1075,6 +1112,7 @@ mod tests {
             minimum_number_of_calls: 10,
             slow_call_duration_threshold: Some(Duration::from_millis(100)),
             slow_call_rate_threshold: 0.5,
+            failure_model: crate::config::FailureModel::SlidingWindow,
             event_listeners: {
                 let mut listeners = EventListeners::new();
                 listeners.add(tower_resilience_core::FnListener::new(move |event| {

--- a/tests/circuitbreaker/failure_model.rs
+++ b/tests/circuitbreaker/failure_model.rs
@@ -1,0 +1,171 @@
+//! `FailureModel::ConsecutiveFailures` trip-condition tests.
+//!
+//! Covers selection, transitions, and interaction with the existing
+//! sliding-window slow-call detector. See #283.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+use std::time::Duration;
+use tokio::time::sleep;
+use tower::{Layer, Service};
+use tower_resilience_circuitbreaker::{CircuitBreakerLayer, CircuitState, FailureModel};
+
+/// Helper: a service that fails on call N if `failure_indices` contains N.
+fn intermittent_service(
+    failure_indices: Arc<Vec<usize>>,
+    counter: Arc<AtomicUsize>,
+) -> impl tower::Service<
+    (),
+    Response = (),
+    Error = &'static str,
+    Future = impl std::future::Future<Output = Result<(), &'static str>> + Send,
+> + Clone
++ Send
++ 'static {
+    tower::service_fn(move |_req: ()| {
+        let idx = counter.fetch_add(1, Ordering::SeqCst);
+        let fail = failure_indices.contains(&idx);
+        async move { if fail { Err::<(), _>("err") } else { Ok(()) } }
+    })
+}
+
+#[tokio::test]
+async fn consecutive_failures_trip_at_k() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let svc = intermittent_service(Arc::new(vec![0, 1, 2]), Arc::clone(&counter));
+
+    let layer = CircuitBreakerLayer::builder()
+        .consecutive_failures(3)
+        .wait_duration_in_open(Duration::from_secs(10))
+        .name("consec-3")
+        .build();
+    let mut cb = layer.layer(svc);
+
+    let _ = cb.call(()).await;
+    assert_eq!(cb.state().await, CircuitState::Closed);
+    let _ = cb.call(()).await;
+    assert_eq!(cb.state().await, CircuitState::Closed);
+    let _ = cb.call(()).await;
+    assert_eq!(cb.state().await, CircuitState::Open);
+}
+
+#[tokio::test]
+async fn consecutive_failures_reset_on_success() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    // Fail, fail, succeed, fail, fail -- should NOT trip at k=3.
+    let svc = intermittent_service(Arc::new(vec![0, 1, 3, 4]), Arc::clone(&counter));
+
+    let layer = CircuitBreakerLayer::builder()
+        .consecutive_failures(3)
+        .wait_duration_in_open(Duration::from_secs(10))
+        .name("consec-3-reset")
+        .build();
+    let mut cb = layer.layer(svc);
+
+    for _ in 0..5 {
+        let _ = cb.call(()).await;
+    }
+    assert_eq!(cb.state().await, CircuitState::Closed);
+}
+
+#[tokio::test]
+async fn consecutive_failures_ignores_failure_rate_threshold_and_window_size() {
+    // With consecutive_failures(2), the trip should fire at the second
+    // failure even if failure_rate_threshold / sliding_window_size would
+    // have required many more samples first.
+    let counter = Arc::new(AtomicUsize::new(0));
+    let svc = intermittent_service(Arc::new(vec![0, 1]), Arc::clone(&counter));
+
+    let layer = CircuitBreakerLayer::builder()
+        .consecutive_failures(2)
+        .failure_rate_threshold(0.99) // would never trip via rate model
+        .sliding_window_size(1000) // window would never fill
+        .minimum_number_of_calls(1000)
+        .wait_duration_in_open(Duration::from_secs(10))
+        .name("consec-ignores-rate")
+        .build();
+    let mut cb = layer.layer(svc);
+
+    let _ = cb.call(()).await;
+    let _ = cb.call(()).await;
+    assert_eq!(cb.state().await, CircuitState::Open);
+}
+
+#[tokio::test]
+async fn consecutive_failures_default_model_is_sliding_window() {
+    // Without `.consecutive_failures(...)` the breaker uses the default
+    // sliding-window model and does not trip just from a few errors when
+    // the window is much larger.
+    let counter = Arc::new(AtomicUsize::new(0));
+    let svc = intermittent_service(Arc::new(vec![0, 1, 2]), Arc::clone(&counter));
+
+    let layer = CircuitBreakerLayer::builder()
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(100)
+        .minimum_number_of_calls(100)
+        .wait_duration_in_open(Duration::from_secs(10))
+        .name("default-sliding")
+        .build();
+    let mut cb = layer.layer(svc);
+
+    let _ = cb.call(()).await;
+    let _ = cb.call(()).await;
+    let _ = cb.call(()).await;
+    assert_eq!(cb.state().await, CircuitState::Closed);
+}
+
+#[tokio::test]
+async fn consecutive_failures_recovers_through_half_open() {
+    // 3 failures trip the breaker; after the wait, half-open lets a probe
+    // through; success closes the breaker.
+    let counter = Arc::new(AtomicUsize::new(0));
+    // Calls 0..3 fail, all subsequent succeed.
+    let svc = intermittent_service(Arc::new(vec![0, 1, 2]), Arc::clone(&counter));
+
+    let layer = CircuitBreakerLayer::builder()
+        .consecutive_failures(3)
+        .wait_duration_in_open(Duration::from_millis(50))
+        .permitted_calls_in_half_open(1)
+        .name("consec-recover")
+        .build();
+    let mut cb = layer.layer(svc);
+
+    for _ in 0..3 {
+        let _ = cb.call(()).await;
+    }
+    assert_eq!(cb.state().await, CircuitState::Open);
+
+    sleep(Duration::from_millis(150)).await;
+
+    // Half-open probe succeeds, breaker closes.
+    let _ = cb.call(()).await;
+    assert_eq!(cb.state().await, CircuitState::Closed);
+}
+
+#[tokio::test]
+#[should_panic(expected = "ConsecutiveFailures requires k > 0")]
+async fn consecutive_failures_zero_k_panics_on_build() {
+    let _ = CircuitBreakerLayer::builder()
+        .failure_model(FailureModel::ConsecutiveFailures { k: 0 })
+        .build();
+}
+
+#[tokio::test]
+async fn failure_model_via_failure_model_method_matches_shortcut() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let svc = intermittent_service(Arc::new(vec![0, 1, 2]), Arc::clone(&counter));
+
+    let layer = CircuitBreakerLayer::builder()
+        .failure_model(FailureModel::ConsecutiveFailures { k: 3 })
+        .wait_duration_in_open(Duration::from_secs(10))
+        .name("via-failure-model")
+        .build();
+    let mut cb = layer.layer(svc);
+
+    for _ in 0..3 {
+        let _ = cb.call(()).await;
+    }
+    assert_eq!(cb.state().await, CircuitState::Open);
+}

--- a/tests/circuitbreaker/mod.rs
+++ b/tests/circuitbreaker/mod.rs
@@ -15,6 +15,7 @@ mod combinations;
 mod concurrency;
 mod config_validation;
 mod edge_cases;
+mod failure_model;
 mod half_open;
 mod integration;
 mod reset;


### PR DESCRIPTION
## Summary

Cross-language parity with \`ex_resilience\` exposed a real semantic gap:
\`tower-resilience\` tripped on a sliding-window failure rate, while
\`ex_resilience\` tripped on K consecutive failures. Polyglot stacks saw
different breaker behavior under identical traffic, and tuning either side
required understanding the trip model the other side wasn't documenting.

This PR adds a \`FailureModel\` enum selectable on the builder:

- \`FailureModel::SlidingWindow\` (default; unchanged behavior).
- \`FailureModel::ConsecutiveFailures { k }\`, which trips on K classified
  failures in a row with no intervening success. Resets on any successful
  call. Available via \`.failure_model(...)\` or the shortcut
  \`.consecutive_failures(k)\`.

Slow-call detection still runs in both models and can open the breaker
independently. State transitions reset the consecutive-failures counter
along with the existing sliding-window counters. The builder panics on
\`k == 0\`.

Module-level docs include a comparison table; \`FailureModel\` doc comments
link the two variants and call out interactions with the sliding-window
settings.

Tests cover: trip at K, reset on intervening success, ignoring the
sliding-window gating, default-is-sliding-window, half-open recovery,
zero-k panic, and equivalence of \`failure_model()\` and
\`consecutive_failures()\`.

Closes #283. Companion: joshrotenberg/ex_resilience#29.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`cargo test --workspace --lib --all-features\`
- [x] \`cargo test --workspace --test '*' --all-features\`
- [x] \`cargo test --doc --workspace --all-features\`