### PR TITLE
chore: use workspace tokio dependency in healthcheck (closes #321)

### DIFF
--- a/crates/tower-resilience-healthcheck/Cargo.toml
+++ b/crates/tower-resilience-healthcheck/Cargo.toml
@@ -8,12 +8,12 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-tokio = { version = "1.0", features = ["rt", "time", "sync"] }
+tokio = { workspace = true, features = ["rt"] }
 rand = { version = "0.9", optional = true }
 tower-resilience-core = { version = "0.9.4", path = "../tower-resilience-core", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.0", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 wiremock = "0.6"
 tower-resilience-chaos = { version = "0.9.4", path = "../tower-resilience-chaos" }
 reqwest = "0.13"


### PR DESCRIPTION
Closes #321.

`tower-resilience-healthcheck` declared tokio independently (`version = "1.0"`), bypassing the workspace pin and letting its feature set drift. Switches both the dep and dev-dep tokio lines to `workspace = true` with the extra features merged on top, matching every other crate. No workspace Cargo.toml or Cargo.lock change.

Dispatched via roba (opus/high) in a worktree off origin/main; part of a parallel disjoint-file batch.