### PR TITLE
fix: recover from mutex poison instead of panicking in cache/chaos (closes #313)

### DIFF
--- a/crates/tower-resilience-cache/src/lib.rs
+++ b/crates/tower-resilience-cache/src/lib.rs
@@ -173,7 +173,7 @@ where
 
         // Check cache first
         let cached = {
-            let mut store = self.store.lock().unwrap();
+            let mut store = self.store.lock().unwrap_or_else(|e| e.into_inner());
             store.get(&key)
         };
 
@@ -221,7 +221,7 @@ where
 
             // Store successful response in cache
             let was_evicted = {
-                let mut store = store.lock().unwrap();
+                let mut store = store.lock().unwrap_or_else(|e| e.into_inner());
                 let was_full = store.len() >= config.max_size;
                 store.insert(key, response.clone());
 

--- a/crates/tower-resilience-chaos/src/service.rs
+++ b/crates/tower-resilience-chaos/src/service.rs
@@ -64,7 +64,7 @@ where
 
             // Determine what chaos to inject
             {
-                let mut rng = rng.lock().unwrap();
+                let mut rng = rng.lock().unwrap_or_else(|e| e.into_inner());
 
                 // Check if we should inject an error
                 if config.error_injector.error_rate() > 0.0 {


### PR DESCRIPTION
Closes #313.

## Plan

`std::sync::Mutex::lock().unwrap()` sits in `Service::call` hot paths in two crates. A poisoned lock (from a panic in another thread holding it) turns into a panic in the caller's async task, potentially taking down unrelated concurrent requests.

Fix: recover the guard from poison with `unwrap_or_else(|e| e.into_inner())` at the three sites (cache `lib.rs:176,224`, chaos `service.rs:67`), plus any others found by grep. No new dependency; no public signature change.

## Execution

Dispatched via roba (opus/high) in a worktree off `origin/main`. roba implements + runs gates (fmt, clippy -D warnings, test --lib, test --test '*') and commits on green; orchestrator owns the PR lifecycle.