### PR TITLE
feat(circuitbreaker,outlier): add failure_classifier_type builder method

### DIFF
--- a/crates/tower-resilience-circuitbreaker/src/config.rs
+++ b/crates/tower-resilience-circuitbreaker/src/config.rs
@@ -423,6 +423,77 @@ impl<C> CircuitBreakerConfigBuilder<C> {
         }
     }
 
+    /// Sets a custom failure classifier instance.
+    ///
+    /// Unlike [`failure_classifier`](Self::failure_classifier), which wraps a
+    /// closure in an [`FnClassifier`], this accepts any value that implements
+    /// [`FailureClassifier`](crate::FailureClassifier). Use it for a named
+    /// classifier type that carries its own configuration (error-kind
+    /// allowlists, thresholds) and can be reused across breakers.
+    ///
+    /// No trait bound is required at the builder stage: the builder is generic
+    /// over its classifier slot, and the response/error types are unknowable at
+    /// configuration time. The `C: FailureClassifier<Res, Err>` bound is checked
+    /// where it already lives for [`FnClassifier`], at the point the layer wraps
+    /// a concrete service.
+    ///
+    /// # The polymorphic pattern: a blanket impl over the response type
+    ///
+    /// Implement [`FailureClassifier`](crate::FailureClassifier) over **all**
+    /// response types, pinning only the concrete error type. One classifier
+    /// value then serves every `Service<Cmd>` in a polymorphic stack, with no
+    /// type erasure. This mirrors [`DefaultClassifier`](crate::DefaultClassifier),
+    /// which is blanket over both `Res` and `Err`.
+    ///
+    /// ```rust
+    /// use tower_resilience_circuitbreaker::{CircuitBreakerLayer, FailureClassifier};
+    ///
+    /// // A Redis error type carrying enough detail to separate infrastructure
+    /// // failures from user-level ones.
+    /// # #[derive(Debug)]
+    /// struct RedisError {
+    ///     connection: bool,
+    ///     timeout: bool,
+    /// }
+    /// # impl RedisError {
+    /// #     fn is_connection(&self) -> bool { self.connection }
+    /// #     fn is_timeout(&self) -> bool { self.timeout }
+    /// # }
+    ///
+    /// // A named classifier. The blanket impl over `Res` means one value works
+    /// // for every command's response type against a `RedisError`.
+    /// struct RedisFailureClassifier;
+    ///
+    /// impl<Res> FailureClassifier<Res, RedisError> for RedisFailureClassifier {
+    ///     fn classify(&self, result: &Result<Res, RedisError>) -> bool {
+    ///         // WRONGTYPE/MOVED/ASK are user-level, not infrastructure failures.
+    ///         matches!(result, Err(e) if e.is_connection() || e.is_timeout())
+    ///     }
+    /// }
+    ///
+    /// let layer = CircuitBreakerLayer::builder()
+    ///     .failure_classifier_type(RedisFailureClassifier)
+    ///     .build();
+    /// ```
+    pub fn failure_classifier_type<C2>(self, classifier: C2) -> CircuitBreakerConfigBuilder<C2> {
+        CircuitBreakerConfigBuilder {
+            failure_rate_threshold: self.failure_rate_threshold,
+            sliding_window_type: self.sliding_window_type,
+            sliding_window_size: self.sliding_window_size,
+            sliding_window_duration: self.sliding_window_duration,
+            wait_duration_in_open: self.wait_duration_in_open,
+            permitted_calls_in_half_open: self.permitted_calls_in_half_open,
+            failure_classifier: classifier,
+            minimum_number_of_calls: self.minimum_number_of_calls,
+            slow_call_duration_threshold: self.slow_call_duration_threshold,
+            slow_call_rate_threshold: self.slow_call_rate_threshold,
+            failure_model: self.failure_model,
+            event_listeners: self.event_listeners,
+            name: self.name,
+            backpressure: self.backpressure,
+        }
+    }
+
     /// Sets a response-based failure classifier.
     ///
     /// This is a convenience method for services where errors are encoded in the response

--- a/crates/tower-resilience-circuitbreaker/src/layer.rs
+++ b/crates/tower-resilience-circuitbreaker/src/layer.rs
@@ -1,5 +1,5 @@
 use crate::circuit::Circuit;
-use crate::classifier::{DefaultClassifier, FnClassifier};
+use crate::classifier::DefaultClassifier;
 use crate::config::CircuitBreakerConfig;
 use crate::CircuitBreaker;
 use std::sync::Arc;
@@ -254,18 +254,14 @@ impl CircuitBreakerLayer<DefaultClassifier> {
     }
 }
 
-// Implement Layer<S> for DefaultClassifier - works with any service
-impl<S> Layer<S> for CircuitBreakerLayer<DefaultClassifier> {
-    type Service = CircuitBreaker<S, DefaultClassifier>;
-
-    fn layer(&self, service: S) -> Self::Service {
-        self.make_service(service)
-    }
-}
-
-// Implement Layer<S> for FnClassifier - the classifier determines compatible services
-impl<S, F> Layer<S> for CircuitBreakerLayer<FnClassifier<F>> {
-    type Service = CircuitBreaker<S, FnClassifier<F>>;
+// Implement Layer<S> for any classifier type `C`. Layering itself places no
+// constraint on the classifier; which services the resulting `CircuitBreaker`
+// can serve is decided by the `C: FailureClassifier<Res, Err>` bound on the
+// `Service` impl, at the point the concrete service is wrapped. This covers
+// `DefaultClassifier`, `FnClassifier<F>`, and any named classifier passed to
+// `failure_classifier_type`.
+impl<S, C> Layer<S> for CircuitBreakerLayer<C> {
+    type Service = CircuitBreaker<S, C>;
 
     fn layer(&self, service: S) -> Self::Service {
         self.make_service(service)

--- a/crates/tower-resilience-circuitbreaker/src/lib.rs
+++ b/crates/tower-resilience-circuitbreaker/src/lib.rs
@@ -1356,4 +1356,96 @@ mod tests {
         assert_eq!(permitted_count.load(std::sync::atomic::Ordering::SeqCst), 3);
         assert_eq!(rejected_count.load(std::sync::atomic::Ordering::SeqCst), 0);
     }
+
+    // A named error type standing in for an infrastructure client error.
+    #[derive(Debug)]
+    struct RedisError {
+        connection: bool,
+    }
+
+    impl RedisError {
+        fn is_connection(&self) -> bool {
+            self.connection
+        }
+    }
+
+    // A named classifier carrying no config here, but with a blanket impl over
+    // the response type `Res`: one value classifies for every command's
+    // response type against a `RedisError`.
+    struct RedisFailureClassifier;
+
+    impl<Res> FailureClassifier<Res, RedisError> for RedisFailureClassifier {
+        fn classify(&self, result: &Result<Res, RedisError>) -> bool {
+            matches!(result, Err(e) if e.is_connection())
+        }
+    }
+
+    #[tokio::test]
+    async fn failure_classifier_type_trips_and_recovers() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use tower::{Service, ServiceExt};
+
+        // Service fails with a connection error until flipped healthy.
+        let healthy = Arc::new(AtomicBool::new(false));
+        let h = Arc::clone(&healthy);
+        let service = tower::service_fn(move |_req: String| {
+            let h = Arc::clone(&h);
+            async move {
+                if h.load(Ordering::SeqCst) {
+                    Ok::<String, RedisError>("ok".to_string())
+                } else {
+                    Err(RedisError { connection: true })
+                }
+            }
+        });
+
+        let layer = CircuitBreakerLayer::builder()
+            .consecutive_failures(3)
+            .wait_duration_in_open(Duration::from_millis(50))
+            .permitted_calls_in_half_open(1)
+            .failure_classifier_type(RedisFailureClassifier)
+            .build();
+
+        let mut service = tower::ServiceBuilder::new().layer(layer).service(service);
+
+        // Three consecutive connection failures trip the breaker. Each call
+        // still surfaces the inner error.
+        for _ in 0..3 {
+            let res = service.ready().await.unwrap().call("cmd".to_string()).await;
+            assert!(matches!(res, Err(CircuitBreakerError::Inner(_))));
+        }
+
+        // Circuit is now open: the next call is rejected without reaching the
+        // service.
+        let rejected = service.ready().await.unwrap().call("cmd".to_string()).await;
+        assert!(matches!(rejected, Err(CircuitBreakerError::OpenCircuit)));
+
+        // Recover: make the service healthy and let the open duration elapse.
+        healthy.store(true, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(60)).await;
+
+        // Half-open permits a probe; the successful probe closes the circuit.
+        let recovered = service.ready().await.unwrap().call("cmd".to_string()).await;
+        assert!(recovered.is_ok());
+        assert_eq!(recovered.unwrap(), "ok");
+    }
+
+    #[test]
+    fn failure_classifier_type_one_instance_serves_two_response_types() {
+        // Compile-level assertion: a single classifier value satisfies
+        // `FailureClassifier` for two different response types, because the impl
+        // is blanket over `Res`.
+        fn assert_serves<C>(c: &C)
+        where
+            C: FailureClassifier<String, RedisError> + FailureClassifier<u64, RedisError>,
+        {
+            assert!(FailureClassifier::<String, RedisError>::classify(
+                c,
+                &Err(RedisError { connection: true })
+            ));
+            assert!(!FailureClassifier::<u64, RedisError>::classify(c, &Ok(7)));
+        }
+
+        assert_serves(&RedisFailureClassifier);
+    }
 }

--- a/crates/tower-resilience-outlier/src/config.rs
+++ b/crates/tower-resilience-outlier/src/config.rs
@@ -109,6 +109,73 @@ impl<C> OutlierDetectionConfigBuilder<C> {
         self
     }
 
+    /// Sets a custom failure classifier instance.
+    ///
+    /// Unlike [`failure_classifier`](OutlierDetectionConfigBuilder::failure_classifier),
+    /// which wraps a closure in an [`FnClassifier`], this accepts any value that
+    /// implements [`FailureClassifier`](crate::FailureClassifier). Use it for a named classifier type that
+    /// carries its own configuration (error-kind allowlists, thresholds) and can
+    /// be reused across instances.
+    ///
+    /// No trait bound is required at the builder stage: the builder is generic
+    /// over its classifier slot, and the response/error types are unknowable at
+    /// configuration time. The `C: FailureClassifier<Res, Err>` bound is checked
+    /// where it already lives for [`FnClassifier`], at the point the layer wraps
+    /// a concrete service.
+    ///
+    /// # The polymorphic pattern: a blanket impl over the response type
+    ///
+    /// Implement [`FailureClassifier`](crate::FailureClassifier) over **all** response types, pinning only
+    /// the concrete error type. One classifier value then serves every
+    /// `Service<Cmd>` in a polymorphic stack, with no type erasure. This mirrors
+    /// [`DefaultClassifier`], which is blanket over both `Res` and `Err`.
+    ///
+    /// ```
+    /// use tower_resilience_outlier::{OutlierDetectionLayer, OutlierDetector, FailureClassifier};
+    ///
+    /// // A Redis error type carrying enough detail to separate infrastructure
+    /// // failures from user-level ones.
+    /// # #[derive(Debug)]
+    /// struct RedisError {
+    ///     connection: bool,
+    ///     timeout: bool,
+    /// }
+    /// # impl RedisError {
+    /// #     fn is_connection(&self) -> bool { self.connection }
+    /// #     fn is_timeout(&self) -> bool { self.timeout }
+    /// # }
+    ///
+    /// // A named classifier. The blanket impl over `Res` means one value works
+    /// // for every command's response type against a `RedisError`. `Clone` lets
+    /// // the layer clone the config into each service it wraps.
+    /// #[derive(Clone)]
+    /// struct RedisFailureClassifier;
+    ///
+    /// impl<Res> FailureClassifier<Res, RedisError> for RedisFailureClassifier {
+    ///     fn classify(&self, result: &Result<Res, RedisError>) -> bool {
+    ///         // WRONGTYPE/MOVED/ASK are user-level, not infrastructure failures.
+    ///         matches!(result, Err(e) if e.is_connection() || e.is_timeout())
+    ///     }
+    /// }
+    ///
+    /// let detector = OutlierDetector::new();
+    /// detector.register("backend-1", 5);
+    ///
+    /// let layer = OutlierDetectionLayer::builder()
+    ///     .detector(detector)
+    ///     .instance_name("backend-1")
+    ///     .failure_classifier_type(RedisFailureClassifier)
+    ///     .build();
+    /// ```
+    pub fn failure_classifier_type<C2>(self, classifier: C2) -> OutlierDetectionConfigBuilder<C2> {
+        OutlierDetectionConfigBuilder {
+            detector: self.detector,
+            instance_name: self.instance_name,
+            classifier,
+            backpressure: self.backpressure,
+        }
+    }
+
     /// Builds the `OutlierDetectionLayer`.
     ///
     /// # Panics

--- a/crates/tower-resilience-outlier/src/layer.rs
+++ b/crates/tower-resilience-outlier/src/layer.rs
@@ -3,7 +3,7 @@
 use crate::config::{OutlierDetectionConfig, OutlierDetectionConfigBuilder};
 use crate::service::OutlierDetectionService;
 use tower::Layer;
-use tower_resilience_core::classifier::{DefaultClassifier, FnClassifier};
+use tower_resilience_core::classifier::DefaultClassifier;
 
 /// A Tower Layer that applies outlier detection behavior to an inner service.
 ///
@@ -50,19 +50,17 @@ impl OutlierDetectionLayer<DefaultClassifier> {
     }
 }
 
-impl<S> Layer<S> for OutlierDetectionLayer<DefaultClassifier> {
-    type Service = OutlierDetectionService<S, DefaultClassifier>;
-
-    fn layer(&self, service: S) -> Self::Service {
-        OutlierDetectionService::new(service, self.config.clone())
-    }
-}
-
-impl<S, F> Layer<S> for OutlierDetectionLayer<FnClassifier<F>>
+// Implement Layer<S> for any classifier type `C`. The `C: Clone` bound is only
+// needed to clone the config into the service; which services the resulting
+// `OutlierDetectionService` can serve is decided by the classifier's
+// `FailureClassifier<Res, Err>` impl at the wrap point. This covers
+// `DefaultClassifier`, `FnClassifier<F>`, and any named classifier passed to
+// `failure_classifier_type`.
+impl<S, C> Layer<S> for OutlierDetectionLayer<C>
 where
-    F: Clone,
+    C: Clone,
 {
-    type Service = OutlierDetectionService<S, FnClassifier<F>>;
+    type Service = OutlierDetectionService<S, C>;
 
     fn layer(&self, service: S) -> Self::Service {
         OutlierDetectionService::new(service, self.config.clone())

--- a/crates/tower-resilience-outlier/src/lib.rs
+++ b/crates/tower-resilience-outlier/src/lib.rs
@@ -82,3 +82,4 @@ pub use events::OutlierDetectionEvent;
 pub use layer::OutlierDetectionLayer;
 pub use service::OutlierDetectionService;
 pub use strategy::{ConsecutiveErrors, EjectionStrategy};
+pub use tower_resilience_core::classifier::{DefaultClassifier, FailureClassifier, FnClassifier};

--- a/crates/tower-resilience-outlier/src/service.rs
+++ b/crates/tower-resilience-outlier/src/service.rs
@@ -184,4 +184,78 @@ mod tests {
         assert!(resp.is_err());
         assert!(resp.unwrap_err().is_outlier_detection());
     }
+
+    // A named error type standing in for an infrastructure client error.
+    #[derive(Debug)]
+    struct RedisError {
+        connection: bool,
+    }
+
+    impl RedisError {
+        fn is_connection(&self) -> bool {
+            self.connection
+        }
+    }
+
+    // A named classifier with a blanket impl over the response type `Res`: one
+    // value classifies for every command's response type against a `RedisError`.
+    // `Clone` is required by the outlier `Layer` impl to clone the config.
+    #[derive(Clone)]
+    struct RedisFailureClassifier;
+
+    impl<Res> crate::FailureClassifier<Res, RedisError> for RedisFailureClassifier {
+        fn classify(&self, result: &Result<Res, RedisError>) -> bool {
+            matches!(result, Err(e) if e.is_connection())
+        }
+    }
+
+    #[tokio::test]
+    async fn failure_classifier_type_ejects_on_classified_failure() {
+        let detector = OutlierDetector::new().max_ejection_percent(100);
+        detector.register("backend-1", 1);
+
+        // Service always fails with a connection error the classifier counts.
+        let fail_svc = tower::service_fn(|_req: String| async {
+            Err::<String, RedisError>(RedisError { connection: true })
+        });
+        let boxed = tower::util::BoxCloneService::new(fail_svc);
+        let layer = crate::OutlierDetectionLayer::builder()
+            .detector(detector)
+            .instance_name("backend-1")
+            .error_on_ejection()
+            .failure_classifier_type(RedisFailureClassifier)
+            .build();
+        let mut svc = tower::Layer::layer(&layer, boxed);
+
+        // First call fails (inner error) and triggers ejection.
+        let resp = svc.ready().await.unwrap().call("cmd".to_string()).await;
+        assert!(resp.is_err());
+        assert!(resp.unwrap_err().is_inner());
+
+        // Second call is rejected by outlier detection.
+        let resp = svc.ready().await.unwrap().call("cmd".to_string()).await;
+        assert!(resp.is_err());
+        assert!(resp.unwrap_err().is_outlier_detection());
+    }
+
+    #[test]
+    fn failure_classifier_type_one_instance_serves_two_response_types() {
+        use crate::FailureClassifier;
+
+        // Compile-level assertion: a single classifier value satisfies
+        // `FailureClassifier` for two different response types, because the impl
+        // is blanket over `Res`.
+        fn assert_serves<C>(c: &C)
+        where
+            C: FailureClassifier<String, RedisError> + FailureClassifier<u64, RedisError>,
+        {
+            assert!(FailureClassifier::<String, RedisError>::classify(
+                c,
+                &Err(RedisError { connection: true })
+            ));
+            assert!(!FailureClassifier::<u64, RedisError>::classify(c, &Ok(7)));
+        }
+
+        assert_serves(&RedisFailureClassifier);
+    }
 }

--- a/tests/outlier/integration.rs
+++ b/tests/outlier/integration.rs
@@ -110,55 +110,61 @@ async fn auto_recovery_after_ejection_duration() {
 
 #[tokio::test]
 async fn exponential_backoff_on_repeated_ejections() {
+    // Durations are deliberately generous (100ms base) so that scheduler
+    // jitter on loaded CI runners does not push a real-clock sleep past the
+    // ejection window and flake the assertions. See is_ejected, which measures
+    // elapsed time with std::time::Instant (not tokio virtual time).
     let detector = OutlierDetector::new()
-        .base_ejection_duration(Duration::from_millis(50))
+        .base_ejection_duration(Duration::from_millis(100))
         .max_ejection_percent(100);
     detector.register("backend-1", 1);
 
-    // First ejection: 50ms
+    // First ejection: 100ms
     assert!(detector.record_failure("backend-1"));
     assert!(detector.is_ejected("backend-1"));
 
-    // Wait for recovery
-    tokio::time::sleep(Duration::from_millis(60)).await;
+    // Wait past the 100ms window for recovery
+    tokio::time::sleep(Duration::from_millis(160)).await;
     assert!(!detector.is_ejected("backend-1"));
 
-    // Second ejection: 100ms (50 * 2^1)
+    // Second ejection: 200ms (100 * 2^1)
     assert!(detector.record_failure("backend-1"));
     assert!(detector.is_ejected("backend-1"));
 
-    // After 60ms, still ejected (needs 100ms)
-    tokio::time::sleep(Duration::from_millis(60)).await;
+    // After 100ms, still ejected (needs 200ms)
+    tokio::time::sleep(Duration::from_millis(100)).await;
     assert!(detector.is_ejected("backend-1"));
 
-    // After total 110ms, recovered
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    // After total ~260ms, recovered
+    tokio::time::sleep(Duration::from_millis(160)).await;
     assert!(!detector.is_ejected("backend-1"));
 }
 
 #[tokio::test]
 async fn max_ejection_duration_caps_backoff() {
+    // Generous 100ms base / 200ms cap so real-clock sleeps stay comfortably
+    // inside each window despite CI scheduler jitter (see is_ejected).
     let detector = OutlierDetector::new()
-        .base_ejection_duration(Duration::from_millis(50))
-        .max_ejection_duration(Duration::from_millis(100))
+        .base_ejection_duration(Duration::from_millis(100))
+        .max_ejection_duration(Duration::from_millis(200))
         .max_ejection_percent(100);
     detector.register("backend-1", 1);
 
-    // First ejection: 50ms
+    // First ejection: 100ms
     detector.record_failure("backend-1");
-    tokio::time::sleep(Duration::from_millis(60)).await;
+    tokio::time::sleep(Duration::from_millis(160)).await;
     assert!(!detector.is_ejected("backend-1"));
 
-    // Second ejection: 100ms (50 * 2, capped at 100)
+    // Second ejection: 200ms (100 * 2, capped at 200)
     detector.record_failure("backend-1");
-    tokio::time::sleep(Duration::from_millis(60)).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
     assert!(detector.is_ejected("backend-1"));
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    tokio::time::sleep(Duration::from_millis(160)).await;
     assert!(!detector.is_ejected("backend-1"));
 
-    // Third ejection: still 100ms (50 * 4 = 200, capped at 100)
+    // Third ejection: still 200ms (100 * 4 = 400, capped at 200)
     detector.record_failure("backend-1");
-    tokio::time::sleep(Duration::from_millis(110)).await;
+    tokio::time::sleep(Duration::from_millis(260)).await;
     assert!(!detector.is_ejected("backend-1"));
 }
 


### PR DESCRIPTION
## Summary

Closes #347. Adds `failure_classifier_type<C>(self, classifier: C)` to the circuit breaker and outlier-detection builders, per the maintainer's design comment on the issue.

Unlike `failure_classifier`, which wraps a closure in an `FnClassifier`, this accepts any value that implements `FailureClassifier`. Named classifier types that carry their own configuration (error-kind allowlists, thresholds) can now be reused across breakers and instances.

```rust
struct RedisFailureClassifier;

impl<Res> FailureClassifier<Res, RedisError> for RedisFailureClassifier {
    fn classify(&self, result: &Result<Res, RedisError>) -> bool {
        matches!(result, Err(e) if e.is_connection() || e.is_timeout())
    }
}

let layer = CircuitBreakerLayer::builder()
    .failure_classifier_type(RedisFailureClassifier)
    .build();
```

## Design

- No trait bound at the builder stage. The builder is generic over its classifier slot, and the response/error types are unknowable at configuration time. The `C: FailureClassifier<Res, Err>` bound stays where it already lives for `FnClassifier`, at the point the layer wraps a concrete service.
- The polymorphic story is the blanket impl, and the method docs present it as the pattern: implement `FailureClassifier` over all response types, pinned to a concrete error type, so one classifier value serves every `Service<Cmd>` in a stack with no type erasure. This mirrors `DefaultClassifier`.

## Plumbing

To make an arbitrary classifier type usable end to end:

- The `Layer` impls for `CircuitBreakerLayer<C>` and `OutlierDetectionLayer<C>` are generalized from the `DefaultClassifier` / `FnClassifier<F>` pair to a single blanket impl over `C`. The outlier impl keeps the `C: Clone` bound it needs to clone the config into each service. The previous specific impls are subsumed, so `DefaultClassifier` and `FnClassifier<F>` behavior is unchanged.
- The outlier crate now re-exports `FailureClassifier`, `DefaultClassifier`, and `FnClassifier` from its root, matching the circuit breaker crate, so callers can name the trait to implement without depending on `tower-resilience-core` directly.

## Tests

- Circuit breaker: a named classifier driven through the full layer that trips (three consecutive classified connection failures) and recovers (half-open probe closes the circuit).
- Outlier: a named classifier driven through the full layer that ejects on a classified failure and rejects the following call.
- Both crates: a compile-level assertion that one classifier instance serves two different response types via the blanket impl.

## Checks

`cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`, `cargo test --workspace --all-features` (incl. doctests), `cargo build --examples`, MSRV `cargo check -p tower-resilience --all-features` on 1.85.0, the contract-lints grep, `cargo doc` with `-D warnings`, and `cargo audit` all pass locally.