### PR TITLE
fix(adaptive): make admission safe across clones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2611,6 +2611,7 @@ dependencies = [
  "metrics",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-resilience-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ tower = { version = "0.5", features = ["util", "limit"] }
 tower-layer = "0.3"
 tower-service = "0.3"
 tokio = { version = "1", features = ["time", "sync"] }
+tokio-util = "0.7"
 futures = "0.3"
 thiserror = "2.0"
 tracing = "0.1"

--- a/crates/tower-resilience-adaptive/Cargo.toml
+++ b/crates/tower-resilience-adaptive/Cargo.toml
@@ -17,6 +17,7 @@ tower = { workspace = true }
 tower-layer = { workspace = true }
 tower-service = { workspace = true }
 tokio = { workspace = true, features = ["sync", "time"] }
+tokio-util.workspace = true
 pin-project-lite = { workspace = true }
 
 # Optional dependencies

--- a/crates/tower-resilience-adaptive/src/service.rs
+++ b/crates/tower-resilience-adaptive/src/service.rs
@@ -4,25 +4,38 @@ use crate::ConcurrencyAlgorithm;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 use std::time::Instant;
-use tokio::sync::Semaphore;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio_util::sync::PollSemaphore;
 use tower_service::Service;
+
+#[derive(Debug)]
+struct CapacityState {
+    desired_limit: usize,
+    shrink_debt: usize,
+}
 
 /// A service that applies adaptive concurrency limiting.
 ///
 /// This service dynamically adjusts the number of concurrent requests based
-/// on observed latency and error rates.
+/// on observed latency and error rates. A successful [`Service::poll_ready`]
+/// reserves one shared permit for that clone. Dropping the clone or the future
+/// returned by [`Service::call`] releases the reservation and wakes a waiter.
 pub struct AdaptiveService<S, A> {
     inner: S,
     algorithm: Arc<A>,
-    /// Current limit (tracked separately for dynamic adjustment)
-    current_limit: Arc<AtomicUsize>,
+    /// Serializes changes to the semaphore's logical capacity.
+    capacity: Arc<Mutex<CapacityState>>,
     /// In-flight requests counter
     in_flight: Arc<AtomicUsize>,
     /// Semaphore for limiting concurrency
     semaphore: Arc<Semaphore>,
+    /// Pollable acquisition state local to this clone.
+    poll_semaphore: PollSemaphore,
+    /// Capacity reserved by a successful `poll_ready` call.
+    permit: Option<OwnedSemaphorePermit>,
 }
 
 impl<S, A> AdaptiveService<S, A>
@@ -32,12 +45,18 @@ where
     /// Create a new adaptive service.
     pub fn new(service: S, algorithm: Arc<A>) -> Self {
         let initial_limit = algorithm.limit();
+        let semaphore = Arc::new(Semaphore::new(initial_limit));
         Self {
             inner: service,
             algorithm,
-            current_limit: Arc::new(AtomicUsize::new(initial_limit)),
+            capacity: Arc::new(Mutex::new(CapacityState {
+                desired_limit: initial_limit,
+                shrink_debt: 0,
+            })),
             in_flight: Arc::new(AtomicUsize::new(0)),
-            semaphore: Arc::new(Semaphore::new(initial_limit)),
+            semaphore: Arc::clone(&semaphore),
+            poll_semaphore: PollSemaphore::new(semaphore),
+            permit: None,
         }
     }
 
@@ -65,9 +84,91 @@ where
         Self {
             inner: self.inner.clone(),
             algorithm: Arc::clone(&self.algorithm),
-            current_limit: Arc::clone(&self.current_limit),
+            capacity: Arc::clone(&self.capacity),
             in_flight: Arc::clone(&self.in_flight),
             semaphore: Arc::clone(&self.semaphore),
+            poll_semaphore: PollSemaphore::new(Arc::clone(&self.semaphore)),
+            permit: None,
+        }
+    }
+}
+
+impl<S, A> Drop for AdaptiveService<S, A> {
+    fn drop(&mut self) {
+        if let Some(permit) = self.permit.take() {
+            release_permit(permit, &self.capacity);
+        }
+    }
+}
+
+fn sync_limit<A>(algorithm: &A, semaphore: &Semaphore, capacity: &Mutex<CapacityState>)
+where
+    A: ConcurrencyAlgorithm + ?Sized,
+{
+    let mut state = capacity.lock().expect("adaptive capacity lock poisoned");
+    let limit = algorithm.limit();
+
+    if limit > state.desired_limit {
+        let increase = limit - state.desired_limit;
+        let cancelled_debt = increase.min(state.shrink_debt);
+        state.shrink_debt -= cancelled_debt;
+        semaphore.add_permits(increase - cancelled_debt);
+    } else if limit < state.desired_limit {
+        let decrease = state.desired_limit - limit;
+        let removed = semaphore.forget_permits(decrease);
+        state.shrink_debt += decrease - removed;
+    }
+
+    state.desired_limit = limit;
+}
+
+fn release_permit(permit: OwnedSemaphorePermit, capacity: &Mutex<CapacityState>) {
+    let retire = {
+        let mut state = capacity.lock().expect("adaptive capacity lock poisoned");
+        if state.shrink_debt == 0 {
+            false
+        } else {
+            state.shrink_debt -= 1;
+            true
+        }
+    };
+
+    if retire {
+        permit.forget();
+    }
+}
+
+struct AdmissionGuard<A: ConcurrencyAlgorithm> {
+    algorithm: Arc<A>,
+    capacity: Arc<Mutex<CapacityState>>,
+    in_flight: Arc<AtomicUsize>,
+    semaphore: Arc<Semaphore>,
+    permit: Option<OwnedSemaphorePermit>,
+    completed: bool,
+}
+
+impl<A> AdmissionGuard<A>
+where
+    A: ConcurrencyAlgorithm,
+{
+    fn complete(mut self) {
+        self.completed = true;
+    }
+}
+
+impl<A> Drop for AdmissionGuard<A>
+where
+    A: ConcurrencyAlgorithm,
+{
+    fn drop(&mut self) {
+        if !self.completed {
+            self.algorithm.record_dropped();
+            sync_limit(self.algorithm.as_ref(), &self.semaphore, &self.capacity);
+        }
+
+        self.in_flight.fetch_sub(1, Ordering::SeqCst);
+        if let Some(permit) = self.permit.take() {
+            release_permit(permit, &self.capacity);
         }
     }
 }
@@ -85,65 +186,61 @@ where
     type Future = AdaptiveFuture<S::Response, S::Error>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // Check if we have capacity
-        let algorithm_limit = self.algorithm.limit();
-        let in_flight = self.in_flight.load(Ordering::Relaxed);
+        sync_limit(self.algorithm.as_ref(), &self.semaphore, &self.capacity);
 
-        if in_flight >= algorithm_limit {
-            // At capacity - wake and try again later
-            cx.waker().wake_by_ref();
-            return Poll::Pending;
+        if self.permit.is_none() {
+            match self.poll_semaphore.poll_acquire(cx) {
+                Poll::Ready(Some(permit)) => self.permit = Some(permit),
+                Poll::Ready(None) => return Poll::Ready(Err(AdaptiveError::LimitReached)),
+                Poll::Pending => return Poll::Pending,
+            }
         }
 
-        // Poll the inner service
-        self.inner.poll_ready(cx).map_err(AdaptiveError::Service)
+        match self.inner.poll_ready(cx) {
+            Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
+            Poll::Ready(Err(error)) => {
+                if let Some(permit) = self.permit.take() {
+                    release_permit(permit, &self.capacity);
+                }
+                Poll::Ready(Err(AdaptiveError::Service(error)))
+            }
+            Poll::Pending => Poll::Pending,
+        }
     }
 
     fn call(&mut self, req: Req) -> Self::Future {
+        let permit = self
+            .permit
+            .take()
+            .expect("AdaptiveService::call requires a successful poll_ready reservation");
         let start = Instant::now();
-        self.in_flight.fetch_add(1, Ordering::Relaxed);
-
-        let future = self.inner.call(req);
-
-        // Adjust semaphore based on algorithm
-        let algorithm_limit = self.algorithm.limit();
-        let current = self.current_limit.load(Ordering::Relaxed);
-        if algorithm_limit > current {
-            let diff = algorithm_limit - current;
-            self.semaphore.add_permits(diff);
-            self.current_limit.store(algorithm_limit, Ordering::Relaxed);
-        } else if algorithm_limit < current {
-            self.current_limit.store(algorithm_limit, Ordering::Relaxed);
-        }
+        self.in_flight.fetch_add(1, Ordering::SeqCst);
 
         let algorithm = Arc::clone(&self.algorithm);
-        let in_flight = Arc::clone(&self.in_flight);
         let semaphore = Arc::clone(&self.semaphore);
-        let current_limit = Arc::clone(&self.current_limit);
+        let capacity = Arc::clone(&self.capacity);
+        let guard = AdmissionGuard {
+            algorithm: Arc::clone(&algorithm),
+            capacity: Arc::clone(&capacity),
+            in_flight: Arc::clone(&self.in_flight),
+            semaphore: Arc::clone(&semaphore),
+            permit: Some(permit),
+            completed: false,
+        };
+        let future = self.inner.call(req);
 
         AdaptiveFuture {
             inner: Box::pin(async move {
                 let result = future.await;
                 let latency = start.elapsed();
 
-                // Decrement in-flight counter
-                in_flight.fetch_sub(1, Ordering::Relaxed);
-
                 match &result {
                     Ok(_) => algorithm.record_success(latency),
                     Err(_) => algorithm.record_failure(),
                 }
 
-                // Adjust semaphore based on new algorithm limit
-                let alg_limit = algorithm.limit();
-                let curr = current_limit.load(Ordering::Relaxed);
-                if alg_limit > curr {
-                    let diff = alg_limit - curr;
-                    semaphore.add_permits(diff);
-                    current_limit.store(alg_limit, Ordering::Relaxed);
-                } else if alg_limit < curr {
-                    current_limit.store(alg_limit, Ordering::Relaxed);
-                }
+                sync_limit(algorithm.as_ref(), &semaphore, &capacity);
+                guard.complete();
 
                 result.map_err(AdaptiveError::Service)
             }),

--- a/crates/tower-resilience-adaptive/tests/contract.rs
+++ b/crates/tower-resilience-adaptive/tests/contract.rs
@@ -2,11 +2,72 @@
 //!
 //! See `crates/tower-resilience-bulkhead/tests/contract.rs` for the rationale.
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 use tower::limit::ConcurrencyLimit;
 use tower::{Service, ServiceExt};
-use tower_resilience_adaptive::{AdaptiveLimiterLayer, Aimd};
-use tower_resilience_core::testing::StatefulInner;
+use tower_resilience_adaptive::{
+    AdaptiveError, AdaptiveLimiterLayer, AdaptiveService, Aimd, ConcurrencyAlgorithm,
+};
+use tower_resilience_core::testing::{ControlledService, ServiceProbe, StatefulInner};
+
+struct ManualLimit {
+    limit: AtomicUsize,
+    dropped: AtomicUsize,
+}
+
+impl ManualLimit {
+    fn new(limit: usize) -> Self {
+        Self {
+            limit: AtomicUsize::new(limit),
+            dropped: AtomicUsize::new(0),
+        }
+    }
+
+    fn set(&self, limit: usize) {
+        self.limit.store(limit, Ordering::SeqCst);
+    }
+
+    fn dropped(&self) -> usize {
+        self.dropped.load(Ordering::SeqCst)
+    }
+}
+
+impl ConcurrencyAlgorithm for ManualLimit {
+    fn record_success(&self, _latency: Duration) {}
+
+    fn record_failure(&self) {}
+
+    fn record_dropped(&self) {
+        self.dropped.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn limit(&self) -> usize {
+        self.limit.load(Ordering::SeqCst)
+    }
+
+    fn min_limit(&self) -> usize {
+        1
+    }
+
+    fn max_limit(&self) -> usize {
+        usize::MAX
+    }
+}
+
+async fn wait_for_calls(handle: &tower_resilience_core::testing::ProbeHandle, calls: usize) {
+    for _ in 0..1_000 {
+        if handle.snapshot().calls == calls {
+            return;
+        }
+        tokio::task::yield_now().await;
+    }
+    panic!(
+        "expected {calls} calls, observed {}",
+        handle.snapshot().calls
+    );
+}
 
 #[tokio::test]
 async fn adaptive_drives_readied_instance() {
@@ -39,4 +100,193 @@ async fn adaptive_composes_with_concurrency_limit() {
     for _ in 0..3 {
         let _ = svc.ready().await.unwrap().call(()).await;
     }
+}
+
+#[tokio::test]
+async fn adaptive_reserves_capacity_across_clones() {
+    let (inner, controller) = ControlledService::new(true);
+    let inner = ServiceProbe::new(inner);
+    let probe = inner.handle();
+    let algorithm = Aimd::builder()
+        .initial_limit(2)
+        .min_limit(2)
+        .max_limit(2)
+        .build();
+    let service = AdaptiveService::new(inner, Arc::new(algorithm));
+
+    let mut tasks = Vec::new();
+    for request in 0..8 {
+        let mut service = service.clone();
+        tasks.push(tokio::spawn(async move {
+            ServiceExt::<usize>::ready(&mut service)
+                .await
+                .unwrap()
+                .call(request)
+                .await
+                .unwrap()
+        }));
+    }
+
+    wait_for_calls(&probe, 2).await;
+    for _ in 0..10 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(probe.snapshot().calls, 2);
+    assert_eq!(probe.snapshot().peak_in_flight, 2);
+
+    controller.allow(8);
+    for task in tasks {
+        task.await.unwrap();
+    }
+
+    let snapshot = probe.snapshot();
+    assert_eq!(snapshot.calls, 8);
+    assert_eq!(snapshot.peak_in_flight, 2);
+    probe.assert_ready_contract();
+    probe.assert_quiescent();
+}
+
+#[tokio::test]
+async fn dropped_call_future_releases_capacity() {
+    let (inner, controller) = ControlledService::new(true);
+    let inner = ServiceProbe::new(inner);
+    let probe = inner.handle();
+    let algorithm = Arc::new(ManualLimit::new(1));
+    let service = AdaptiveService::new(inner, Arc::clone(&algorithm));
+
+    let mut first = service.clone();
+    let first_future = ServiceExt::<usize>::ready(&mut first)
+        .await
+        .unwrap()
+        .call(1);
+    assert_eq!(service.in_flight(), 1);
+    drop(first_future);
+    assert_eq!(service.in_flight(), 0);
+    assert_eq!(algorithm.dropped(), 1);
+
+    let mut second = service.clone();
+    let second_future = tokio::time::timeout(
+        Duration::from_secs(1),
+        ServiceExt::<usize>::ready(&mut second),
+    )
+    .await
+    .expect("dropping an admitted future must wake the next waiter")
+    .unwrap()
+    .call(2);
+    controller.allow(1);
+    assert_eq!(second_future.await.unwrap(), 2);
+
+    let snapshot = probe.snapshot();
+    assert_eq!(snapshot.cancelled, 1);
+    assert_eq!(snapshot.peak_in_flight, 1);
+    probe.assert_ready_contract();
+    probe.assert_quiescent();
+}
+
+#[tokio::test]
+async fn dropping_a_readied_clone_releases_its_reservation() {
+    let (inner, controller) = ControlledService::new(true);
+    let inner = ServiceProbe::new(inner);
+    let probe = inner.handle();
+    let algorithm = Arc::new(ManualLimit::new(1));
+    let service = AdaptiveService::new(inner, algorithm);
+
+    let mut reserved = service.clone();
+    ServiceExt::<usize>::ready(&mut reserved).await.unwrap();
+    drop(reserved);
+
+    let mut next = service.clone();
+    let future = tokio::time::timeout(
+        Duration::from_secs(1),
+        ServiceExt::<usize>::ready(&mut next),
+    )
+    .await
+    .expect("dropping a readiness grant must wake the next waiter")
+    .unwrap()
+    .call(7);
+    controller.allow(1);
+    assert_eq!(future.await.unwrap(), 7);
+
+    assert_eq!(probe.snapshot().peak_in_flight, 1);
+    probe.assert_ready_contract();
+    probe.assert_quiescent();
+}
+
+#[tokio::test]
+async fn inner_readiness_error_is_preserved_and_releases_capacity() {
+    let (inner, controller) = ControlledService::new(false);
+    let inner = ServiceProbe::new(inner);
+    let probe = inner.handle();
+    let algorithm = Arc::new(ManualLimit::new(1));
+    let mut service = AdaptiveService::new(inner, algorithm);
+    controller.close();
+
+    match ServiceExt::<usize>::ready(&mut service).await {
+        Err(AdaptiveError::Service(_)) => {}
+        Err(AdaptiveError::LimitReached) => panic!("inner error was replaced by a limit error"),
+        Ok(_) => panic!("closed inner service unexpectedly became ready"),
+    }
+
+    let snapshot = probe.snapshot();
+    assert_eq!(snapshot.readiness_errors, 1);
+    assert_eq!(snapshot.calls, 0);
+    assert_eq!(service.in_flight(), 0);
+    probe.assert_quiescent();
+}
+
+#[tokio::test]
+async fn shrinking_limit_retires_in_flight_permits_before_readmitting() {
+    let (inner, controller) = ControlledService::new(true);
+    let inner = ServiceProbe::new(inner);
+    let probe = inner.handle();
+    let algorithm = Arc::new(ManualLimit::new(2));
+    let service = AdaptiveService::new(inner, Arc::clone(&algorithm));
+
+    let mut first = service.clone();
+    let first_future = ServiceExt::<usize>::ready(&mut first)
+        .await
+        .unwrap()
+        .call(1);
+    let mut second = service.clone();
+    let second_future = ServiceExt::<usize>::ready(&mut second)
+        .await
+        .unwrap()
+        .call(2);
+    assert_eq!(probe.snapshot().calls, 2);
+
+    algorithm.set(1);
+    let mut third = service.clone();
+    let third_task = tokio::spawn(async move {
+        ServiceExt::<usize>::ready(&mut third)
+            .await
+            .unwrap()
+            .call(3)
+            .await
+            .unwrap()
+    });
+    for _ in 0..10 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(probe.snapshot().calls, 2);
+
+    controller.allow(1);
+    assert_eq!(first_future.await.unwrap(), 1);
+    for _ in 0..10 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(
+        probe.snapshot().calls,
+        2,
+        "the first released permit must pay down the shrink"
+    );
+
+    controller.allow(1);
+    assert_eq!(second_future.await.unwrap(), 2);
+    wait_for_calls(&probe, 3).await;
+    controller.allow(1);
+    assert_eq!(third_task.await.unwrap(), 3);
+
+    assert_eq!(probe.snapshot().peak_in_flight, 2);
+    probe.assert_ready_contract();
+    probe.assert_quiescent();
 }

--- a/docs/tower-contract-matrix.md
+++ b/docs/tower-contract-matrix.md
@@ -15,7 +15,7 @@ into a regression test. It does **not** mean the behavior is assumed correct.
 
 | Crate | Readied receiver / Tower composition | Internal attempts | Cancellation / drop | Admission / wake | Response / error preservation | Configuration edges | Differential reference |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| adaptive | Covered in crate + umbrella contract tests | N/A | Gap ([#365]) | Gap: clone-heavy permit reservation and wake ([#365]); atomic controller updates ([#368]) | Gap ([#365]) | Gap ([#368], [#372]) | `tower::limit::ConcurrencyLimit` |
+| adaptive | Covered in crate + umbrella contract tests | N/A | Covered for readied-clone and call-future drop ([#365]) | Covered for clone-heavy reservation, wake, and safe dynamic shrink ([#365]); atomic controller updates remain ([#368]) | Covered by contract and behavior tests | Gap ([#368], [#372]) | `tower::limit::ConcurrencyLimit` |
 | bulkhead | Covered in rejection and backpressure modes | N/A | Gap: waiter/future drop ([#367]) | Differential single-permit test matches Tower; direct permit polling remains ([#367]) | Covered by integration tests | Audit in [#372] | `tower::limit::ConcurrencyLimit` |
 | cache | Covered on forced misses | N/A | Pass-through cancellation; probe regression not yet added | Covered by existing concurrency tests | Covered on hits/misses | Audit in [#372] | `tower::Service` pass-through |
 | chaos | Covered | N/A | Pass-through cancellation; probe regression not yet added | N/A | Covered by behavior tests | Audit in [#372] | `tower::Service` pass-through |


### PR DESCRIPTION
## Summary
- reserve shared semaphore capacity during poll_ready and transfer one grant into call
- release or retire permits on completion, inner error, cancellation, and readied-service drop
- remove self-waking backpressure and preserve Send + Sync using the same pollable semaphore adapter as Tower
- cover clone-heavy peak admission, wakeups, cancellation, dynamic shrink, readiness errors, and the Tower contract matrix

## Stack
This is the fourth PR in the ordered correctness stack:
1. #383
2. #385
3. #386
4. this PR

The base is #386's branch so the review-specific change is commit f3bb1a4.

## Verification
- cargo fmt --all -- --check
- cargo test -p tower-resilience-adaptive --all-features
- cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
- cargo test --locked --workspace --all-features
- RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --workspace --all-features
- rustup run 1.85.0 cargo check --locked -p tower-resilience-adaptive --all-features

Closes #365