### PR TITLE
feat(fallback): relax E: Clone bound on Service impl

### DIFF
--- a/crates/tower-resilience-fallback/src/lib.rs
+++ b/crates/tower-resilience-fallback/src/lib.rs
@@ -267,7 +267,7 @@ where
     S::Future: Send + 'static,
     Req: Clone + Send + Sync + 'static,
     Res: Clone + Send + Sync + 'static,
-    E: Clone + Send + Sync + 'static,
+    E: Send + Sync + 'static,
 {
     type Response = Res;
     type Error = FallbackError<E>;
@@ -898,5 +898,53 @@ mod tests {
         let recorded = events.lock().unwrap();
         assert!(recorded.contains(&"failed_attempt".to_string()));
         assert!(recorded.contains(&"applied".to_string()));
+    }
+
+    // Regression: the Fallback Service impl must not require `E: Clone`. The
+    // error is only ever used by reference or moved once, never cloned, so a
+    // non-Clone error type must work end to end. This fails to compile if the
+    // `E: Clone` bound is reintroduced on the Service impl.
+    #[derive(Debug)]
+    struct NonCloneError(String);
+
+    #[tokio::test]
+    async fn works_with_non_clone_error() {
+        // Fallback applied: the error is consumed by reference (from_error).
+        let service = service_fn(|_req: String| async move {
+            Err::<String, _>(NonCloneError("boom".to_string()))
+        });
+        let layer =
+            FallbackLayer::<String, String, NonCloneError>::from_error(|e: &NonCloneError| {
+                format!("recovered: {}", e.0)
+            });
+        let mut service = layer.layer(service);
+        let response = service
+            .ready()
+            .await
+            .unwrap()
+            .call("test".to_string())
+            .await
+            .unwrap();
+        assert_eq!(response, "recovered: boom");
+
+        // Error propagated: the original error is moved into FallbackError::Inner.
+        let service = service_fn(|_req: String| async move {
+            Err::<String, _>(NonCloneError("permanent".to_string()))
+        });
+        let layer = FallbackLayer::builder()
+            .value("unused".to_string())
+            .handle(|_e: &NonCloneError| false) // never handle -> propagate original
+            .build();
+        let mut service = layer.layer(service);
+        let result = service
+            .ready()
+            .await
+            .unwrap()
+            .call("test".to_string())
+            .await;
+        match result {
+            Err(FallbackError::Inner(e)) => assert_eq!(e.0, "permanent"),
+            _ => panic!("expected original error to propagate"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

Removes the vestigial `E: Clone` bound from the `Fallback` `Service` impl in `crates/tower-resilience-fallback/src/lib.rs`, relaxing it to `E: Send + Sync + 'static`. This lets non-Clone error types compose with the fallback layer.

The error value is never cloned in `Service::call`. It is only:
- used by reference: the `handle` predicate, `from_error`, and `from_request_error` all take `&E`;
- moved exactly once at a terminal return: `FallbackError::Inner(error)` and the `Exception` transform.

Every `.clone()` in the call body is on `config.name` (a `String`), not on the error. The struct's own `Clone` impl already requires only `S: Clone + Res: Clone`, not `E: Clone`.

## Changes

- `Service` impl `where` clause: `E: Clone + Send + Sync + 'static` -> `E: Send + Sync + 'static`.
- New regression test `works_with_non_clone_error` using a `NonCloneError` type (no `Clone` derive), covering both the fallback-applied path (error consumed by reference via `from_error`) and the error-propagated path (error moved into `FallbackError::Inner`). Fails to compile if the bound is reintroduced.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p tower-resilience-fallback --all-features` (unit, contract, doctests)
- `cargo clippy -p tower-resilience-fallback --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p tower-resilience-fallback --all-features --no-deps`
- `cargo +1.85.0 check -p tower-resilience --all-features` (MSRV)
- source contract lints: clean

## Context

Part of #346. This is the fallback slice, mirroring the retry slice in #350. The hedge case is distinct (it needs an `Arc<E>` restructure for fan-out) and remains a separate follow-up.

Left as a draft pending review.