### PR TITLE
feat(retry): relax E: Clone bound on retry Service impl

### DIFF
--- a/crates/tower-resilience-retry/src/lib.rs
+++ b/crates/tower-resilience-retry/src/lib.rs
@@ -240,7 +240,7 @@ where
     S::Future: Send + 'static,
     Req: Clone + Send + 'static,
     Res: Send + 'static,
-    E: Clone + Send + 'static,
+    E: Send + 'static,
 {
     type Response = Res;
     type Error = E;

--- a/tests/retry/retry_behavior.rs
+++ b/tests/retry/retry_behavior.rs
@@ -538,3 +538,49 @@ async fn empty_response_type() {
     assert!(result.is_ok());
     assert_eq!(call_count.load(Ordering::SeqCst), 3);
 }
+
+/// Regression test for #346: the retry Service impl must not require
+/// `E: Clone`. Many real-world client errors wrap `std::io::Error` (which is
+/// not `Clone` by design), for example redis-tower's `RedisError`. This error
+/// type deliberately wraps `std::io::Error` and does NOT derive `Clone`, so
+/// this test fails to compile if the `E: Clone` bound is reintroduced.
+#[derive(Debug)]
+struct NonCloneError {
+    #[allow(dead_code)]
+    source: std::io::Error,
+}
+
+#[tokio::test]
+async fn retries_error_without_clone_bound() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let cc = Arc::clone(&call_count);
+
+    let service = tower::service_fn(move |_req: String| {
+        let cc = Arc::clone(&cc);
+        async move {
+            cc.fetch_add(1, Ordering::SeqCst);
+            Err::<String, _>(NonCloneError {
+                source: std::io::Error::new(std::io::ErrorKind::ConnectionReset, "boom"),
+            })
+        }
+    });
+
+    let layer = RetryLayer::builder()
+        .max_attempts(3)
+        .fixed_backoff(std::time::Duration::from_millis(10))
+        .build();
+    let mut service = layer.layer(service);
+
+    let result = service
+        .ready()
+        .await
+        .unwrap()
+        .call("test".to_string())
+        .await;
+
+    // The last error is returned by value (no per-attempt clone), and every
+    // attempt ran.
+    let err = result.unwrap_err();
+    assert_eq!(err.source.kind(), std::io::ErrorKind::ConnectionReset);
+    assert_eq!(call_count.load(Ordering::SeqCst), 3);
+}


### PR DESCRIPTION
## Summary

First slice of #346. The retry `Service` impl required `E: Clone`, which blocked adopters whose error type wraps `std::io::Error` (not `Clone` by design), including redis-tower's `RedisError`.

The bound was vestigial: `call()` returns the error by value in every terminal branch and never clones it per attempt. No other bound in the retry crate (config, policy, layer, budget) requires `E: Clone`.

## Changes

- Drop `E: Clone` from the `Service<Req> for Retry` impl in `crates/tower-resilience-retry/src/lib.rs` (now `E: Send + 'static`).
- Add a regression test (`retries_error_without_clone_bound`) that drives retry with a non-`Clone` error type wrapping `std::io::Error`. The test fails to compile if the bound is reintroduced.

## Scope

This does not close #346. The remaining parts of that issue stay as follow-ups:

- Hedge: move to `Arc<E>` internally where fan-out genuinely needs shared ownership.
- Fallback: audit for the same constraint (`E: Clone` is genuinely used there today).

## Checks

Run locally against the CI gates:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test retry --all-features` (60 passed, incl. new regression test)
- `cargo test --lib -p tower-resilience-retry --all-features`
- `cargo test --doc -p tower-resilience-retry --all-features`
- MSRV: `cargo +1.85.0 check -p tower-resilience --all-features`
- Docs: `RUSTDOCFLAGS="-D warnings" cargo doc -p tower-resilience-retry --all-features --no-deps`
- Contract-lints: clone-in-call check clean

Refs #346