### PR TITLE
test(timelimiter): make deadline tests deterministic

### DIFF
--- a/crates/tower-resilience-timelimiter/Cargo.toml
+++ b/crates/tower-resilience-timelimiter/Cargo.toml
@@ -22,7 +22,7 @@ metrics = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["full", "test-util"] }
 tower = { workspace = true, features = ["util"] }
 tower-resilience-core = { workspace = true, features = ["testing"] }
 

--- a/crates/tower-resilience-timelimiter/src/lib.rs
+++ b/crates/tower-resilience-timelimiter/src/lib.rs
@@ -309,7 +309,7 @@ mod tests {
     use tokio::time::sleep;
     use tower::{service_fn, Layer, ServiceExt};
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_success_within_timeout() {
         // No type parameters needed!
         let layer = TimeLimiterLayer::builder()
@@ -328,7 +328,7 @@ mod tests {
         assert_eq!(result.unwrap(), "success");
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_timeout_occurs() {
         let layer = TimeLimiterLayer::builder()
             .timeout_duration(Duration::from_millis(10))
@@ -363,7 +363,7 @@ mod tests {
         assert_eq!(err.into_inner(), Some("inner error"));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_event_listeners() {
         let success_count = Arc::new(AtomicUsize::new(0));
         let timeout_count = Arc::new(AtomicUsize::new(0));
@@ -400,7 +400,7 @@ mod tests {
         assert_eq!(timeout_count.load(Ordering::SeqCst), 1);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_per_request_timeout() {
         #[derive(Clone)]
         struct Request {
@@ -446,7 +446,7 @@ mod tests {
         assert!(result.unwrap_err().is_timeout());
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_different_timeouts_per_request() {
         #[derive(Clone)]
         struct Request {


### PR DESCRIPTION
## Summary

- run all sleep-based TimeLimiter deadline tests with Tokio's paused clock
- enable Tokio's `test-util` feature for this crate's dev dependency only
- eliminate host scheduling sensitivity from timeout-vs-completion assertions

## Context

The macOS stable lane for release PR #395 failed because `test_different_timeouts_per_request` expected a 100 ms operation to exceed a 50 ms timeout, but wall-clock scheduling allowed the assertion to observe success. Virtual time preserves the behavior under test while removing machine-load timing variance.

Closes #396

## Validation

- `cargo test -p tower-resilience-timelimiter --all-features`
- `cargo clippy -p tower-resilience-timelimiter --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
