### PR TITLE
test: stress tests for router/outlier/executor + wire missing patterns into matrix (closes #320)

### DIFF
--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -33,14 +33,21 @@ jobs:
       fail-fast: false
       matrix:
         pattern:
+          - adaptive
           - bulkhead
           - cache
           - circuitbreaker
+          - coalesce
           - composition
+          - executor
+          - fallback
           - healthcheck
+          - hedge
+          - outlier
           - ratelimiter
           - reconnect
           - retry
+          - router
           - timelimiter
 
     steps:

--- a/tests/stress/executor.rs
+++ b/tests/stress/executor.rs
@@ -1,0 +1,221 @@
+//! Executor stress tests - task-spawning delegation under load
+//!
+//! `ExecutorLayer` spawns each request onto a captured tokio runtime handle and
+//! ferries the result back over a oneshot channel. Because it depends on a live
+//! runtime, every test runs under `#[tokio::test]`. These tests validate
+//! throughput, genuine parallel execution, error propagation across the spawn
+//! boundary, and memory stability under sustained load.
+
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::time::sleep;
+use tower::{Service, ServiceBuilder, ServiceExt};
+use tower_resilience_executor::{ExecutorError, ExecutorLayer};
+
+use super::{ConcurrencyTracker, get_memory_usage_mb};
+
+/// Test: High-volume sequential throughput through the spawn boundary.
+///
+/// Every request crosses a spawn + oneshot round trip. This drives a large
+/// sequential volume and validates that results round-trip correctly at scale.
+#[tokio::test]
+#[ignore]
+async fn stress_high_volume_throughput() {
+    let service = tower::service_fn(|req: usize| async move { Ok::<usize, Infallible>(req * 2) });
+
+    let mut service = ServiceBuilder::new()
+        .layer(ExecutorLayer::current())
+        .service(service);
+
+    let total = 100_000;
+    let start = Instant::now();
+    let mut mismatches = 0;
+
+    for i in 0..total {
+        let resp = service.ready().await.unwrap().call(i).await.unwrap();
+        if resp != i * 2 {
+            mismatches += 1;
+        }
+    }
+
+    let elapsed = start.elapsed();
+    let throughput = total as f64 / elapsed.as_secs_f64();
+
+    println!("Executor throughput: {} requests", total);
+    println!("Completed in: {:?}", elapsed);
+    println!("Throughput: {:.0} req/sec", throughput);
+
+    assert_eq!(mismatches, 0, "every response must round-trip correctly");
+    assert!(throughput > 1_000.0, "should sustain reasonable throughput");
+}
+
+/// Test: High concurrency yields genuine parallel execution.
+///
+/// On a multi-threaded runtime the executor should run many requests at once.
+/// A concurrency tracker confirms the peak in-flight count exceeds one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore]
+async fn stress_high_concurrency_parallel() {
+    let tracker = ConcurrencyTracker::new();
+    let tracker_clone = Arc::clone(&tracker);
+
+    let service = tower::service_fn(move |_req: usize| {
+        let tracker = Arc::clone(&tracker_clone);
+        async move {
+            tracker.enter();
+            sleep(Duration::from_millis(5)).await;
+            tracker.exit();
+            Ok::<(), Infallible>(())
+        }
+    });
+
+    let service = ServiceBuilder::new()
+        .layer(ExecutorLayer::current())
+        .service(service);
+
+    let total = 5_000;
+    let start = Instant::now();
+    let mut handles = Vec::with_capacity(total);
+
+    for i in 0..total {
+        let mut svc = service.clone();
+        handles.push(tokio::spawn(async move {
+            svc.ready().await.unwrap().call(i).await
+        }));
+    }
+
+    let mut success = 0;
+    for handle in handles {
+        if handle.await.unwrap().is_ok() {
+            success += 1;
+        }
+    }
+
+    let elapsed = start.elapsed();
+    let peak = tracker.peak();
+
+    println!("Executor parallel: {} concurrent requests", total);
+    println!("Completed in: {:?}", elapsed);
+    println!("Peak concurrency: {}", peak);
+
+    assert_eq!(success, total, "every request should complete successfully");
+    assert!(
+        peak > 1,
+        "executor should run requests in parallel, peak was {}",
+        peak
+    );
+}
+
+/// Test: Service errors propagate across the spawn boundary under load.
+///
+/// A fraction of requests fail in the inner service. Each failure must surface
+/// as `ExecutorError::Service` on the caller side, with an exact count match.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore]
+async fn stress_error_propagation_under_load() {
+    let service = tower::service_fn(|req: usize| async move {
+        if req.is_multiple_of(7) {
+            Err::<usize, &'static str>("boom")
+        } else {
+            Ok(req)
+        }
+    });
+
+    let service = ServiceBuilder::new()
+        .layer(ExecutorLayer::current())
+        .service(service);
+
+    let total: usize = 10_000;
+    let expected_errors = (0..total).filter(|i| i.is_multiple_of(7)).count();
+
+    let start = Instant::now();
+    let mut handles = Vec::with_capacity(total);
+
+    for i in 0..total {
+        let mut svc = service.clone();
+        handles.push(tokio::spawn(async move {
+            svc.ready().await.unwrap().call(i).await
+        }));
+    }
+
+    let mut service_errors = 0;
+    let mut successes = 0;
+    for handle in handles {
+        match handle.await.unwrap() {
+            Ok(_) => successes += 1,
+            Err(ExecutorError::Service("boom")) => service_errors += 1,
+            Err(other) => panic!("unexpected error variant: {:?}", other),
+        }
+    }
+
+    let elapsed = start.elapsed();
+    println!("Executor error propagation: {} requests", total);
+    println!("Completed in: {:?}", elapsed);
+    println!(
+        "Successes: {}, Service errors: {}",
+        successes, service_errors
+    );
+
+    assert_eq!(
+        service_errors, expected_errors,
+        "all inner errors must propagate"
+    );
+    assert_eq!(
+        successes + service_errors,
+        total,
+        "every request accounted for"
+    );
+}
+
+/// Test: Memory stays stable across sustained spawn/oneshot churn.
+///
+/// Each request allocates a task and a oneshot channel. Over many requests the
+/// resident memory should not grow unbounded.
+#[tokio::test]
+#[ignore]
+async fn stress_memory_stability() {
+    let mem_start = get_memory_usage_mb();
+
+    let service = tower::service_fn(|_req: usize| async move { Ok::<(), Infallible>(()) });
+
+    let mut service = ServiceBuilder::new()
+        .layer(ExecutorLayer::current())
+        .service(service);
+
+    let total = 50_000;
+    let mut mem_samples = vec![];
+
+    for i in 0..total {
+        let _ = service.ready().await.unwrap().call(i).await;
+        if i % 5_000 == 0 {
+            let mem = get_memory_usage_mb();
+            if mem > 0.0 {
+                mem_samples.push(mem);
+            }
+        }
+    }
+
+    let mem_end = get_memory_usage_mb();
+    let mem_delta = mem_end - mem_start;
+
+    println!("Executor memory stability: {} requests", total);
+    println!(
+        "Start: {:.2} MB, End: {:.2} MB, Delta: {:.2} MB",
+        mem_start, mem_end, mem_delta
+    );
+
+    if !mem_samples.is_empty() {
+        let mem_max = mem_samples.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b));
+        let mem_min = mem_samples.iter().fold(f64::INFINITY, |a, &b| a.min(b));
+        println!("Memory: min={:.2} MB, max={:.2} MB", mem_min, mem_max);
+        assert!(
+            mem_max - mem_min < 100.0,
+            "memory should stay stable under load"
+        );
+    }
+
+    if mem_delta > 0.0 {
+        assert!(mem_delta < 100.0, "memory growth should be bounded");
+    }
+}

--- a/tests/stress/mod.rs
+++ b/tests/stress/mod.rs
@@ -29,12 +29,15 @@ pub mod cache;
 pub mod circuitbreaker;
 pub mod coalesce;
 pub mod composition;
+pub mod executor;
 pub mod fallback;
 pub mod healthcheck;
 pub mod hedge;
+pub mod outlier;
 pub mod ratelimiter;
 pub mod reconnect;
 pub mod retry;
+pub mod router;
 pub mod timelimiter;
 
 use std::sync::Arc;

--- a/tests/stress/outlier.rs
+++ b/tests/stress/outlier.rs
@@ -1,0 +1,290 @@
+//! Outlier detection stress tests - shared fleet state under load
+//!
+//! `OutlierDetector` holds fleet-wide ejection state behind an internal
+//! `Arc<Mutex<...>>` shared across every per-instance service. These tests push
+//! concurrent traffic through a fleet and assert that ejection, the
+//! `max_ejection_percent` cap, and time-based readmission stay consistent under
+//! load.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+use tokio::time::sleep;
+use tower::util::BoxCloneService;
+use tower::{Layer, Service, ServiceExt};
+use tower_resilience_outlier::{
+    OutlierDetectionLayer, OutlierDetectionServiceError, OutlierDetector,
+};
+
+/// Uniform, cloneable per-instance service type for a fleet. We box so every
+/// instance shares one type and can be stored in a `Vec` and cloned per task.
+type FleetService = BoxCloneService<usize, usize, OutlierDetectionServiceError<std::io::Error>>;
+
+/// Builds one fleet instance sharing `detector`, in error-on-ejection mode so
+/// ejected instances surface an explicit error instead of parking `poll_ready`
+/// (which would hang the driving loop).
+fn make_instance(detector: OutlierDetector, name: &str, healthy: Arc<AtomicBool>) -> FleetService {
+    let inner = tower::service_fn(move |req: usize| {
+        let healthy = Arc::clone(&healthy);
+        async move {
+            if healthy.load(Ordering::Relaxed) {
+                Ok::<usize, std::io::Error>(req)
+            } else {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::ConnectionRefused,
+                    "down",
+                ))
+            }
+        }
+    });
+
+    let layer = OutlierDetectionLayer::builder()
+        .detector(detector)
+        .instance_name(name)
+        .error_on_ejection()
+        .build();
+
+    BoxCloneService::new(layer.layer(inner))
+}
+
+/// Test: Healthy fleet sustains high concurrent throughput with no ejections.
+#[tokio::test]
+#[ignore]
+async fn stress_healthy_fleet_throughput() {
+    let fleet_size = 10;
+    let detector = OutlierDetector::new().max_ejection_percent(100);
+
+    let mut fleet = Vec::with_capacity(fleet_size);
+    for i in 0..fleet_size {
+        let name = format!("backend-{}", i);
+        detector.register(&name, 5);
+        fleet.push(make_instance(
+            detector.clone(),
+            &name,
+            Arc::new(AtomicBool::new(true)),
+        ));
+    }
+
+    let total = 30_000;
+    let start = Instant::now();
+    let mut handles = Vec::with_capacity(total);
+
+    for i in 0..total {
+        let mut svc = fleet[i % fleet_size].clone();
+        handles.push(tokio::spawn(async move {
+            svc.ready().await.unwrap().call(i).await
+        }));
+    }
+
+    let mut success = 0;
+    for handle in handles {
+        if handle.await.unwrap().is_ok() {
+            success += 1;
+        }
+    }
+
+    let elapsed = start.elapsed();
+    println!(
+        "Healthy fleet throughput: {} requests across {} instances",
+        total, fleet_size
+    );
+    println!("Completed in: {:?}", elapsed);
+    println!(
+        "Throughput: {:.0} req/sec",
+        total as f64 / elapsed.as_secs_f64()
+    );
+
+    assert_eq!(success, total, "healthy fleet should serve every request");
+    assert_eq!(detector.ejected_count(), 0, "no instance should be ejected");
+    assert_eq!(
+        detector.instance_count(),
+        fleet_size,
+        "fleet membership is stable"
+    );
+}
+
+/// Test: The `max_ejection_percent` cap holds under concurrent failures.
+///
+/// Half the fleet fails every call. With a 30% cap on a 10-instance fleet, at
+/// most 3 instances may be ejected simultaneously even though 5 are unhealthy.
+#[tokio::test]
+#[ignore]
+async fn stress_concurrent_ejection_cap() {
+    let fleet_size = 10;
+    let failing = 5;
+    // Long ejection duration so nothing recovers mid-test.
+    let detector = OutlierDetector::new()
+        .max_ejection_percent(30)
+        .base_ejection_duration(Duration::from_secs(60));
+
+    let mut fleet = Vec::with_capacity(fleet_size);
+    for i in 0..fleet_size {
+        let name = format!("backend-{}", i);
+        detector.register(&name, 3);
+        let healthy = Arc::new(AtomicBool::new(i >= failing));
+        fleet.push(make_instance(detector.clone(), &name, healthy));
+    }
+
+    let total = 20_000;
+    let start = Instant::now();
+    let mut handles = Vec::with_capacity(total);
+
+    for i in 0..total {
+        let mut svc = fleet[i % fleet_size].clone();
+        handles.push(tokio::spawn(async move {
+            svc.ready().await.unwrap().call(i).await
+        }));
+    }
+
+    for handle in handles {
+        let _ = handle.await.unwrap();
+    }
+
+    let elapsed = start.elapsed();
+    let ejected = detector.ejected_count();
+    println!(
+        "Concurrent ejection cap: {} requests, {} failing instances",
+        total, failing
+    );
+    println!("Completed in: {:?}", elapsed);
+    println!("Ejected count: {} (cap = 3)", ejected);
+
+    // 30% of 10 instances = at most 3 ejected; all 5 failing reach threshold so
+    // the cap is the binding constraint.
+    assert!(
+        ejected <= 3,
+        "must never exceed the 30% ejection cap, got {}",
+        ejected
+    );
+    assert_eq!(
+        ejected, 3,
+        "cap should be saturated by the failing instances"
+    );
+    assert_eq!(
+        detector.instance_count(),
+        fleet_size,
+        "fleet membership is stable"
+    );
+}
+
+/// Test: Ejection and time-based readmission stay consistent across cycles.
+///
+/// A single unhealthy instance is repeatedly ejected and, after its (capped)
+/// ejection duration elapses, readmitted. Over many cycles both ejection and
+/// recovery events must keep firing -- the detector must not get stuck.
+#[tokio::test]
+#[ignore]
+async fn stress_ejection_readmission_cycle() {
+    let ejections = Arc::new(AtomicUsize::new(0));
+    let recoveries = Arc::new(AtomicUsize::new(0));
+    let ej = Arc::clone(&ejections);
+    let rec = Arc::clone(&recoveries);
+
+    // Cap the ejection duration so every ejection lasts ~50ms regardless of the
+    // exponential backoff applied on repeated ejections.
+    let detector = OutlierDetector::new()
+        .max_ejection_percent(100)
+        .base_ejection_duration(Duration::from_millis(50))
+        .max_ejection_duration(Duration::from_millis(50))
+        .on_ejection(move |_name, _errors| {
+            ej.fetch_add(1, Ordering::Relaxed);
+        })
+        .on_recovery(move |_name, _dur| {
+            rec.fetch_add(1, Ordering::Relaxed);
+        });
+
+    detector.register("backend-1", 2);
+    let svc = make_instance(
+        detector.clone(),
+        "backend-1",
+        Arc::new(AtomicBool::new(false)),
+    );
+
+    let cycles = 6;
+    for _ in 0..cycles {
+        // Drive enough failing calls to (re-)eject the instance.
+        for i in 0..5 {
+            let mut s = svc.clone();
+            let _ = s.ready().await.unwrap().call(i).await;
+        }
+        // Wait past the ejection duration so the instance becomes eligible for
+        // readmission on the next probe.
+        sleep(Duration::from_millis(120)).await;
+        // A probe call triggers the time-based recovery path.
+        let mut s = svc.clone();
+        let _ = s.ready().await.unwrap().call(0).await;
+    }
+
+    let ej = ejections.load(Ordering::Relaxed);
+    let rec = recoveries.load(Ordering::Relaxed);
+    println!("Ejection/readmission cycle: {} cycles", cycles);
+    println!("Ejections: {}, Recoveries: {}", ej, rec);
+
+    // Generous lower bounds: timing on CI is noisy, but the detector must keep
+    // ejecting and readmitting rather than wedging in one state.
+    assert!(ej >= 3, "should re-eject across cycles, got {}", ej);
+    assert!(rec >= 2, "should readmit across cycles, got {}", rec);
+}
+
+/// Test: Mixed healthy/unhealthy fleet under high concurrency stays consistent.
+///
+/// A 20-instance fleet with 10 unhealthy instances and a 50% cap: all 10
+/// unhealthy instances should eject (50% of 20), healthy traffic keeps
+/// succeeding, and fleet membership never changes.
+#[tokio::test]
+#[ignore]
+async fn stress_high_concurrency_mixed_load() {
+    let fleet_size = 20;
+    let failing = 10;
+    let detector = OutlierDetector::new()
+        .max_ejection_percent(50)
+        .base_ejection_duration(Duration::from_secs(60));
+
+    let mut fleet = Vec::with_capacity(fleet_size);
+    for i in 0..fleet_size {
+        let name = format!("backend-{}", i);
+        detector.register(&name, 3);
+        let healthy = Arc::new(AtomicBool::new(i >= failing));
+        fleet.push(make_instance(detector.clone(), &name, healthy));
+    }
+
+    let total = 20_000;
+    let start = Instant::now();
+    let mut handles = Vec::with_capacity(total);
+
+    for i in 0..total {
+        let mut svc = fleet[i % fleet_size].clone();
+        handles.push(tokio::spawn(async move {
+            svc.ready().await.unwrap().call(i).await.is_ok()
+        }));
+    }
+
+    let mut success = 0;
+    for handle in handles {
+        if handle.await.unwrap() {
+            success += 1;
+        }
+    }
+
+    let elapsed = start.elapsed();
+    let ejected = detector.ejected_count();
+    println!(
+        "Mixed load: {} requests, {}/{} instances unhealthy",
+        total, failing, fleet_size
+    );
+    println!("Completed in: {:?}", elapsed);
+    println!("Successful responses: {}", success);
+    println!("Ejected count: {} (cap = 10)", ejected);
+
+    assert_eq!(
+        detector.instance_count(),
+        fleet_size,
+        "fleet membership is stable"
+    );
+    assert!(
+        ejected <= failing,
+        "ejected must not exceed unhealthy count"
+    );
+    assert_eq!(ejected, 10, "50% of 20 instances should be ejected");
+    assert!(success > 0, "healthy instances must keep serving traffic");
+}

--- a/tests/stress/router.rs
+++ b/tests/stress/router.rs
@@ -1,0 +1,227 @@
+//! Router stress tests - weighted traffic distribution under load
+//!
+//! `WeightedRouter` coordinates backend selection through an atomic counter.
+//! These tests validate that the weighted distribution stays exact at high
+//! volume and under concurrent access, and that many-backend fan-out remains
+//! consistent.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
+use tower::util::BoxService;
+use tower::{Service, ServiceExt};
+use tower_resilience_router::WeightedRouter;
+
+/// All backends must share a single type, so we box them. `BoxService` is not
+/// `Clone`, which is why the concurrency test drives a single shared router
+/// behind a `Mutex` rather than cloning per task.
+type Backend = BoxService<usize, usize, ()>;
+
+/// Builds a backend that counts every request it handles and echoes the value.
+fn counting_backend(counter: Arc<AtomicUsize>) -> Backend {
+    BoxService::new(tower::service_fn(move |req: usize| {
+        let counter = Arc::clone(&counter);
+        async move {
+            counter.fetch_add(1, Ordering::Relaxed);
+            Ok::<usize, ()>(req)
+        }
+    }))
+}
+
+/// Test: High-volume deterministic distribution stays exact.
+///
+/// With weights `[70, 20, 10]` (total 100) and a request count that is a whole
+/// number of cycles, the deterministic selector must route exactly according to
+/// the weights -- no drift, no rounding error at scale.
+#[tokio::test]
+#[ignore]
+async fn stress_high_volume_deterministic_distribution() {
+    let counts: Vec<Arc<AtomicUsize>> = (0..3).map(|_| Arc::new(AtomicUsize::new(0))).collect();
+
+    let mut router = WeightedRouter::builder()
+        .route(counting_backend(Arc::clone(&counts[0])), 70)
+        .route(counting_backend(Arc::clone(&counts[1])), 20)
+        .route(counting_backend(Arc::clone(&counts[2])), 10)
+        .build();
+
+    let total = 300_000;
+    let start = Instant::now();
+
+    for i in 0..total {
+        let _ = router.ready().await.unwrap().call(i).await;
+    }
+
+    let elapsed = start.elapsed();
+    let a = counts[0].load(Ordering::Relaxed);
+    let b = counts[1].load(Ordering::Relaxed);
+    let c = counts[2].load(Ordering::Relaxed);
+
+    println!("Deterministic distribution: {} requests", total);
+    println!("Completed in: {:?}", elapsed);
+    println!(
+        "Throughput: {:.0} req/sec",
+        total as f64 / elapsed.as_secs_f64()
+    );
+    println!("Backend counts: a={}, b={}, c={}", a, b, c);
+
+    // 300k / 100 = 3000 full cycles -> exact weighted split.
+    assert_eq!(a, 210_000, "70% backend");
+    assert_eq!(b, 60_000, "20% backend");
+    assert_eq!(c, 30_000, "10% backend");
+    assert_eq!(a + b + c, total, "every request routed exactly once");
+}
+
+/// Test: Concurrent routing keeps the distribution exact.
+///
+/// The selector's atomic counter is the only coordination point. Driving a
+/// single shared router from many concurrent tasks must still produce an exact
+/// weighted split, because each `call` performs exactly one atomic increment.
+#[tokio::test]
+#[ignore]
+async fn stress_concurrent_distribution_consistency() {
+    let count_a = Arc::new(AtomicUsize::new(0));
+    let count_b = Arc::new(AtomicUsize::new(0));
+
+    let router = WeightedRouter::builder()
+        .route(counting_backend(Arc::clone(&count_a)), 80)
+        .route(counting_backend(Arc::clone(&count_b)), 20)
+        .build();
+
+    // BoxService backends are not Clone, so share one router instance. The lock
+    // is held only long enough to obtain the backend future; the future itself
+    // is awaited concurrently outside the lock.
+    let router = Arc::new(Mutex::new(router));
+
+    let total = 40_000;
+    let start = Instant::now();
+    let mut handles = Vec::with_capacity(total);
+
+    for i in 0..total {
+        let router = Arc::clone(&router);
+        handles.push(tokio::spawn(async move {
+            // service_fn backends are always ready, so calling without an
+            // explicit poll_ready is safe here.
+            let fut = {
+                let mut guard = router.lock().unwrap();
+                guard.call(i)
+            };
+            fut.await
+        }));
+    }
+
+    let mut completed = 0;
+    for handle in handles {
+        if handle.await.unwrap().is_ok() {
+            completed += 1;
+        }
+    }
+
+    let elapsed = start.elapsed();
+    let a = count_a.load(Ordering::Relaxed);
+    let b = count_b.load(Ordering::Relaxed);
+
+    println!("Concurrent distribution: {} requests", total);
+    println!("Completed in: {:?}", elapsed);
+    println!("Backend counts: a={}, b={}", a, b);
+
+    assert_eq!(completed, total, "all requests completed successfully");
+    // 40k / 100 = 400 full cycles -> exact split regardless of interleaving.
+    assert_eq!(a, 32_000, "80% backend under concurrency");
+    assert_eq!(b, 8_000, "20% backend under concurrency");
+}
+
+/// Test: Many backends with equal weight fan out evenly.
+///
+/// 64 backends each weighted 1 exercise the cumulative-weight binary search and
+/// confirm state consistency across a large backend set.
+#[tokio::test]
+#[ignore]
+async fn stress_many_backends_even_split() {
+    let backend_count = 64;
+    let counts: Vec<Arc<AtomicUsize>> = (0..backend_count)
+        .map(|_| Arc::new(AtomicUsize::new(0)))
+        .collect();
+
+    let mut builder = WeightedRouter::builder();
+    for c in &counts {
+        builder = builder.route(counting_backend(Arc::clone(c)), 1);
+    }
+    let mut router = builder.build();
+
+    let cycles = 2_000;
+    let total = backend_count * cycles;
+    let start = Instant::now();
+
+    for i in 0..total {
+        let _ = router.ready().await.unwrap().call(i).await;
+    }
+
+    let elapsed = start.elapsed();
+    let observed: usize = counts.iter().map(|c| c.load(Ordering::Relaxed)).sum();
+
+    println!(
+        "Many backends: {} backends, {} requests",
+        backend_count, total
+    );
+    println!("Completed in: {:?}", elapsed);
+
+    for (idx, c) in counts.iter().enumerate() {
+        let n = c.load(Ordering::Relaxed);
+        assert_eq!(
+            n, cycles,
+            "backend {} should get exactly {} requests",
+            idx, cycles
+        );
+    }
+    assert_eq!(observed, total, "every request routed exactly once");
+}
+
+/// Test: Random strategy converges to the configured weights at volume.
+///
+/// Unlike the deterministic strategy, random selection only converges
+/// statistically. At high volume the observed ratios should land close to the
+/// configured weights. Bounds are intentionally generous for CI stability.
+#[tokio::test]
+#[ignore]
+async fn stress_random_strategy_convergence() {
+    let counts: Vec<Arc<AtomicUsize>> = (0..3).map(|_| Arc::new(AtomicUsize::new(0))).collect();
+
+    let mut router = WeightedRouter::builder()
+        .route(counting_backend(Arc::clone(&counts[0])), 50)
+        .route(counting_backend(Arc::clone(&counts[1])), 30)
+        .route(counting_backend(Arc::clone(&counts[2])), 20)
+        .random()
+        .build();
+
+    let total = 300_000;
+    let start = Instant::now();
+
+    for i in 0..total {
+        let _ = router.ready().await.unwrap().call(i).await;
+    }
+
+    let elapsed = start.elapsed();
+    let ratios: Vec<f64> = counts
+        .iter()
+        .map(|c| c.load(Ordering::Relaxed) as f64 / total as f64)
+        .collect();
+
+    println!("Random strategy: {} requests", total);
+    println!("Completed in: {:?}", elapsed);
+    println!(
+        "Observed ratios: {:.3}, {:.3}, {:.3}",
+        ratios[0], ratios[1], ratios[2]
+    );
+
+    let expected = [0.50, 0.30, 0.20];
+    for (idx, (&r, &e)) in ratios.iter().zip(expected.iter()).enumerate() {
+        assert!(
+            (r - e).abs() < 0.05,
+            "backend {} ratio {:.3} should be near {:.2}",
+            idx,
+            r,
+            e
+        );
+    }
+}


### PR DESCRIPTION
Closes #320.

Adds stress tests for router, outlier, and executor (none existed), registers them in `tests/stress/mod.rs`, and wires every stress module missing from the CI matrix into `stress-tests.yml`. While scoping, found four orphaned stress files (adaptive, coalesce, fallback, hedge) that had real `#[ignore]` tests but were never in the matrix -- those are added too, so the matrix now covers all stress modules.

Dispatched via roba (opus/high) in a worktree off origin/main, part of a parallel disjoint-file batch.