### PR TITLE
fix!: return Result from CacheLayer/SharedCacheLayer build() (closes #314)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,8 @@ let layer = CacheLayer::builder()
     .key_extractor(|req: &Request| req.id.clone())
     .on_hit(|| println!("Cache hit!"))
     .on_miss(|| println!("Cache miss"))
-    .build();
+    .build()
+    .unwrap();
 
 let service = layer.layer(my_service);
 ```

--- a/benches/comprehensive_benchmarks.rs
+++ b/benches/comprehensive_benchmarks.rs
@@ -264,7 +264,8 @@ fn bench_cache_miss(c: &mut Criterion) {
                 .max_size(100)
                 .ttl(Duration::from_secs(60))
                 .key_extractor(|req: &TestRequest| req.0)
-                .build();
+                .build()
+                .unwrap();
 
             let mut service = layer.layer(BaselineService);
 

--- a/benches/happy_path_overhead.rs
+++ b/benches/happy_path_overhead.rs
@@ -164,7 +164,8 @@ fn bench_cache(c: &mut Criterion) {
                 .max_size(100)
                 .ttl(Duration::from_secs(60))
                 .key_extractor(|req: &TestRequest| req.0)
-                .build();
+                .build()
+                .unwrap();
             let mut service = layer.layer(BaselineService);
 
             // Prime the cache

--- a/crates/tower-resilience-cache/examples/cache_example.rs
+++ b/crates/tower-resilience-cache/examples/cache_example.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .on_hit(|| println!("  [EVENT] Cache HIT"))
         .on_miss(|| println!("  [EVENT] Cache MISS"))
         .on_eviction(|| println!("  [EVENT] Cache EVICTION"))
-        .build();
+        .build()?;
 
     let mut service = cache_layer.layer(service);
 

--- a/crates/tower-resilience-cache/src/config.rs
+++ b/crates/tower-resilience-cache/src/config.rs
@@ -90,7 +90,8 @@ where
     ///     .max_size(100)
     ///     .eviction_policy(EvictionPolicy::Lfu)
     ///     .key_extractor(|req| req.clone())
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     ///
     /// Default: `EvictionPolicy::Lru`
@@ -145,7 +146,8 @@ where
     ///         let count = counter.fetch_add(1, Ordering::SeqCst);
     ///         println!("Cache hit #{}", count + 1);
     ///     })
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn on_hit<F>(mut self, f: F) -> Self
     where
@@ -187,7 +189,8 @@ where
     ///         let count = counter.fetch_add(1, Ordering::SeqCst);
     ///         println!("Cache miss #{} - fetching from service", count + 1);
     ///     })
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn on_miss<F>(mut self, f: F) -> Self
     where
@@ -233,7 +236,8 @@ where
     ///         let count = counter.fetch_add(1, Ordering::SeqCst);
     ///         println!("Entry evicted (total: {})", count + 1);
     ///     })
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn on_eviction<F>(mut self, f: F) -> Self
     where
@@ -249,13 +253,14 @@ where
 
     /// Builds the cache layer.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `key_extractor` was not set.
-    pub fn build(self) -> crate::CacheLayer<Req, K> {
+    /// Returns [`crate::CacheBuildError::MissingKeyExtractor`] if `key_extractor`
+    /// was not set before calling `build()`.
+    pub fn build(self) -> Result<crate::CacheLayer<Req, K>, crate::CacheBuildError> {
         let key_extractor = self
             .key_extractor
-            .expect("key_extractor must be set before building");
+            .ok_or(crate::CacheBuildError::MissingKeyExtractor)?;
 
         let config = CacheConfig {
             max_size: self.max_size,
@@ -266,7 +271,7 @@ where
             name: self.name,
         };
 
-        crate::CacheLayer::new(config)
+        Ok(crate::CacheLayer::new(config))
     }
 }
 
@@ -293,7 +298,8 @@ mod tests {
     fn test_builder_defaults() {
         let _layer = CacheLayer::<TestRequest, String>::builder()
             .key_extractor(|req| req.id.clone())
-            .build();
+            .build()
+            .unwrap();
         // If this compiles and doesn't panic, the builder works
     }
 
@@ -304,7 +310,8 @@ mod tests {
             .ttl(Duration::from_secs(60))
             .key_extractor(|req| req.id.clone())
             .name("my-cache")
-            .build();
+            .build()
+            .unwrap();
         // If this compiles and doesn't panic, the builder works
     }
 
@@ -315,13 +322,17 @@ mod tests {
             .on_hit(|| {})
             .on_miss(|| {})
             .on_eviction(|| {})
-            .build();
+            .build()
+            .unwrap();
         // If this compiles and doesn't panic, the event listener registration works
     }
 
     #[test]
-    #[should_panic(expected = "key_extractor must be set")]
-    fn test_builder_panics_without_key_extractor() {
-        let _config = CacheLayer::<TestRequest, String>::builder().build();
+    fn test_builder_errors_without_key_extractor() {
+        let result = CacheLayer::<TestRequest, String>::builder().build();
+        assert!(matches!(
+            result,
+            Err(crate::CacheBuildError::MissingKeyExtractor)
+        ));
     }
 }

--- a/crates/tower-resilience-cache/src/error.rs
+++ b/crates/tower-resilience-cache/src/error.rs
@@ -34,6 +34,25 @@ impl<E> CacheError<E> {
     }
 }
 
+/// Errors that can occur when building a cache layer.
+#[derive(Debug)]
+pub enum CacheBuildError {
+    /// A `key_extractor` was not set before calling `build()`.
+    MissingKeyExtractor,
+}
+
+impl fmt::Display for CacheBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CacheBuildError::MissingKeyExtractor => {
+                write!(f, "key_extractor must be set before building")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CacheBuildError {}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tower-resilience-cache/src/layer.rs
+++ b/crates/tower-resilience-cache/src/layer.rs
@@ -29,7 +29,8 @@ use tower::Layer;
 ///     .max_size(100)
 ///     .ttl(Duration::from_secs(60))
 ///     .key_extractor(|req: &String| req.clone())
-///     .build();
+///     .build()
+///     .unwrap();
 ///
 /// let service = ServiceBuilder::new()
 ///     .layer(cache_layer)
@@ -67,7 +68,8 @@ where
     ///     .max_size(100)
     ///     .ttl(Duration::from_secs(60))
     ///     .key_extractor(|req: &String| req.clone())
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn builder() -> crate::CacheConfigBuilder<Req, K> {
         crate::CacheConfigBuilder::new()
@@ -97,6 +99,7 @@ where
     ///     .ttl(Duration::from_secs(60))
     ///     .key_extractor(|req: &String| req.clone())
     ///     .build()
+    ///     .unwrap()
     ///     .shared::<String>();  // Specify the response type
     ///
     /// // Both services share the same cache

--- a/crates/tower-resilience-cache/src/lib.rs
+++ b/crates/tower-resilience-cache/src/lib.rs
@@ -27,7 +27,7 @@
 //!     .key_extractor(|req: &String| req.clone())
 //!     .on_hit(|| println!("Cache hit!"))
 //!     .on_miss(|| println!("Cache miss!"))
-//!     .build();
+//!     .build()?;
 //!
 //! // Apply to a service
 //! let service = ServiceBuilder::new()
@@ -48,7 +48,7 @@ mod shared_layer;
 mod store;
 
 pub use config::{CacheConfig, CacheConfigBuilder, KeyExtractor};
-pub use error::CacheError;
+pub use error::{CacheBuildError, CacheError};
 pub use events::CacheEvent;
 pub use eviction::EvictionPolicy;
 pub use layer::CacheLayer;
@@ -281,7 +281,8 @@ mod tests {
         let layer = CacheLayer::builder()
             .max_size(10)
             .key_extractor(|req: &String| req.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = layer.layer(service);
 
@@ -317,7 +318,8 @@ mod tests {
         let layer = CacheLayer::builder()
             .max_size(10)
             .key_extractor(|req: &String| req.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = layer.layer(service);
 
@@ -347,7 +349,8 @@ mod tests {
         let layer = CacheLayer::builder()
             .max_size(10)
             .key_extractor(|req: &String| req.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = layer.layer(service);
 
@@ -386,7 +389,8 @@ mod tests {
             .max_size(10)
             .ttl(Duration::from_millis(50))
             .key_extractor(|req: &String| req.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = layer.layer(service);
 
@@ -421,7 +425,8 @@ mod tests {
         let layer = CacheLayer::builder()
             .max_size(2)
             .key_extractor(|req: &String| req.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = layer.layer(service);
 
@@ -501,7 +506,8 @@ mod tests {
             .on_eviction(move || {
                 ec.fetch_add(1, Ordering::SeqCst);
             })
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = layer.layer(service);
 
@@ -554,7 +560,8 @@ mod tests {
         let layer = CacheLayer::builder()
             .max_size(10)
             .key_extractor(|req: &String| req.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = layer.layer(service);
 

--- a/crates/tower-resilience-cache/src/shared_layer.rs
+++ b/crates/tower-resilience-cache/src/shared_layer.rs
@@ -36,7 +36,8 @@ use tower_resilience_core::{EventListeners, FnListener};
 ///     .max_size(100)
 ///     .ttl(Duration::from_secs(60))
 ///     .key_extractor(|req: &String| req.clone())
-///     .build();
+///     .build()
+///     .unwrap();
 ///
 /// // Both services share the same cache
 /// let service1 = ServiceBuilder::new()
@@ -65,6 +66,7 @@ use tower_resilience_core::{EventListeners, FnListener};
 ///     .ttl(Duration::from_secs(60))
 ///     .key_extractor(|req: &String| req.clone())
 ///     .build()
+///     .unwrap()
 ///     .shared::<String>();  // Specify the response type
 /// ```
 #[derive(Clone)]
@@ -115,7 +117,8 @@ where
     ///     .max_size(100)
     ///     .ttl(Duration::from_secs(60))
     ///     .key_extractor(|req: &String| req.clone())
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn builder() -> SharedCacheConfigBuilder<Req, K, Resp> {
         SharedCacheConfigBuilder::new()
@@ -257,13 +260,14 @@ where
 
     /// Builds the shared cache layer.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `key_extractor` was not set.
-    pub fn build(self) -> SharedCacheLayer<Req, K, Resp> {
+    /// Returns [`crate::CacheBuildError::MissingKeyExtractor`] if `key_extractor`
+    /// was not set before calling `build()`.
+    pub fn build(self) -> Result<SharedCacheLayer<Req, K, Resp>, crate::CacheBuildError> {
         let key_extractor = self
             .key_extractor
-            .expect("key_extractor must be set before building");
+            .ok_or(crate::CacheBuildError::MissingKeyExtractor)?;
 
         let config = CacheConfig {
             max_size: self.max_size,
@@ -274,7 +278,7 @@ where
             name: self.name,
         };
 
-        SharedCacheLayer::new(config)
+        Ok(SharedCacheLayer::new(config))
     }
 }
 
@@ -304,7 +308,8 @@ mod tests {
     fn test_shared_builder_defaults() {
         let _layer: SharedCacheLayer<TestRequest, String, String> = SharedCacheLayer::builder()
             .key_extractor(|req: &TestRequest| req.id.clone())
-            .build();
+            .build()
+            .unwrap();
     }
 
     #[test]
@@ -314,14 +319,17 @@ mod tests {
             .ttl(Duration::from_secs(60))
             .key_extractor(|req: &TestRequest| req.id.clone())
             .name("my-shared-cache")
-            .build();
+            .build()
+            .unwrap();
     }
 
     #[test]
-    #[should_panic(expected = "key_extractor must be set")]
-    fn test_shared_builder_panics_without_key_extractor() {
-        let _config: SharedCacheLayer<TestRequest, String, String> =
-            SharedCacheLayer::builder().build();
+    fn test_shared_builder_errors_without_key_extractor() {
+        let result = SharedCacheLayer::<TestRequest, String, String>::builder().build();
+        assert!(matches!(
+            result,
+            Err(crate::CacheBuildError::MissingKeyExtractor)
+        ));
     }
 
     #[tokio::test]
@@ -351,7 +359,8 @@ mod tests {
         let shared_layer: SharedCacheLayer<String, String, String> = SharedCacheLayer::builder()
             .max_size(10)
             .key_extractor(|req: &String| req.clone())
-            .build();
+            .build()
+            .unwrap();
 
         // Apply to both services
         let mut wrapped1 = shared_layer.clone().layer(service1);
@@ -410,7 +419,8 @@ mod tests {
         let layer = CacheLayer::builder()
             .max_size(10)
             .key_extractor(|req: &String| req.clone())
-            .build();
+            .build()
+            .unwrap();
 
         // Apply to both services
         let mut wrapped1 = layer.clone().layer(service1);

--- a/crates/tower-resilience-cache/tests/contract.rs
+++ b/crates/tower-resilience-cache/tests/contract.rs
@@ -22,6 +22,7 @@ fn unique_key_layer() -> CacheLayer<(), usize> {
         .ttl(Duration::from_secs(60))
         .key_extractor(move |_: &()| counter.fetch_add(1, Ordering::SeqCst))
         .build()
+        .unwrap()
 }
 
 #[tokio::test]

--- a/crates/tower-resilience/examples/full_stack.rs
+++ b/crates/tower-resilience/examples/full_stack.rs
@@ -208,7 +208,8 @@ async fn demo_cache() {
         .key_extractor(|req: &String| req.clone())
         .on_hit(|| println!("  [Cache] Hit!"))
         .on_miss(|| println!("  [Cache] Miss"))
-        .build();
+        .build()
+        .expect("key_extractor is set");
 
     let mut service = cache_layer.layer(service);
 

--- a/crates/tower-resilience/src/composition.rs
+++ b/crates/tower-resilience/src/composition.rs
@@ -972,6 +972,7 @@ pub mod advanced {
     //!     .ttl(Duration::from_secs(300))
     //!     .key_extractor(|req: &Request| req.id)
     //!     .build()
+    //!     .unwrap()
     //!     .layer(with_circuit_breaker);
     //! # }
     //! # }
@@ -1012,6 +1013,7 @@ pub mod advanced {
     //!     .ttl(Duration::from_secs(300))
     //!     .key_extractor(|req: &Request| req.id)
     //!     .build()
+    //!     .unwrap()
     //!     .layer(inner);
     //! # }
     //! # }

--- a/crates/tower-resilience/src/patterns.rs
+++ b/crates/tower-resilience/src/patterns.rs
@@ -322,7 +322,8 @@ pub mod cache {
     //!     .max_size(1000)
     //!     .ttl(Duration::from_secs(300))
     //!     .key_extractor(|req: &Request| req.id)
-    //!     .build();
+    //!     .build()
+    //!     .unwrap();
     //!
     //! let service = tower::ServiceBuilder::new()
     //!     .layer(cache)
@@ -549,7 +550,8 @@ pub mod coalesce {
     //!     .max_size(1000)
     //!     .ttl(Duration::from_secs(300))
     //!     .key_extractor(|req: &Request| req.id.clone())
-    //!     .build();
+    //!     .build()
+    //!     .unwrap();
     //!
     //! let coalesce = CoalesceLayer::new(|req: &Request| req.id.clone());
     //!

--- a/examples/cache.rs
+++ b/examples/cache.rs
@@ -36,7 +36,8 @@ async fn main() {
         .on_hit(|| {
             println!("  Cache hit - returning cached response");
         })
-        .build();
+        .build()
+        .expect("key_extractor is set");
 
     let layer = config;
     let mut service = layer.layer(svc);

--- a/examples/composition_outbound.rs
+++ b/examples/composition_outbound.rs
@@ -280,7 +280,8 @@ async fn scenario_cache() {
         .on_miss(|| {
             println!("[Cache] Miss");
         })
-        .build();
+        .build()
+        .expect("key_extractor is set");
 
     let mut client = cache_layer.layer(base_client);
 
@@ -347,7 +348,8 @@ async fn scenario_full_stack() {
                 .on_miss(|| {
                     println!("[Cache] Miss - calling API");
                 })
-                .build(),
+                .build()
+                .expect("key_extractor is set"),
         )
         // 2. Circuit breaker - fail fast when downstream is degraded
         .layer(circuit_breaker_layer)

--- a/examples/observability_metrics.rs
+++ b/examples/observability_metrics.rs
@@ -317,6 +317,7 @@ async fn demo_cache() {
         .ttl(Duration::from_secs(60))
         .key_extractor(|req: &Request| req.id)
         .build()
+        .expect("key_extractor is set")
         .layer(base_service);
 
     let mut service = service;

--- a/tests/cache/cache_concurrency.rs
+++ b/tests/cache/cache_concurrency.rs
@@ -31,7 +31,8 @@ async fn concurrent_reads_from_same_cached_item() {
     let config = CacheLayer::builder()
         .max_size(10)
         .key_extractor(|req: &String| req.clone())
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let mut service = layer.layer(service);
@@ -87,7 +88,8 @@ async fn concurrent_writes_with_different_keys() {
     let config = CacheLayer::builder()
         .max_size(100)
         .key_extractor(|req: &String| req.clone())
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let service = layer.layer(service);
@@ -138,7 +140,8 @@ async fn concurrent_read_write_mix() {
     let config = CacheLayer::builder()
         .max_size(50)
         .key_extractor(|req: &String| req.clone())
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let service = layer.layer(service);
@@ -203,7 +206,8 @@ async fn cache_service_cloning_preserves_shared_state() {
     let config = CacheLayer::builder()
         .max_size(10)
         .key_extractor(|req: &String| req.clone())
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let mut service1 = layer.layer(service);
@@ -260,7 +264,8 @@ async fn thread_safety_of_arc_mutex_cache_store() {
     let config = CacheLayer::builder()
         .max_size(100)
         .key_extractor(|req: &u32| *req)
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let service = layer.layer(service);
@@ -304,7 +309,8 @@ async fn multiple_clones_accessing_simultaneously() {
     let config = CacheLayer::builder()
         .max_size(20)
         .key_extractor(|req: &String| req.clone())
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let service = layer.layer(service);
@@ -352,7 +358,8 @@ async fn no_data_corruption_under_concurrent_load() {
     let config = CacheLayer::builder()
         .max_size(100)
         .key_extractor(|req: &u64| *req)
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let service = layer.layer(service);
@@ -403,7 +410,8 @@ async fn concurrent_cache_hits_maintain_correctness() {
     let config = CacheLayer::builder()
         .max_size(10)
         .key_extractor(|req: &String| req.clone())
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let mut service = layer.layer(service);

--- a/tests/cache/cache_edge_cases.rs
+++ b/tests/cache/cache_edge_cases.rs
@@ -31,7 +31,8 @@ async fn empty_cache_behavior() {
     let config = CacheLayer::builder()
         .max_size(10)
         .key_extractor(|req: &String| req.clone())
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let mut service = layer.layer(service);
@@ -83,7 +84,8 @@ async fn single_item_cache_lru_works() {
         .on_eviction(move || {
             ec.fetch_add(1, Ordering::SeqCst);
         })
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let mut service = layer.layer(service);
@@ -140,7 +142,8 @@ async fn large_cache_stress_test() {
     let config = CacheLayer::builder()
         .max_size(2000) // Large cache
         .key_extractor(|req: &u32| *req)
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let mut service = layer.layer(service);
@@ -181,7 +184,8 @@ async fn zero_ttl_instant_expiration() {
         .max_size(10)
         .ttl(Duration::from_nanos(1)) // Effectively instant expiration
         .key_extractor(|req: &String| req.clone())
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let mut service = layer.layer(service);
@@ -227,7 +231,8 @@ async fn very_long_ttl() {
         .max_size(10)
         .ttl(Duration::from_secs(365 * 24 * 60 * 60)) // 1 year
         .key_extractor(|req: &String| req.clone())
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let mut service = layer.layer(service);
@@ -274,7 +279,8 @@ async fn multiple_items_same_value_different_keys() {
     let config = CacheLayer::builder()
         .max_size(10)
         .key_extractor(|req: &String| req.clone())
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let mut service = layer.layer(service);
@@ -332,7 +338,8 @@ async fn rapid_insert_evict_cycles() {
         .on_eviction(move || {
             ec.fetch_add(1, Ordering::SeqCst);
         })
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let mut service = layer.layer(service);
@@ -374,7 +381,8 @@ async fn cache_full_behavior() {
         .on_eviction(move || {
             ec.fetch_add(1, Ordering::SeqCst);
         })
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let mut service = layer.layer(service);
@@ -418,7 +426,8 @@ async fn ttl_expiration_during_service_call() {
         .max_size(10)
         .ttl(Duration::from_millis(80))
         .key_extractor(|req: &String| req.clone())
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let mut service = layer.layer(service);
@@ -468,7 +477,8 @@ async fn clone_overhead_with_large_responses() {
     let config = CacheLayer::builder()
         .max_size(10)
         .key_extractor(|req: &u32| *req)
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let mut service = layer.layer(service);

--- a/tests/cache/cache_key_extraction.rs
+++ b/tests/cache/cache_key_extraction.rs
@@ -50,7 +50,8 @@ async fn complex_key_extraction_from_struct() {
             user_id: req.user_id,
             resource_id: req.resource_id,
         })
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let mut service = layer.layer(service);
@@ -110,7 +111,8 @@ async fn key_collision_handling() {
     let config = CacheLayer::builder()
         .max_size(10)
         .key_extractor(|req: &String| req.chars().next().unwrap_or('?').to_string())
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let mut service = layer.layer(service);
@@ -173,7 +175,8 @@ async fn different_request_types_same_key_extracted() {
     let config = CacheLayer::builder()
         .max_size(10)
         .key_extractor(|req: &RequestV1| req.id)
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let mut service = layer.layer(service);
@@ -236,7 +239,8 @@ async fn key_extractor_with_hash_of_struct_fields() {
             req.hash(&mut hasher);
             hasher.finish()
         })
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let mut service = layer.layer(service);
@@ -300,7 +304,8 @@ async fn key_extractor_with_simple_types() {
     let config = CacheLayer::builder()
         .max_size(10)
         .key_extractor(|req: &u64| *req)
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let mut service = layer.layer(service);
@@ -327,7 +332,8 @@ async fn key_extractor_with_simple_types() {
     let string_config = CacheLayer::builder()
         .max_size(10)
         .key_extractor(|req: &String| req.clone())
-        .build();
+        .build()
+        .unwrap();
 
     let string_layer = string_config;
     let mut string_service = string_layer.layer(string_service);
@@ -365,7 +371,8 @@ async fn key_extraction_consistency() {
     let config = CacheLayer::builder()
         .max_size(10)
         .key_extractor(|req: &Request| (req.a, req.b))
-        .build();
+        .build()
+        .unwrap();
 
     let layer = config;
     let mut service = layer.layer(service);

--- a/tests/cache/cache_layer.rs
+++ b/tests/cache/cache_layer.rs
@@ -31,7 +31,8 @@ async fn layer_composition_with_service_builder() {
     let cache_layer = CacheLayer::builder()
         .max_size(10)
         .key_extractor(|req: &String| req.clone())
-        .build();
+        .build()
+        .unwrap();
 
     // Compose using ServiceBuilder
     let mut composed_service = ServiceBuilder::new().layer(cache_layer).service(service);
@@ -78,14 +79,16 @@ async fn multiple_cache_layers_in_same_stack() {
         .max_size(10)
         .name("outer-cache")
         .key_extractor(|req: &u32| *req)
-        .build();
+        .build()
+        .unwrap();
 
     // Inner cache: smaller capacity
     let inner_cache = CacheLayer::builder()
         .max_size(5)
         .name("inner-cache")
         .key_extractor(|req: &u32| *req)
-        .build();
+        .build()
+        .unwrap();
 
     // Stack them: request -> outer_cache -> inner_cache -> service
     let mut stacked_service = ServiceBuilder::new()
@@ -156,7 +159,8 @@ async fn cache_with_map_response_layer() {
     let cache_layer = CacheLayer::builder()
         .max_size(10)
         .key_extractor(|req: &String| req.clone())
-        .build();
+        .build()
+        .unwrap();
 
     // Use map_response to transform cached responses
     let map_layer = tower::util::MapResponseLayer::new(|response: String| response.to_uppercase());
@@ -206,7 +210,8 @@ async fn cache_with_map_request_layer() {
     let cache_layer = CacheLayer::builder()
         .max_size(10)
         .key_extractor(|req: &String| req.clone())
-        .build();
+        .build()
+        .unwrap();
 
     // Use map_request to transform incoming requests before caching
     let map_layer = tower::util::MapRequestLayer::new(|req: String| req.to_lowercase());
@@ -266,7 +271,8 @@ async fn service_cloning_through_layer() {
     let cache_layer = CacheLayer::builder()
         .max_size(10)
         .key_extractor(|req: &String| req.clone())
-        .build();
+        .build()
+        .unwrap();
 
     let mut service1 = ServiceBuilder::new().layer(cache_layer).service(service);
 
@@ -324,7 +330,8 @@ async fn layer_returns_correct_service_type() {
     let cache_config = CacheLayer::builder()
         .max_size(10)
         .key_extractor(|req: &String| req.clone())
-        .build();
+        .build()
+        .unwrap();
 
     let cache_layer = cache_config;
 

--- a/tests/cache/eviction_policies.rs
+++ b/tests/cache/eviction_policies.rs
@@ -10,7 +10,8 @@ async fn lru_evicts_least_recently_used() {
         .max_size(2)
         .eviction_policy(EvictionPolicy::Lru)
         .key_extractor(|req: &String| req.clone())
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = cache_layer.layer(tower::service_fn(|req: String| async move {
         Ok::<_, ()>(format!("Response: {}", req))
@@ -61,7 +62,8 @@ async fn lfu_evicts_least_frequently_used() {
         .max_size(2)
         .eviction_policy(EvictionPolicy::Lfu)
         .key_extractor(|req: &String| req.clone())
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = cache_layer.layer(tower::service_fn(|req: String| async move {
         Ok::<_, ()>(format!("Response: {}", req))
@@ -133,7 +135,8 @@ async fn fifo_evicts_oldest_entry() {
         .max_size(2)
         .eviction_policy(EvictionPolicy::Fifo)
         .key_extractor(|req: &String| req.clone())
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = cache_layer.layer(tower::service_fn(|req: String| async move {
         Ok::<_, ()>(format!("Response: {}", req))
@@ -195,7 +198,8 @@ async fn eviction_policies_work_with_ttl() {
             .ttl(Duration::from_millis(50))
             .eviction_policy(policy)
             .key_extractor(|req: &String| req.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = cache_layer.layer(tower::service_fn(|req: String| async move {
             Ok::<_, ()>(format!("Response: {}", req))
@@ -251,7 +255,8 @@ async fn different_policies_produce_different_eviction_behavior() {
             .on_miss(move || {
                 misses.fetch_add(1, Ordering::Relaxed);
             })
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = cache_layer.layer(tower::service_fn(|req: String| async move {
             Ok::<_, ()>(format!("Response: {}", req))
@@ -312,7 +317,8 @@ async fn different_policies_produce_different_eviction_behavior() {
             .on_miss(move || {
                 misses.fetch_add(1, Ordering::Relaxed);
             })
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = cache_layer.layer(tower::service_fn(|req: String| async move {
             Ok::<_, ()>(format!("Response: {}", req))
@@ -373,7 +379,8 @@ async fn different_policies_produce_different_eviction_behavior() {
             .on_miss(move || {
                 misses.fetch_add(1, Ordering::Relaxed);
             })
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = cache_layer.layer(tower::service_fn(|req: String| async move {
             Ok::<_, ()>(format!("Response: {}", req))

--- a/tests/metrics_regression/cache.rs
+++ b/tests/metrics_regression/cache.rs
@@ -14,7 +14,8 @@ async fn cache_metrics_exist() {
         .name("test_cache")
         .max_size(10)
         .key_extractor(|req: &u64| *req)
-        .build();
+        .build()
+        .unwrap();
 
     let counter = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let counter_clone = counter.clone();
@@ -54,7 +55,8 @@ async fn cache_eviction_metrics() {
         .name("eviction_cache")
         .max_size(2)
         .key_extractor(|req: &u64| *req)
-        .build();
+        .build()
+        .unwrap();
 
     let service = tower::service_fn(|req: u64| async move { Ok::<_, &'static str>(req) });
 

--- a/tests/stress/cache.rs
+++ b/tests/stress/cache.rs
@@ -27,7 +27,8 @@ async fn stress_large_cache() {
     let layer = CacheLayer::builder()
         .max_size(100_000)
         .key_extractor(|req: &u32| *req)
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -82,7 +83,8 @@ async fn stress_eviction_churn() {
         .max_size(1000)
         .eviction_policy(EvictionPolicy::Lru)
         .key_extractor(|req: &u32| *req)
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -123,7 +125,8 @@ async fn stress_ttl_expiration() {
         .max_size(1000)
         .ttl(Duration::from_millis(100))
         .key_extractor(|req: &u32| *req)
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -180,7 +183,8 @@ async fn stress_eviction_policy_comparison() {
             .max_size(100)
             .eviction_policy(policy)
             .key_extractor(|req: &u32| *req)
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = layer.layer(svc);
 
@@ -230,7 +234,8 @@ async fn stress_concurrent_access() {
     let layer = CacheLayer::builder()
         .max_size(1000)
         .key_extractor(|req: &u32| *req)
-        .build();
+        .build()
+        .unwrap();
 
     let service = layer.layer(svc);
 
@@ -276,7 +281,8 @@ async fn stress_memory_scaling() {
         let layer = CacheLayer::builder()
             .max_size(size)
             .key_extractor(|req: &u32| *req)
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = layer.layer(svc);
 
@@ -316,7 +322,8 @@ async fn stress_throughput() {
     let layer = CacheLayer::builder()
         .max_size(1000)
         .key_extractor(|req: &u32| *req)
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -364,7 +371,8 @@ async fn stress_stability() {
         .ttl(Duration::from_millis(500))
         .eviction_policy(EvictionPolicy::Lru)
         .key_extractor(|req: &u32| *req)
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 


### PR DESCRIPTION
Closes #314.

## Plan

Both `CacheConfigBuilder::build()` and `SharedCacheConfigBuilder::build()` `.expect()`-panic when `key_extractor` is unset. Per project convention, a library should surface API misuse as an error, not panic at `build()` time.

This PR (breaking, acceptable pre-1.0):
- Adds a non-generic `CacheBuildError { MissingKeyExtractor }` to `error.rs`, matching the crate's existing hand-rolled error style (no thiserror). `CacheError<E>` is generic over the inner service error, which doesn't exist at build time, so it can't be reused here.
- Changes both `build()` methods to return `Result<_, CacheBuildError>` (`# Panics` -> `# Errors`).
- Updates every call site (unit tests, doctests, `cache_example.rs`, workspace `examples/cache.rs`) to handle the `Result`.

`fix!` marks the breaking change so release-plz cuts a minor bump.

## Execution

Dispatched via roba (opus/high) in a worktree off `origin/main`. roba implements + runs all gates (fmt, clippy -D warnings, test --lib, test --test '*', test --doc, doc) and commits on green; orchestrator owns the PR lifecycle.