### PR TITLE
ci: pin dtolnay/rust-toolchain to @stable in test matrix (closes #318)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
 


### PR DESCRIPTION
Closes #318.

The test-matrix job in `ci.yml` used `dtolnay/rust-toolchain@master` (unpinned); every other job uses `@stable`. Pins the outlier to `@stable` so an action change can't silently break the matrix.

Dispatched via roba (opus/high) in a worktree off origin/main, part of a parallel disjoint-file batch.