### PR TITLE
test: add Tower contract harness

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,6 +188,14 @@ The contract says `Ready(Err(_))` from `poll_ready` means the service is done an
 
 `tests/clone_in_call_contract.rs` wraps each layer around a `StatefulInner` whose `Clone` resets readiness. A new layer should add a `<layer>_drives_readied_instance` case to that suite.
 
+For retry paths, cancellation, wake behavior, admission boundaries, and
+response/error preservation, compose the reusable `ServiceProbe` and
+`ControlledService` from `tower_resilience_core::testing`. The current coverage
+and known gaps are tracked in [`docs/tower-contract-matrix.md`](docs/tower-contract-matrix.md).
+When reviewing a new or changed `Service` implementation, paste and complete
+the [`Tower service review checklist`](docs/tower-service-review-checklist.md)
+in the pull request.
+
 `tests/auto_traits.rs` asserts every layer is `Send + Sync + 'static` when its inner is. New layers should be added there too -- a regression that drops `Sync` (e.g., storing a `Pin<Box<dyn Future + Send>>` field) fails to compile there. See #287.
 
 ### Testing

--- a/crates/tower-resilience-core/Cargo.toml
+++ b/crates/tower-resilience-core/Cargo.toml
@@ -29,7 +29,7 @@ tracing = ["dep:tracing"]
 metrics = ["dep:metrics"]
 # Enable HealthTriggerable trait for health-based pattern control
 health-integration = []
-# Expose test helpers (StatefulInner probe). Intended for dev-dependencies only.
+# Expose adversarial Tower contract probes. Intended for dev-dependencies only.
 testing = ["dep:tower"]
 
 [dev-dependencies]

--- a/crates/tower-resilience-core/src/testing.rs
+++ b/crates/tower-resilience-core/src/testing.rs
@@ -17,10 +17,12 @@
 //! Tests that wrap a layer around `tower::service_fn` or a `MockService` style
 //! probe never exercise this -- those inners have no-op `poll_ready` and no
 //! per-instance readiness state, so the contract violation is invisible. The
-//! `StatefulInner` probe in this module deliberately resets its `ready` flag
-//! on `Clone`, mirroring how `tower::limit::ConcurrencyLimit`, `Buffer`,
-//! `LoadShed`, and other stateful tower middleware behave in production. Any
-//! regression to the clone-in-call anti-pattern (see #286) panics here.
+//! The probes in this module deliberately reset per-instance readiness on
+//! `Clone`, mirroring how `tower::limit::ConcurrencyLimit`, `Buffer`,
+//! `LoadShed`, and other stateful tower middleware behave in production.
+//! `StatefulInner` remains the minimal panic-on-violation probe;
+//! `ServiceProbe` and `ControlledService` add observations and deterministic
+//! control for multi-attempt and concurrent paths.
 //!
 //! # Example
 //!
@@ -45,7 +47,405 @@
 
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
+
+/// A snapshot of the observations made by a [`ServiceProbe`].
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ProbeSnapshot {
+    /// Number of times the probe was cloned.
+    pub clones: usize,
+    /// Number of calls to [`tower::Service::poll_ready`].
+    pub readiness_polls: usize,
+    /// Number of readiness polls that returned `Ready(Ok(()))`.
+    pub readiness_successes: usize,
+    /// Number of readiness polls that returned `Pending`.
+    pub readiness_pending: usize,
+    /// Number of readiness polls that returned `Ready(Err(_))`.
+    pub readiness_errors: usize,
+    /// Number of calls to [`tower::Service::call`].
+    pub calls: usize,
+    /// Calls made without readiness obtained on the same service instance.
+    pub readiness_violations: usize,
+    /// Futures currently returned by `call` and not yet completed or dropped.
+    pub in_flight: usize,
+    /// Maximum number of call futures simultaneously in flight.
+    pub peak_in_flight: usize,
+    /// Call futures that completed.
+    pub completed: usize,
+    /// Call futures dropped before completion.
+    pub cancelled: usize,
+}
+
+#[derive(Debug, Default)]
+struct ProbeState {
+    clones: AtomicUsize,
+    readiness_polls: AtomicUsize,
+    readiness_successes: AtomicUsize,
+    readiness_pending: AtomicUsize,
+    readiness_errors: AtomicUsize,
+    calls: AtomicUsize,
+    readiness_violations: AtomicUsize,
+    in_flight: AtomicUsize,
+    peak_in_flight: AtomicUsize,
+    completed: AtomicUsize,
+    cancelled: AtomicUsize,
+}
+
+/// Shared observations for a [`ServiceProbe`] and all of its clones.
+#[derive(Clone, Debug, Default)]
+pub struct ProbeHandle {
+    state: Arc<ProbeState>,
+}
+
+impl ProbeHandle {
+    /// Loads the current value of every observation counter.
+    ///
+    /// Each counter is atomic, but concurrent activity may advance some
+    /// counters while the snapshot is being assembled. Quiesce the service
+    /// before asserting relationships between counters.
+    pub fn snapshot(&self) -> ProbeSnapshot {
+        ProbeSnapshot {
+            clones: self.state.clones.load(Ordering::SeqCst),
+            readiness_polls: self.state.readiness_polls.load(Ordering::SeqCst),
+            readiness_successes: self.state.readiness_successes.load(Ordering::SeqCst),
+            readiness_pending: self.state.readiness_pending.load(Ordering::SeqCst),
+            readiness_errors: self.state.readiness_errors.load(Ordering::SeqCst),
+            calls: self.state.calls.load(Ordering::SeqCst),
+            readiness_violations: self.state.readiness_violations.load(Ordering::SeqCst),
+            in_flight: self.state.in_flight.load(Ordering::SeqCst),
+            peak_in_flight: self.state.peak_in_flight.load(Ordering::SeqCst),
+            completed: self.state.completed.load(Ordering::SeqCst),
+            cancelled: self.state.cancelled.load(Ordering::SeqCst),
+        }
+    }
+
+    /// Panics if any call bypassed readiness on its exact service instance.
+    ///
+    /// Keeping the assertion on the handle allows a test to observe all
+    /// attempts before failing, including attempts running in spawned tasks.
+    pub fn assert_ready_contract(&self) {
+        let snapshot = self.snapshot();
+        assert_eq!(
+            snapshot.readiness_violations, 0,
+            "{} Service::call invocation(s) occurred without prior poll_ready on the same instance",
+            snapshot.readiness_violations
+        );
+    }
+
+    /// Panics if any returned call future is still alive.
+    pub fn assert_quiescent(&self) {
+        let snapshot = self.snapshot();
+        assert_eq!(
+            snapshot.in_flight, 0,
+            "{} call future(s) still in flight",
+            snapshot.in_flight
+        );
+    }
+}
+
+/// A composable [`tower::Service`] contract probe.
+///
+/// The probe delegates responses and errors unchanged while recording
+/// readiness, clone, concurrency, completion, and cancellation behavior. Its
+/// [`Clone`] implementation deliberately resets per-instance readiness. This
+/// makes it suitable for retry, reconnect, hedge, and router paths that create
+/// additional service instances internally.
+///
+/// Unlike [`StatefulInner`], a readiness violation is recorded rather than
+/// panicking immediately. Call [`ProbeHandle::assert_ready_contract`] after
+/// the operation so violations in spawned attempts are reported reliably.
+pub struct ServiceProbe<S> {
+    inner: S,
+    ready: bool,
+    handle: ProbeHandle,
+}
+
+impl<S> ServiceProbe<S> {
+    /// Wraps `inner` in a new probe.
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+            ready: false,
+            handle: ProbeHandle::default(),
+        }
+    }
+
+    /// Returns a handle shared with this probe and all future clones.
+    pub fn handle(&self) -> ProbeHandle {
+        self.handle.clone()
+    }
+
+    /// Returns the wrapped service.
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
+}
+
+impl<S> Clone for ServiceProbe<S>
+where
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        self.handle.state.clones.fetch_add(1, Ordering::SeqCst);
+        Self {
+            inner: self.inner.clone(),
+            ready: false,
+            handle: self.handle.clone(),
+        }
+    }
+}
+
+impl<S, Request> tower::Service<Request> for ServiceProbe<S>
+where
+    S: tower::Service<Request>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ProbeFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.handle
+            .state
+            .readiness_polls
+            .fetch_add(1, Ordering::SeqCst);
+
+        match self.inner.poll_ready(cx) {
+            Poll::Ready(Ok(())) => {
+                self.ready = true;
+                self.handle
+                    .state
+                    .readiness_successes
+                    .fetch_add(1, Ordering::SeqCst);
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Err(error)) => {
+                self.ready = false;
+                self.handle
+                    .state
+                    .readiness_errors
+                    .fetch_add(1, Ordering::SeqCst);
+                Poll::Ready(Err(error))
+            }
+            Poll::Pending => {
+                self.handle
+                    .state
+                    .readiness_pending
+                    .fetch_add(1, Ordering::SeqCst);
+                Poll::Pending
+            }
+        }
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        self.handle.state.calls.fetch_add(1, Ordering::SeqCst);
+        if !std::mem::take(&mut self.ready) {
+            self.handle
+                .state
+                .readiness_violations
+                .fetch_add(1, Ordering::SeqCst);
+        }
+
+        let future = self.inner.call(request);
+        let in_flight = self.handle.state.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+        self.handle
+            .state
+            .peak_in_flight
+            .fetch_max(in_flight, Ordering::SeqCst);
+
+        ProbeFuture {
+            inner: Box::pin(future),
+            state: Arc::clone(&self.handle.state),
+            finished: false,
+        }
+    }
+}
+
+/// A call future returned by [`ServiceProbe`].
+pub struct ProbeFuture<F> {
+    inner: Pin<Box<F>>,
+    state: Arc<ProbeState>,
+    finished: bool,
+}
+
+impl<F> Future for ProbeFuture<F>
+where
+    F: Future,
+{
+    type Output = F::Output;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.as_mut().get_mut();
+        match this.inner.as_mut().poll(cx) {
+            Poll::Ready(output) => {
+                this.finished = true;
+                this.state.completed.fetch_add(1, Ordering::SeqCst);
+                this.state.in_flight.fetch_sub(1, Ordering::SeqCst);
+                Poll::Ready(output)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<F> Drop for ProbeFuture<F> {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.state.cancelled.fetch_add(1, Ordering::SeqCst);
+            self.state.in_flight.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+}
+
+/// Error returned after a [`ControlledService`] is closed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ControlledServiceClosed;
+
+impl std::fmt::Display for ControlledServiceClosed {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("controlled service is closed")
+    }
+}
+
+impl std::error::Error for ControlledServiceClosed {}
+
+#[derive(Debug)]
+struct ControlledState {
+    ready: AtomicBool,
+    closed: AtomicBool,
+    calls: AtomicUsize,
+    permits: Arc<tokio::sync::Semaphore>,
+    readiness_wakers: Mutex<Vec<Waker>>,
+}
+
+/// Controller for a [`ControlledService`].
+#[derive(Clone, Debug)]
+pub struct ControlledHandle {
+    state: Arc<ControlledState>,
+}
+
+impl ControlledHandle {
+    /// Changes readiness and wakes all registered readiness waiters when open.
+    pub fn set_ready(&self, ready: bool) {
+        self.state.ready.store(ready, Ordering::SeqCst);
+        if ready {
+            self.wake_readiness_waiters();
+        }
+    }
+
+    /// Allows `count` call futures to complete.
+    pub fn allow(&self, count: usize) {
+        self.state.permits.add_permits(count);
+    }
+
+    /// Permanently closes readiness and all pending call futures.
+    pub fn close(&self) {
+        self.state.closed.store(true, Ordering::SeqCst);
+        self.state.permits.close();
+        self.wake_readiness_waiters();
+    }
+
+    /// Returns how many requests reached the controlled service.
+    pub fn calls(&self) -> usize {
+        self.state.calls.load(Ordering::SeqCst)
+    }
+
+    fn wake_readiness_waiters(&self) {
+        let waiters = std::mem::take(
+            &mut *self
+                .state
+                .readiness_wakers
+                .lock()
+                .expect("controlled service readiness lock poisoned"),
+        );
+        for waker in waiters {
+            waker.wake();
+        }
+    }
+}
+
+/// A deterministic service with externally controlled readiness and completion.
+///
+/// `poll_ready` remains pending until [`ControlledHandle::set_ready`] is called.
+/// Every accepted call then waits for one permit from [`ControlledHandle::allow`]
+/// and echoes its request unchanged. Compose this with [`ServiceProbe`] to test
+/// wakeups, clone-heavy admission, cancellation, and thundering-herd behavior
+/// without sleeps.
+#[derive(Clone, Debug)]
+pub struct ControlledService {
+    handle: ControlledHandle,
+}
+
+impl ControlledService {
+    /// Creates a service/controller pair with the requested initial readiness.
+    pub fn new(initially_ready: bool) -> (Self, ControlledHandle) {
+        let handle = ControlledHandle {
+            state: Arc::new(ControlledState {
+                ready: AtomicBool::new(initially_ready),
+                closed: AtomicBool::new(false),
+                calls: AtomicUsize::new(0),
+                permits: Arc::new(tokio::sync::Semaphore::new(0)),
+                readiness_wakers: Mutex::new(Vec::new()),
+            }),
+        };
+        (
+            Self {
+                handle: handle.clone(),
+            },
+            handle,
+        )
+    }
+}
+
+impl<Request> tower::Service<Request> for ControlledService
+where
+    Request: Send + 'static,
+{
+    type Response = Request;
+    type Error = ControlledServiceClosed;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        if self.handle.state.closed.load(Ordering::SeqCst) {
+            return Poll::Ready(Err(ControlledServiceClosed));
+        }
+        if self.handle.state.ready.load(Ordering::SeqCst) {
+            return Poll::Ready(Ok(()));
+        }
+
+        let mut waiters = self
+            .handle
+            .state
+            .readiness_wakers
+            .lock()
+            .expect("controlled service readiness lock poisoned");
+        if self.handle.state.closed.load(Ordering::SeqCst) {
+            return Poll::Ready(Err(ControlledServiceClosed));
+        }
+        if self.handle.state.ready.load(Ordering::SeqCst) {
+            return Poll::Ready(Ok(()));
+        }
+        if !waiters.iter().any(|waker| waker.will_wake(cx.waker())) {
+            waiters.push(cx.waker().clone());
+        }
+        Poll::Pending
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        self.handle.state.calls.fetch_add(1, Ordering::SeqCst);
+        let permits = Arc::clone(&self.handle.state.permits);
+        Box::pin(async move {
+            let permit = permits
+                .acquire_owned()
+                .await
+                .map_err(|_| ControlledServiceClosed)?;
+            permit.forget();
+            Ok(request)
+        })
+    }
+}
 
 /// An inner [`tower::Service`] whose [`Clone`] resets readiness state.
 ///
@@ -101,5 +501,139 @@ impl tower::Service<()> for StatefulInner {
         // The contract: call consumes readiness. Next call must re-poll.
         self.ready = false;
         Box::pin(async { Ok(()) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::convert::Infallible;
+    use tower::{service_fn, Service, ServiceExt};
+
+    #[tokio::test]
+    async fn records_and_rejects_a_readiness_violation() {
+        let mut probe = ServiceProbe::new(service_fn(|request: usize| async move {
+            Ok::<_, Infallible>(request)
+        }));
+        let handle = probe.handle();
+
+        assert_eq!(probe.call(7).await.unwrap(), 7);
+        assert_eq!(handle.snapshot().readiness_violations, 1);
+
+        let assertion = std::panic::catch_unwind(|| handle.assert_ready_contract());
+        assert!(
+            assertion.is_err(),
+            "the nonconforming call must be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn clone_does_not_inherit_readiness() {
+        let mut probe = ServiceProbe::new(service_fn(|(): ()| async { Ok::<_, Infallible>(()) }));
+        probe.ready().await.unwrap();
+        let mut clone = probe.clone();
+        let handle = clone.handle();
+
+        clone.call(()).await.unwrap();
+
+        let snapshot = handle.snapshot();
+        assert_eq!(snapshot.clones, 1);
+        assert_eq!(snapshot.readiness_violations, 1);
+    }
+
+    #[tokio::test]
+    async fn tracks_completion_cancellation_and_peak_in_flight() {
+        let (controlled, controller) = ControlledService::new(true);
+        let mut probe = ServiceProbe::new(controlled);
+        let handle = probe.handle();
+
+        let first = ServiceExt::<&'static str>::ready(&mut probe)
+            .await
+            .unwrap()
+            .call("first");
+        let cancelled = ServiceExt::<&'static str>::ready(&mut probe)
+            .await
+            .unwrap()
+            .call("cancelled");
+        drop(cancelled);
+        let second = ServiceExt::<&'static str>::ready(&mut probe)
+            .await
+            .unwrap()
+            .call("second");
+
+        controller.allow(2);
+        let (first, second) = tokio::join!(first, second);
+        assert_eq!(first.unwrap(), "first");
+        assert_eq!(second.unwrap(), "second");
+
+        let snapshot = handle.snapshot();
+        assert_eq!(snapshot.calls, 3);
+        assert_eq!(snapshot.peak_in_flight, 2);
+        assert_eq!(snapshot.completed, 2);
+        assert_eq!(snapshot.cancelled, 1);
+        handle.assert_ready_contract();
+        handle.assert_quiescent();
+    }
+
+    #[tokio::test]
+    async fn controlled_readiness_registers_and_wakes() {
+        let (controlled, controller) = ControlledService::new(false);
+        let probe = ServiceProbe::new(controlled);
+        let handle = probe.handle();
+        let task = tokio::spawn(async move {
+            let mut probe = probe;
+            ServiceExt::<()>::ready(&mut probe).await.unwrap();
+        });
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while handle.snapshot().readiness_pending == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("readiness was never polled");
+
+        controller.set_ready(true);
+        tokio::time::timeout(std::time::Duration::from_secs(1), task)
+            .await
+            .expect("registered readiness waiter was not woken")
+            .unwrap();
+        assert!(handle.snapshot().readiness_successes >= 1);
+    }
+
+    #[tokio::test]
+    async fn preserves_responses_and_readiness_errors() {
+        let (controlled, controller) = ControlledService::new(true);
+        let mut probe = ServiceProbe::new(controlled);
+        let handle = probe.handle();
+
+        let response = ServiceExt::<String>::ready(&mut probe)
+            .await
+            .unwrap()
+            .call(String::from("sentinel"));
+        controller.allow(1);
+        assert_eq!(response.await.unwrap(), "sentinel");
+
+        controller.close();
+        assert!(matches!(
+            ServiceExt::<String>::ready(&mut probe).await,
+            Err(ControlledServiceClosed)
+        ));
+        assert_eq!(handle.snapshot().readiness_errors, 1);
+    }
+
+    #[tokio::test]
+    async fn preserves_call_errors() {
+        let mut probe = ServiceProbe::new(service_fn(|(): ()| async {
+            Err::<(), _>("sentinel call error")
+        }));
+        let handle = probe.handle();
+
+        let error = probe.ready().await.unwrap().call(()).await.unwrap_err();
+
+        assert_eq!(error, "sentinel call error");
+        assert_eq!(handle.snapshot().completed, 1);
+        handle.assert_ready_contract();
+        handle.assert_quiescent();
     }
 }

--- a/docs/tower-contract-matrix.md
+++ b/docs/tower-contract-matrix.md
@@ -1,0 +1,67 @@
+# Tower contract test matrix
+
+This matrix is the source of truth for `tower::Service` contract coverage. A
+green baseline means a layer drives the exact readied receiver and composes
+with Tower's stateful `ConcurrencyLimit`. The adversarial columns use
+`tower_resilience_core::testing::{ServiceProbe, ControlledService}` so tests can
+observe internal attempts, cancellation, in-flight admission, wakeups, and
+value preservation deterministically.
+
+Use the companion [Tower service review checklist](tower-service-review-checklist.md)
+for the human review pass on each implementation.
+
+`Gap` is intentional and links to the ordered issue that must turn the cell
+into a regression test. It does **not** mean the behavior is assumed correct.
+
+| Crate | Readied receiver / Tower composition | Internal attempts | Cancellation / drop | Admission / wake | Response / error preservation | Configuration edges | Differential reference |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| adaptive | Covered in crate + umbrella contract tests | N/A | Gap ([#365]) | Gap: clone-heavy permit reservation and wake ([#365]); atomic controller updates ([#368]) | Gap ([#365]) | Gap ([#368], [#372]) | `tower::limit::ConcurrencyLimit` |
+| bulkhead | Covered in rejection and backpressure modes | N/A | Gap: waiter/future drop ([#367]) | Differential single-permit test matches Tower; direct permit polling remains ([#367]) | Covered by integration tests | Audit in [#372] | `tower::limit::ConcurrencyLimit` |
+| cache | Covered on forced misses | N/A | Pass-through cancellation; probe regression not yet added | Covered by existing concurrency tests | Covered on hits/misses | Audit in [#372] | `tower::Service` pass-through |
+| chaos | Covered | N/A | Pass-through cancellation; probe regression not yet added | N/A | Covered by behavior tests | Audit in [#372] | `tower::Service` pass-through |
+| circuitbreaker | Covered | N/A | Gap: half-open future drop ([#382]) | Gap: open-state readiness gate ([#381]) and half-open reservations ([#382]) | Covered by behavior tests | Audit in [#372] | Tower circuit breaker [#855] |
+| coalesce | Covered on leader path | N/A | Leader/waiter cancellation has behavior coverage; probe regression not yet added | Covered by concurrency/stress tests | Covered for leaders/waiters | Audit in [#372] | Singleflight semantics |
+| executor | Covered | N/A | Executor cancellation semantics tracked in [#371] | N/A | Covered by contract/behavior tests | Audit in [#372] | `tower::Service` pass-through |
+| fallback | Covered | Fallback is a value/function, not a second `Service`; see [#374] | Pass-through cancellation; probe regression not yet added | Fallback-service readiness gap ([#374]) | Covered for values/functions | Audit in [#372] | Tower [#413] service-to-service fallback |
+| hedge | Covered for delayed and parallel attempts | Covered for attempt readiness | Gap: loser tasks outlive the returned future ([#369]) | Gap ([#369]) | Covered by behavior tests | Gap ([#369], [#372]) | `tower::Service` cancellation contract |
+| outlier | Covered | N/A | Pass-through cancellation; probe regression not yet added | Covered by detector tests | Covered by behavior tests | Audit in [#372] | `tower::load::Load` routing semantics |
+| ratelimiter | Covered in rejection and backpressure modes | N/A | Gap ([#363]) | Gap: contended post-sleep admission ([#363]) | Gap ([#363]) | Gap ([#363], [#372]) | `tower::limit::RateLimit` |
+| reconnect | Covered on retry attempt | Gap: retries a clone instead of rebuilding a service ([#361]) | Gap ([#361]) | Gap ([#361]) | Gap ([#361]) | Audit in [#372] | `tower::reconnect::Reconnect` / `MakeService` |
+| retry | Covered for one attempt | Gap: re-poll readiness before every retry ([#362]) | Gap ([#362]) | Gap ([#362]) | Covered by policy tests | Audit in [#372] | `tower::retry::Retry` |
+| router | Covered across two backends | N/A | Gap ([#366]) | Gap: partial readiness and backend isolation ([#366]) | Covered by routing tests | Gap ([#366], [#372]) | `tower::balance` / readiness-aware routing |
+| timelimiter | Covered | N/A | Covered by cancellation tests | Readiness/deadline scope tracked in [#373] | Covered for timeout and inner errors | Audit in [#372] | `tower::timeout::Timeout` |
+
+`healthcheck` is not in the matrix because it does not implement a Tower
+`Service`; it supplies a monitor/handle used by other layers. `core` supplies
+shared infrastructure, and the facade crate only re-exports layer crates.
+
+## Required assertions for new or changed services
+
+Every new execution path must demonstrate, where applicable:
+
+1. `poll_ready` is driven before every `call`, including calls on internal
+   clones and retry attempts.
+2. Readiness or admission is reserved across clones; multiple clones cannot
+   all spend one permit.
+3. pending readiness registers a waker and readiness errors are preserved.
+4. dropping the returned future cancels owned work and releases resources.
+5. losing hedge/fan-out work is cancelled before the winning future returns.
+6. responses and errors are returned without lossy conversion.
+7. edge configuration fails explicitly rather than panicking or busy-spinning.
+
+[#361]: https://github.com/joshrotenberg/tower-resilience/issues/361
+[#362]: https://github.com/joshrotenberg/tower-resilience/issues/362
+[#363]: https://github.com/joshrotenberg/tower-resilience/issues/363
+[#365]: https://github.com/joshrotenberg/tower-resilience/issues/365
+[#366]: https://github.com/joshrotenberg/tower-resilience/issues/366
+[#367]: https://github.com/joshrotenberg/tower-resilience/issues/367
+[#368]: https://github.com/joshrotenberg/tower-resilience/issues/368
+[#369]: https://github.com/joshrotenberg/tower-resilience/issues/369
+[#371]: https://github.com/joshrotenberg/tower-resilience/issues/371
+[#372]: https://github.com/joshrotenberg/tower-resilience/issues/372
+[#373]: https://github.com/joshrotenberg/tower-resilience/issues/373
+[#374]: https://github.com/joshrotenberg/tower-resilience/issues/374
+[#381]: https://github.com/joshrotenberg/tower-resilience/issues/381
+[#382]: https://github.com/joshrotenberg/tower-resilience/issues/382
+[#413]: https://github.com/tower-rs/tower/issues/413
+[#855]: https://github.com/tower-rs/tower/pull/855

--- a/docs/tower-service-review-checklist.md
+++ b/docs/tower-service-review-checklist.md
@@ -1,0 +1,67 @@
+# Tower service review checklist
+
+Paste this checklist into a pull request that adds or materially changes a
+`tower::Service` implementation. Mark an item `N/A` only with a short reason;
+middleware policies differ, but the base Tower laws do not.
+
+This is the short operational companion to the project
+[contract matrix](tower-contract-matrix.md). The rationale and longer-term
+verification options are captured in the
+[Tower service contract verification research note](https://gist.github.com/joshrotenberg/017d09e16dd7a9592628f5206062444b).
+
+## Base readiness laws
+
+- [ ] Every `call` follows `Poll::Ready(Ok(()))` from `poll_ready` on the same
+      logical service instance.
+- [ ] A successful readiness grant remains usable until one call consumes it
+      or a readiness error makes the instance terminal.
+- [ ] `Pending` stores a usable waker and the state transition that may enable
+      progress wakes it; there is no unconditional self-wake loop.
+- [ ] `Ready(Err(_))` is treated as terminal for that instance and is preserved
+      or mapped deliberately.
+- [ ] `call` does not manufacture a task context or drive `poll_ready` itself.
+
+## Ownership, cloning, and admission
+
+- [ ] The implementation calls the exact inner value that was made ready; a
+      fresh clone does not accidentally inherit an instance-local grant.
+- [ ] Clone semantics are explicit: readiness, permits, counters, and routing
+      progression are intentionally shared or intentionally independent.
+- [ ] Capacity is reserved atomically before admission and cannot be spent by
+      multiple concurrent clones.
+- [ ] Repeated `poll_ready` calls do not double-acquire, replace, or lose a
+      reservation.
+
+## Drop and cancellation
+
+- [ ] Dropping the service after readiness but before `call` releases any
+      reservation.
+- [ ] Dropping the response future releases capacity and other owned resources
+      on success, error, and pending paths.
+- [ ] Spawned or external work has an explicit lifecycle; dropping a handle
+      does not silently detach work when cancellation is promised.
+- [ ] Racing/fan-out middleware cancels and accounts for losing attempts before
+      the winning future returns.
+
+## Errors, values, and policy
+
+- [ ] Responses and call errors are preserved without an undocumented lossy
+      conversion.
+- [ ] Readiness and call errors are classified and observed consistently.
+- [ ] Any intentional buffering, shedding, backpressure, or always-ready policy
+      explains how it remains valid for a readiness-sensitive inner service.
+- [ ] Invalid, zero, non-finite, and inverted-bound configuration is rejected
+      explicitly rather than panicking or busy-spinning.
+
+## Evidence
+
+- [ ] `ServiceProbe`/`ControlledService` exercises readiness, clones, wakeups,
+      peak in-flight work, and dropped futures without wall-clock sleeps.
+- [ ] A deliberately nonconforming fixture fails with a specific contract
+      assertion.
+- [ ] A Tower differential scenario exists where core Tower provides comparable
+      middleware or a useful behavioral reference.
+- [ ] Contended shared-state code has deterministic, property, Loom, Shuttle,
+      or equivalent schedule coverage proportional to its risk.
+- [ ] Effect-specific cleanup (tasks, sockets, subprocesses, remote requests)
+      is tested separately from merely observing response-future drop.

--- a/tests/ratelimiter/window_comparison.rs
+++ b/tests/ratelimiter/window_comparison.rs
@@ -52,8 +52,9 @@ async fn all_window_types_enforce_limit() {
 }
 
 #[tokio::test]
-async fn fixed_vs_sliding_at_boundary() {
-    // Fixed window allows burst at boundary, sliding windows don't
+async fn fixed_window_refreshes_while_sliding_log_limits_recent_requests() {
+    // A fixed window refreshes all permits after its period. A sliding log
+    // continues to reject requests while the recorded requests are recent.
 
     // Test Fixed Window - should allow burst
     {
@@ -97,7 +98,10 @@ async fn fixed_vs_sliding_at_boundary() {
             async { Ok::<_, std::io::Error>(()) }
         });
 
-        let layer = create_limiter(WindowType::SlidingLog, 5, 100);
+        // Use a deliberately long window here. A 100ms window made this test
+        // depend on CI scheduler latency: a sufficiently delayed task could
+        // cross the whole window before the assertion ran.
+        let layer = create_limiter(WindowType::SlidingLog, 5, 10_000);
         let mut service = layer.layer(svc);
 
         // Use all 5 permits
@@ -105,71 +109,13 @@ async fn fixed_vs_sliding_at_boundary() {
             assert!(service.ready().await.unwrap().call(i).await.is_ok());
         }
 
-        // Wait only 50ms (not full window)
-        tokio::time::sleep(Duration::from_millis(50)).await;
-
-        // Should NOT get any more (requests still in window)
+        // Requests were just recorded, so the sliding log must reject another
+        // request without relying on a wall-clock sleep or a narrow boundary.
         let result = service.ready().await.unwrap().call(5).await;
         assert!(
             result.is_err(),
             "Sliding log should prevent burst at boundary"
         );
-    }
-}
-
-#[tokio::test]
-async fn sliding_log_more_precise_than_counter() {
-    // Sliding log is exact, sliding counter is approximate
-    // This test shows they both prevent boundary bursts but behave slightly differently
-
-    for window_type in [WindowType::SlidingLog, WindowType::SlidingCounter] {
-        let call_count = Arc::new(AtomicUsize::new(0));
-        let counter = Arc::clone(&call_count);
-
-        let svc = tower::service_fn(move |_req: u32| {
-            counter.fetch_add(1, Ordering::SeqCst);
-            async { Ok::<_, std::io::Error>(()) }
-        });
-
-        let layer = create_limiter(window_type, 10, 100);
-        let mut service = layer.layer(svc);
-
-        // Use all permits
-        for i in 0..10 {
-            assert!(service.ready().await.unwrap().call(i).await.is_ok());
-        }
-
-        // Wait 50ms
-        tokio::time::sleep(Duration::from_millis(50)).await;
-
-        // Count how many more we can make
-        let mut additional = 0;
-        for i in 10..20 {
-            if service.ready().await.unwrap().call(i).await.is_ok() {
-                additional += 1;
-            }
-        }
-
-        // Both should limit, but sliding counter may allow a few more due to weighted decay
-        println!(
-            "{:?} allowed {} additional at 50% through window",
-            window_type, additional
-        );
-
-        match window_type {
-            WindowType::SlidingLog => {
-                // Sliding log should allow 0 (all 10 requests still in window)
-                assert_eq!(additional, 0, "Sliding log should be precise");
-            }
-            WindowType::SlidingCounter => {
-                // Sliding counter may allow ~5 due to 50% weight decay
-                assert!(
-                    additional <= 6,
-                    "Sliding counter should limit approximately"
-                );
-            }
-            _ => {}
-        }
     }
 }
 

--- a/tests/tower_differential_contract.rs
+++ b/tests/tower_differential_contract.rs
@@ -1,0 +1,88 @@
+//! Differential contract tests against comparable Tower middleware.
+//!
+//! These tests intentionally compare observable invariants rather than error
+//! types or implementation details. Add a scenario here when a
+//! tower-resilience feature is a superset of middleware shipped by Tower.
+
+use std::future::poll_fn;
+use std::task::Poll;
+use tower::{Service, ServiceExt};
+use tower_resilience_core::testing::{
+    ControlledHandle, ControlledService, ProbeHandle, ServiceProbe,
+};
+
+#[derive(Debug, Eq, PartialEq)]
+struct SinglePermitObservation {
+    contender_was_pending: bool,
+    calls: usize,
+    peak_in_flight: usize,
+    readiness_violations: usize,
+}
+
+async fn observe_single_permit<S>(
+    mut service: S,
+    controller: ControlledHandle,
+    probe: ProbeHandle,
+) -> SinglePermitObservation
+where
+    S: Service<usize, Response = usize> + Clone,
+    S::Error: std::fmt::Debug,
+{
+    let mut contender = service.clone();
+    let first = service.ready().await.unwrap().call(1);
+
+    let contender_was_pending =
+        poll_fn(|cx| Poll::Ready(matches!(contender.poll_ready(cx), Poll::Pending))).await;
+
+    controller.allow(1);
+    assert_eq!(first.await.unwrap(), 1);
+
+    let second = contender.ready().await.unwrap().call(2);
+    controller.allow(1);
+    assert_eq!(second.await.unwrap(), 2);
+
+    let snapshot = probe.snapshot();
+    probe.assert_ready_contract();
+    probe.assert_quiescent();
+    SinglePermitObservation {
+        contender_was_pending,
+        calls: snapshot.calls,
+        peak_in_flight: snapshot.peak_in_flight,
+        readiness_violations: snapshot.readiness_violations,
+    }
+}
+
+#[tokio::test]
+async fn bulkhead_backpressure_matches_tower_single_permit_admission() {
+    use tower_resilience_bulkhead::BulkheadLayer;
+
+    let (tower_inner, tower_controller) = ControlledService::new(true);
+    let tower_probe = ServiceProbe::new(tower_inner);
+    let tower_handle = tower_probe.handle();
+    let tower = tower::limit::ConcurrencyLimit::new(tower_probe, 1);
+
+    let (bulkhead_inner, bulkhead_controller) = ControlledService::new(true);
+    let bulkhead_probe = ServiceProbe::new(bulkhead_inner);
+    let bulkhead_handle = bulkhead_probe.handle();
+    let bulkhead = tower::ServiceBuilder::new()
+        .layer(
+            BulkheadLayer::builder()
+                .max_concurrent_calls(1)
+                .backpressure()
+                .build(),
+        )
+        .service(bulkhead_probe);
+
+    let tower_observation = observe_single_permit(tower, tower_controller, tower_handle).await;
+    let bulkhead_observation =
+        observe_single_permit(bulkhead, bulkhead_controller, bulkhead_handle).await;
+
+    let expected = SinglePermitObservation {
+        contender_was_pending: true,
+        calls: 2,
+        peak_in_flight: 1,
+        readiness_violations: 0,
+    };
+    assert_eq!(tower_observation, expected);
+    assert_eq!(bulkhead_observation, expected);
+}


### PR DESCRIPTION
## Summary

- add a reusable `ServiceProbe` that records per-instance readiness, clone behavior, peak in-flight work, completion, and cancellation
- add a deterministic `ControlledService` for readiness wakeups, closed-service errors, admission, and response preservation without wall-clock sleeps
- add a differential single-permit admission test comparing bulkhead backpressure with Tower `ConcurrencyLimit`
- add an explicit cross-crate contract/gap matrix, refreshed for #381, #382, and the other current roadmap issues
- add a pasteable manual review checklist derived from the Tower service verification research note

## Why

The existing `StatefulInner` regression catches the clone-in-call anti-pattern, but it cannot measure spawned/internal attempts, cancellation, contention, wake behavior, or preservation. This gives the individual P0 fixes a shared deterministic harness and makes known gaps explicit instead of letting broad happy-path coverage imply correctness.

## Checks

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --workspace --all-features --no-deps`
- `rustup run 1.85.0 cargo check --locked -p tower-resilience-core --features testing`

## Stack

Stacked on #383. Merge #383 first, then retarget this PR to `main` (or let GitHub update the base after the stack lands).

Closes #360