### PR TITLE
docs: document default changelog-path intent in release-plz.toml (closes #323)

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -8,7 +8,12 @@ semver_check = true
 # Release all crates together to keep versions in sync
 release_always = true
 
-# Generate separate changelogs for each crate
+# Generate separate changelogs for each crate.
+#
+# Crates without an explicit [[package]] entry intentionally rely on
+# release-plz's default per-crate changelog path (crates/<name>/CHANGELOG.md),
+# which is the same location the explicit entries below point to. The explicit
+# entries are kept only for clarity on the core crates.
 [[package]]
 name = "tower-resilience-core"
 changelog_path = "crates/tower-resilience-core/CHANGELOG.md"


### PR DESCRIPTION
Closes #323.

`release-plz.toml` has explicit `[[package]]` changelog paths for only 3 of 18 crates; the rest rely on release-plz's default (same resolved path). Adds a clarifying comment documenting that the default is intentionally relied upon, removing the ambiguity. No structural change.

Dispatched via roba (opus/high) in a worktree off origin/main, part of a parallel disjoint-file batch.