### PR TITLE
fix(timelimiter): define streamed HTTP timeout phases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,7 +1831,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower",
- "tower-http",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2574,6 +2574,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2870,10 +2887,16 @@ dependencies = [
 name = "tower-resilience-timelimiter"
 version = "0.12.0"
 dependencies = [
+ "bytes",
  "futures",
+ "http",
+ "http-body",
+ "http-body-util",
  "metrics",
+ "pin-project-lite",
  "tokio",
  "tower",
+ "tower-http 0.7.0",
  "tower-resilience-core",
  "tracing",
 ]

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ let hedge = HedgeLayer::standard();
 | **Time Limiter** | `fast()` | 1s timeout, cancel on timeout |
 | | `standard()` | 5s timeout, cancel on timeout |
 | | `slow()` | 30s timeout, cancel on timeout |
-| | `streaming()` | 60s timeout, no cancellation |
+| | `detached()` | 60s timeout, continue call in background |
 
 Presets return builders, so you can customize any setting:
 
@@ -658,6 +658,41 @@ let layer = TimeLimiterLayer::builder()
 
 let service = layer.layer(my_service);
 ```
+
+The timeout begins when `Service::call` is invoked. It does not include time
+spent waiting for `poll_ready`, and it ends as soon as the service future
+returns a response or error. In an HTTP service that normally means response
+status and headers are covered, but response-body frames are not.
+
+Use the protocol-agnostic body layers in `tower-http` 0.7+ for streamed bodies:
+
+```rust,ignore
+use std::time::Duration;
+use tower::ServiceBuilder;
+use tower_http::timeout::{ResponseBodyDeadlineLayer, ResponseBodyTimeoutLayer};
+use tower_resilience::timelimiter::TimeLimiterLayer;
+
+let service = ServiceBuilder::new()
+    // Detect a body that produces no frame for 10 seconds.
+    .layer(ResponseBodyTimeoutLayer::new(Duration::from_secs(10)))
+    // Also cap total body transfer time at 60 seconds.
+    .layer(ResponseBodyDeadlineLayer::new(Duration::from_secs(60)))
+    // Time only the service future (typically until response headers).
+    .layer(TimeLimiterLayer::standard().build())
+    .service(my_http_service);
+```
+
+The body idle timer resets after each frame. The body deadline is wall-clock
+time from response-body wrapper construction, so it starts after the response
+is produced rather than sharing TimeLimiter's call deadline. Body timeouts
+preserve the response status and headers and surface an error from the body,
+since those response parts may already have been sent. The analogous
+`RequestBodyTimeoutLayer` and `RequestBodyDeadlineLayer` cover request frames.
+
+`cancel_running_future` controls only the service call future. It does not
+control HTTP bodies after that future returns. The old `streaming()` preset is
+deprecated because it never timed body frames; use `detached()` when the
+intended behavior is to let a timed-out call continue in the background.
 
 **Full examples:** [timelimiter.rs](examples/timelimiter.rs) | [timelimiter_example.rs](crates/tower-resilience-timelimiter/examples/timelimiter_example.rs)
 

--- a/crates/tower-resilience-timelimiter/CHANGELOG.md
+++ b/crates/tower-resilience-timelimiter/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Define TimeLimiter's deadline as covering only the `Service::call` future,
+  excluding readiness and response-body frames; document and test composition
+  with tower-http 0.7 idle and absolute body timeouts.
+- Rename the misleading `streaming()` preset to `detached()`; the old name is
+  retained as a deprecated alias.
+
 ## [0.12.0](https://github.com/joshrotenberg/tower-resilience/compare/tower-resilience-timelimiter-v0.11.0...tower-resilience-timelimiter-v0.12.0) - 2026-08-17
 
 ### Fixed

--- a/crates/tower-resilience-timelimiter/Cargo.toml
+++ b/crates/tower-resilience-timelimiter/Cargo.toml
@@ -22,8 +22,14 @@ metrics = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
+bytes = "1"
+http = "1"
+http-body = "1"
+http-body-util = "0.1"
+pin-project-lite = { workspace = true }
 tokio = { workspace = true, features = ["full", "test-util"] }
 tower = { workspace = true, features = ["util"] }
+tower-http = { version = "0.7", features = ["timeout"] }
 tower-resilience-core = { workspace = true, features = ["testing"] }
 
 [features]

--- a/crates/tower-resilience-timelimiter/src/config.rs
+++ b/crates/tower-resilience-timelimiter/src/config.rs
@@ -242,7 +242,10 @@ impl<T> TimeLimiterConfigBuilder<T> {
     ///
     /// When true (the default), the future will be dropped on timeout, canceling
     /// ongoing work. When false, the future continues running in the background
-    /// but its result is ignored.
+    /// on a spawned Tokio task but its result is ignored. This setting applies
+    /// only to the future returned by [`tower::Service::call`]. It does not
+    /// control readiness or an HTTP request/response body after the service
+    /// future has completed.
     ///
     /// Default: true
     pub fn cancel_running_future(mut self, cancel: bool) -> Self {
@@ -394,7 +397,13 @@ mod tests {
     }
 
     #[test]
-    fn test_preset_streaming() {
+    fn test_preset_detached() {
+        let _layer = TimeLimiterLayer::detached().build();
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn test_deprecated_streaming_alias() {
         let _layer = TimeLimiterLayer::streaming().build();
     }
 

--- a/crates/tower-resilience-timelimiter/src/layer.rs
+++ b/crates/tower-resilience-timelimiter/src/layer.rs
@@ -187,15 +187,16 @@ impl TimeLimiterLayer<FixedTimeout> {
         Self::builder().timeout_duration(Duration::from_secs(30))
     }
 
-    /// Preset: Long timeout for streaming and long-poll scenarios.
+    /// Preset: Long timeout whose service future continues in the background.
     ///
     /// Configuration:
     /// - 60 second timeout
     /// - Does NOT cancel running future on timeout
     ///
-    /// Use this for streaming responses, long-polling, or WebSocket
-    /// connections where you want the background work to continue
-    /// even after the timeout fires.
+    /// Use this when abandoning the caller must not cancel the work submitted
+    /// to the inner service. This preset only times the future returned by
+    /// [`tower::Service::call`]; it does not time readiness or
+    /// HTTP body frames.
     ///
     /// # Examples
     ///
@@ -203,17 +204,32 @@ impl TimeLimiterLayer<FixedTimeout> {
     /// use tower_resilience_timelimiter::TimeLimiterLayer;
     ///
     /// // Use as-is
-    /// let layer = TimeLimiterLayer::streaming().build();
+    /// let layer = TimeLimiterLayer::detached().build();
     ///
     /// // Or customize further
-    /// let layer = TimeLimiterLayer::streaming()
-    ///     .name("stream-timeout")
+    /// let layer = TimeLimiterLayer::detached()
+    ///     .name("detached-timeout")
     ///     .build();
     /// ```
-    pub fn streaming() -> crate::TimeLimiterConfigBuilder<FixedTimeout> {
+    pub fn detached() -> crate::TimeLimiterConfigBuilder<FixedTimeout> {
         Self::builder()
             .timeout_duration(Duration::from_secs(60))
             .cancel_running_future(false)
+    }
+
+    /// Deprecated alias for [`TimeLimiterLayer::detached`].
+    ///
+    /// Despite its name, this preset has never timed HTTP request or response
+    /// body frames. It only lets the inner service future continue after the
+    /// caller receives a timeout. Compose `TimeLimiterLayer` with the body
+    /// timeout layers in `tower-http` 0.7 or later when body-frame timing is
+    /// required.
+    #[deprecated(
+        since = "0.13.0",
+        note = "this preset does not time streams; use `detached()` for its service-future behavior and tower-http 0.7 body timeout layers for HTTP bodies"
+    )]
+    pub fn streaming() -> crate::TimeLimiterConfigBuilder<FixedTimeout> {
+        Self::detached()
     }
 }
 

--- a/crates/tower-resilience-timelimiter/src/lib.rs
+++ b/crates/tower-resilience-timelimiter/src/lib.rs
@@ -6,6 +6,34 @@
 //! - Event system for observability (onSuccess, onError, onTimeout)
 //! - Metrics integration
 //!
+//! ## What the timeout covers
+//!
+//! `TimeLimiter` starts its timer when [`Service::call`]
+//! is invoked and stops it when that future returns a response or error.
+//! [`Service::poll_ready`] is delegated directly,
+//! so time spent waiting for readiness is **not** part of the timeout.
+//!
+//! For an HTTP service, returning `http::Response<B>` completes the service
+//! future. Response-body frames produced by `B` afterwards are therefore not
+//! timed. If the service consumes request-body frames before returning its
+//! response, that work remains inside the service future, but TimeLimiter does
+//! not apply an independent timeout between request-body frames.
+//!
+//! For idle or absolute HTTP body limits, compose this layer with `tower-http`
+//! 0.7 or later:
+//!
+//! - `RequestBodyTimeoutLayer` / `ResponseBodyTimeoutLayer` reset their timer
+//!   after every frame and detect idle transfers.
+//! - `RequestBodyDeadlineLayer` / `ResponseBodyDeadlineLayer` use one
+//!   wall-clock timer from body-wrapper construction and cap total transfer
+//!   time.
+//!
+//! A response-body deadline starts after the response is produced; it is not a
+//! continuation of TimeLimiter's service-future deadline. The two layers
+//! intentionally have independent clocks. Body timeout errors are emitted by
+//! the body after the response status and headers already exist, so those
+//! response parts are preserved.
+//!
 //! ## Presets
 //!
 //! ```rust
@@ -14,7 +42,7 @@
 //! let fast = TimeLimiterLayer::fast().build();        // 1s, cancel on timeout
 //! let standard = TimeLimiterLayer::standard().build(); // 5s, cancel on timeout
 //! let slow = TimeLimiterLayer::slow().build();         // 30s, cancel on timeout
-//! let stream = TimeLimiterLayer::streaming().build();  // 60s, no cancellation
+//! let detached = TimeLimiterLayer::detached().build(); // 60s, continue call in background
 //! ```
 //!
 //! Presets return builders, so you can customize further:
@@ -133,7 +161,12 @@ mod error;
 mod events;
 mod layer;
 
-/// A Tower service that applies timeout limiting to an inner service.
+/// A Tower service that applies timeout limiting to an inner service's call future.
+///
+/// The timeout begins in [`Service::call`] and does not include
+/// [`Service::poll_ready`]. It ends when the inner call future yields its
+/// response, so asynchronously produced response data (such as HTTP body
+/// frames) is outside this service's deadline.
 ///
 /// The type parameter `T` is the timeout source:
 /// - `FixedTimeout` - uses the same timeout for all requests
@@ -185,6 +218,8 @@ where
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // Readiness has no request to inspect and is deliberately outside the
+        // per-call timeout budget.
         self.inner.poll_ready(cx).map_err(TimeLimiterError::Inner)
     }
 

--- a/crates/tower-resilience-timelimiter/tests/contract.rs
+++ b/crates/tower-resilience-timelimiter/tests/contract.rs
@@ -2,11 +2,53 @@
 //!
 //! See `crates/tower-resilience-bulkhead/tests/contract.rs` for the rationale.
 
+use std::convert::Infallible;
+use std::future::{ready, Future, Ready};
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::time::Duration;
+use tokio::time::{sleep, Sleep};
 use tower::limit::ConcurrencyLimit;
 use tower::{Service, ServiceExt};
 use tower_resilience_core::testing::StatefulInner;
 use tower_resilience_timelimiter::TimeLimiterLayer;
+
+struct DelayedReady {
+    delay_duration: Duration,
+    delay: Pin<Box<Sleep>>,
+}
+
+impl DelayedReady {
+    fn new(delay: Duration) -> Self {
+        Self {
+            delay_duration: delay,
+            delay: Box::pin(sleep(delay)),
+        }
+    }
+}
+
+impl Clone for DelayedReady {
+    fn clone(&self) -> Self {
+        // TimeLimiter's readied-instance replacement requires Clone. Calls use
+        // the instance that poll_ready drove; the replacement is for the next
+        // request and gets its own readiness delay.
+        Self::new(self.delay_duration)
+    }
+}
+
+impl Service<()> for DelayedReady {
+    type Response = &'static str;
+    type Error = Infallible;
+    type Future = Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.delay.as_mut().poll(cx).map(|()| Ok(()))
+    }
+
+    fn call(&mut self, (): ()) -> Self::Future {
+        ready(Ok("ready"))
+    }
+}
 
 #[tokio::test]
 async fn timelimiter_drives_readied_instance() {
@@ -33,4 +75,20 @@ async fn timelimiter_composes_with_concurrency_limit() {
     for _ in 0..3 {
         let _ = svc.ready().await.unwrap().call(()).await;
     }
+}
+
+#[tokio::test(start_paused = true)]
+async fn readiness_wait_is_outside_the_call_timeout() {
+    let layer = TimeLimiterLayer::builder()
+        .timeout_duration(Duration::from_millis(10))
+        .build();
+    let mut svc = tower::ServiceBuilder::new()
+        .layer(layer)
+        .service(DelayedReady::new(Duration::from_millis(100)));
+
+    let started = tokio::time::Instant::now();
+    let result = svc.ready().await.unwrap().call(()).await;
+
+    assert_eq!(result.unwrap(), "ready");
+    assert_eq!(started.elapsed(), Duration::from_millis(100));
 }

--- a/crates/tower-resilience-timelimiter/tests/http_body.rs
+++ b/crates/tower-resilience-timelimiter/tests/http_body.rs
@@ -1,0 +1,295 @@
+//! HTTP response-phase contracts for TimeLimiter and tower-http 0.7.
+
+use bytes::Bytes;
+use http::{Request, Response, StatusCode};
+use http_body::{Body, Frame};
+use http_body_util::BodyExt;
+use pin_project_lite::pin_project;
+use std::collections::VecDeque;
+use std::convert::Infallible;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::task::{ready, Context, Poll};
+use std::time::Duration;
+use tokio::time::{sleep, Sleep};
+use tower::{service_fn, Service, ServiceBuilder, ServiceExt};
+use tower_http::timeout::{ResponseBodyDeadlineLayer, ResponseBodyTimeoutLayer, TimeoutError};
+use tower_resilience_timelimiter::TimeLimiterLayer;
+
+struct DropFlag(Arc<AtomicBool>);
+
+impl Drop for DropFlag {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+}
+
+pin_project! {
+    struct DelayedBody {
+        delays: VecDeque<Duration>,
+        #[pin]
+        sleep: Option<Sleep>,
+        _drop_flag: Option<DropFlag>,
+    }
+}
+
+impl DelayedBody {
+    fn new(delays: impl IntoIterator<Item = Duration>) -> Self {
+        Self {
+            delays: delays.into_iter().collect(),
+            sleep: None,
+            _drop_flag: None,
+        }
+    }
+
+    fn with_drop_flag(
+        delays: impl IntoIterator<Item = Duration>,
+        dropped: Arc<AtomicBool>,
+    ) -> Self {
+        Self {
+            delays: delays.into_iter().collect(),
+            sleep: None,
+            _drop_flag: Some(DropFlag(dropped)),
+        }
+    }
+}
+
+impl Body for DelayedBody {
+    type Data = Bytes;
+    type Error = Infallible;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        let mut this = self.project();
+        let Some(delay) = this.delays.front().copied() else {
+            return Poll::Ready(None);
+        };
+
+        let sleep = if let Some(sleep) = this.sleep.as_mut().as_pin_mut() {
+            sleep
+        } else {
+            this.sleep.set(Some(sleep(delay)));
+            this.sleep.as_mut().as_pin_mut().unwrap()
+        };
+
+        ready!(sleep.poll(cx));
+        this.sleep.set(None);
+        this.delays.pop_front();
+        Poll::Ready(Some(Ok(Frame::data(Bytes::from_static(b"chunk")))))
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.delays.is_empty()
+    }
+}
+
+fn assert_body_timeout(error: &(dyn std::error::Error + Send + Sync + 'static)) {
+    assert!(
+        error.downcast_ref::<TimeoutError>().is_some(),
+        "expected tower-http TimeoutError, got {error}"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn slow_response_future_times_out_and_is_cancelled() {
+    let dropped = Arc::new(AtomicBool::new(false));
+    let service_dropped = Arc::clone(&dropped);
+    let inner = service_fn(move |_request: Request<()>| {
+        let service_dropped = Arc::clone(&service_dropped);
+        async move {
+            let _drop_flag = DropFlag(service_dropped);
+            sleep(Duration::from_millis(50)).await;
+            Ok::<_, Infallible>(Response::new(DelayedBody::new([])))
+        }
+    });
+    let mut service = ServiceBuilder::new()
+        .layer(
+            TimeLimiterLayer::builder()
+                .timeout_duration(Duration::from_millis(10))
+                .build(),
+        )
+        .service(inner);
+
+    let result = service.ready().await.unwrap().call(Request::new(())).await;
+    let error = match result {
+        Err(error) => error,
+        Ok(_) => panic!("slow response future unexpectedly completed"),
+    };
+
+    assert!(error.is_timeout());
+    assert!(
+        dropped.load(Ordering::SeqCst),
+        "the slow service future must be dropped on timeout"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn time_limiter_stops_when_the_response_is_produced() {
+    let inner = service_fn(|_request: Request<()>| async {
+        Ok::<_, Infallible>(Response::new(DelayedBody::new([Duration::from_millis(50)])))
+    });
+    let mut service = ServiceBuilder::new()
+        .layer(
+            TimeLimiterLayer::builder()
+                .timeout_duration(Duration::from_millis(10))
+                .build(),
+        )
+        .service(inner);
+
+    let response = service
+        .ready()
+        .await
+        .unwrap()
+        .call(Request::new(()))
+        .await
+        .expect("the response value is immediately available");
+    let mut body = Box::pin(response.into_body());
+    let body_started = tokio::time::Instant::now();
+
+    let frame = body
+        .frame()
+        .await
+        .expect("one delayed frame")
+        .expect("body has no errors");
+    assert_eq!(frame.into_data().unwrap(), Bytes::from_static(b"chunk"));
+    assert_eq!(body_started.elapsed(), Duration::from_millis(50));
+}
+
+#[tokio::test(start_paused = true)]
+async fn idle_body_timeout_preserves_response_parts_and_cancels_the_body() {
+    let dropped = Arc::new(AtomicBool::new(false));
+    let body_dropped = Arc::clone(&dropped);
+    let inner = service_fn(move |_request: Request<()>| {
+        let body_dropped = Arc::clone(&body_dropped);
+        async move {
+            Ok::<_, Infallible>(
+                Response::builder()
+                    .status(StatusCode::PARTIAL_CONTENT)
+                    .header("x-stream", "timed")
+                    .body(DelayedBody::with_drop_flag(
+                        [Duration::from_millis(50)],
+                        body_dropped,
+                    ))
+                    .unwrap(),
+            )
+        }
+    });
+    let mut service = ServiceBuilder::new()
+        .layer(ResponseBodyTimeoutLayer::new(Duration::from_millis(10)))
+        .layer(
+            TimeLimiterLayer::builder()
+                .timeout_duration(Duration::from_millis(100))
+                .build(),
+        )
+        .service(inner);
+
+    let response = service
+        .ready()
+        .await
+        .unwrap()
+        .call(Request::new(()))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::PARTIAL_CONTENT);
+    assert_eq!(response.headers()["x-stream"], "timed");
+
+    {
+        let mut body = Box::pin(response.into_body());
+        let error = body.frame().await.unwrap().unwrap_err();
+        assert_body_timeout(error.as_ref());
+    }
+    assert!(
+        dropped.load(Ordering::SeqCst),
+        "dropping a timed-out response body must release the inner body"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn idle_body_timeout_resets_after_each_frame() {
+    let inner = service_fn(|_request: Request<()>| async {
+        Ok::<_, Infallible>(Response::new(DelayedBody::new([
+            Duration::from_millis(6),
+            Duration::from_millis(6),
+            Duration::from_millis(6),
+        ])))
+    });
+    let mut service = ServiceBuilder::new()
+        .layer(ResponseBodyTimeoutLayer::new(Duration::from_millis(10)))
+        .layer(
+            TimeLimiterLayer::builder()
+                .timeout_duration(Duration::from_millis(100))
+                .build(),
+        )
+        .service(inner);
+    let response = service
+        .ready()
+        .await
+        .unwrap()
+        .call(Request::new(()))
+        .await
+        .unwrap();
+    let mut body = Box::pin(response.into_body());
+    let mut frames = 0;
+
+    while let Some(frame) = body.frame().await {
+        frame.unwrap();
+        frames += 1;
+    }
+
+    assert_eq!(frames, 3);
+}
+
+#[tokio::test(start_paused = true)]
+async fn absolute_body_deadline_expires_despite_steady_frames() {
+    let inner = service_fn(|_request: Request<()>| async {
+        Ok::<_, Infallible>(Response::new(DelayedBody::new([
+            Duration::from_millis(6),
+            Duration::from_millis(6),
+            Duration::from_millis(6),
+        ])))
+    });
+    let mut service = ServiceBuilder::new()
+        .layer(ResponseBodyDeadlineLayer::new(Duration::from_millis(15)))
+        .layer(
+            TimeLimiterLayer::builder()
+                .timeout_duration(Duration::from_millis(100))
+                .build(),
+        )
+        .service(inner);
+    let response = service
+        .ready()
+        .await
+        .unwrap()
+        .call(Request::new(()))
+        .await
+        .unwrap();
+    let mut body = Box::pin(response.into_body());
+
+    body.frame().await.unwrap().unwrap();
+    body.frame().await.unwrap().unwrap();
+    let error = body.frame().await.unwrap().unwrap_err();
+    assert_body_timeout(error.as_ref());
+}
+
+#[tokio::test]
+async fn response_body_layers_preserve_inner_service_errors() {
+    let inner = service_fn(|_request: Request<()>| async {
+        Err::<Response<DelayedBody>, _>("service error")
+    });
+    let mut service = ServiceBuilder::new()
+        .layer(ResponseBodyTimeoutLayer::new(Duration::from_secs(1)))
+        .layer(TimeLimiterLayer::standard().build())
+        .service(inner);
+
+    let result = service.ready().await.unwrap().call(Request::new(())).await;
+    let error = match result {
+        Err(error) => error,
+        Ok(_) => panic!("inner service error was unexpectedly replaced by a response"),
+    };
+
+    assert_eq!(error.into_inner(), Some("service error"));
+}

--- a/crates/tower-resilience/src/lib.rs
+++ b/crates/tower-resilience/src/lib.rs
@@ -69,7 +69,7 @@
 //! | **Hedge** | [`conservative()`][h_conservative], [`standard()`][h_standard], [`aggressive()`][h_aggressive] |
 //! | **Rate Limiter** | [`per_second(n)`], [`per_minute(n)`], [`burst(rate, size)`] |
 //! | **Retry** | [`exponential_backoff()`], [`aggressive()`], [`conservative()`] |
-//! | **Time Limiter** | [`fast()`], [`standard()`][tl_standard], [`slow()`], [`streaming()`] |
+//! | **Time Limiter** | [`fast()`], [`standard()`][tl_standard], [`slow()`], [`detached()`] |
 //!
 //! Presets return builders, so you can customize any setting:
 //!
@@ -104,7 +104,7 @@
 //! [`fast()`]: timelimiter::TimeLimiterLayer::fast
 //! [tl_standard]: timelimiter::TimeLimiterLayer::standard
 //! [`slow()`]: timelimiter::TimeLimiterLayer::slow
-//! [`streaming()`]: timelimiter::TimeLimiterLayer::streaming
+//! [`detached()`]: timelimiter::TimeLimiterLayer::detached
 //!
 //! # Resilience Patterns
 //!

--- a/crates/tower-resilience/src/patterns.rs
+++ b/crates/tower-resilience/src/patterns.rs
@@ -1771,7 +1771,7 @@ pub mod time_limiter {
     //! let fast = TimeLimiterLayer::fast().build();        // 1s, cancel on timeout
     //! let standard = TimeLimiterLayer::standard().build(); // 5s, cancel on timeout
     //! let slow = TimeLimiterLayer::slow().build();         // 30s, cancel on timeout
-    //! let stream = TimeLimiterLayer::streaming().build();  // 60s, no cancellation
+    //! let detached = TimeLimiterLayer::detached().build(); // 60s, continue call in background
     //! # }
     //! ```
     //!


### PR DESCRIPTION
Closes #373.

## Summary

- define the generic TimeLimiter deadline as `Service::call` through its returned response/error, excluding readiness
- document the distinct HTTP request, response-header, and response-body phases
- rename the misleading `streaming()` preset to `detached()` while retaining a deprecated compatibility alias
- verify idle and absolute streamed-body timeout composition against tower-http 0.7
- add deterministic cancellation, readiness, response-part, body-resource, and inner-error contracts

## Semantics

- waiting in `poll_ready` is outside the call timeout
- response-body frames produced after the response are outside TimeLimiter
- tower-http idle body timers reset after every frame
- tower-http body deadlines start when the body wrapper is created after the response; they do not continue TimeLimiter's call deadline
- body timeouts preserve status and headers and surface as body errors

## Validation

- `cargo test -p tower-resilience-timelimiter --all-features`
- `cargo test --workspace --all-features`
- `cargo clippy -p tower-resilience-timelimiter --all-targets --all-features -- -D warnings`
- strict crate rustdoc
- formatting and diff checks
