### PR TITLE
ci: stop dependabot bumping dtolnay/rust-toolchain toolchain pin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,9 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+    ignore:
+      # dtolnay/rust-toolchain is pinned to a Rust toolchain VERSION tag
+      # (e.g. @1.85.0), not an action release. Dependabot's github-actions
+      # updater misreads the tag and proposes bumps like 1.85.0 -> 1.100.0,
+      # which fail the MSRV CI job because that Rust version does not exist.
+      - dependency-name: "dtolnay/rust-toolchain"


### PR DESCRIPTION
## Problem

`dtolnay/rust-toolchain` is pinned in the workflows to a Rust toolchain **version** tag (e.g. `@1.85.0`), not to an action release. Dependabot's github-actions updater reads that tag as if it were an action version and opens bumps such as `1.85.0 -> 1.100.0` (see PR #348). Those PRs fail the MSRV CI job because the proposed Rust version does not exist.

## Change

Add an `ignore` entry for `dependency-name: "dtolnay/rust-toolchain"` to the github-actions block of `.github/dependabot.yml`, so dependabot stops opening these false-positive PRs. A comment records why.

This does not touch PR #348 itself; that stale PR should be closed separately by a maintainer.

## Scope

CI configuration only, no Rust code changed. YAML validated locally.