### PR TITLE
fix: validate and correct MSRV, add MSRV CI job (closes #312)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,28 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Validates the published-crate MSRV (declared in [workspace.package]
+      # rust-version). This pins the toolchain to the declared floor so the
+      # advertised MSRV can't silently drift. Scope note: this checks the
+      # publishable surface only (`-p tower-resilience --all-features`, all
+      # edition 2021), NOT the repo-root `tower-resilience-tests` harness,
+      # which is edition 2024 (publish = false) and is not part of the MSRV
+      # contract.
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.85.0
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check MSRV
+        run: cargo check -p tower-resilience --all-features
+
   contract-lints:
     name: Source Contract Lints
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/joshrotenberg/tower-resilience"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
-rust-version = "1.64.0"
+rust-version = "1.85.0"
 
 [workspace.dependencies]
 tower = { version = "0.5", features = ["util", "limit"] }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/tower-resilience.svg)](https://crates.io/crates/tower-resilience)
 [![Documentation](https://docs.rs/tower-resilience/badge.svg)](https://docs.rs/tower-resilience)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](LICENSE-MIT)
-[![Rust Version](https://img.shields.io/badge/rust-1.64.0%2B-blue.svg)](https://www.rust-lang.org)
+[![Rust Version](https://img.shields.io/badge/rust-1.85.0%2B-blue.svg)](https://www.rust-lang.org)
 
 A comprehensive resilience and fault-tolerance toolkit for [Tower](https://github.com/tower-rs/tower) services, inspired by [Resilience4j](https://resilience4j.readme.io/).
 
@@ -737,7 +737,9 @@ cargo test --test stress -- --ignored
 
 ## MSRV
 
-1.64.0 (matches Tower)
+1.85.0. The floor is set by the edition-2024 dependency graph (the
+all-features build pulls `metrics-util` -> `indexmap`, which requires
+Rust 1.85). Validated in CI by the `msrv` job.
 
 ## License
 


### PR DESCRIPTION
Closes #312.

The workspace declares `rust-version = "1.64.0"` (and the README repeats it), but it's unvalidated and almost certainly wrong given the current dependency graph (tokio 1.52.x, thiserror 2, etc.), and no CI job builds on the claimed toolchain.

This PR:
- Determines the real MSRV empirically by probing `cargo +<ver> check -p tower-resilience --all-features` across toolchains (scoped to the published crates, edition 2021 -- not the edition-2024 root test harness).
- Corrects `rust-version` and the README badge + MSRV section to the verified value.
- Adds an `msrv` CI job that runs the scoped check on the pinned toolchain so the MSRV can't silently drift again.

Dispatched via roba (opus/high) in a worktree off origin/main.