### PR TITLE
test(ratelimiter): make stress checks reflect elapsed-time admission semantics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tower-resilience-coalesce = { path = "crates/tower-resilience-coalesce" }
 tower-resilience-executor = { path = "crates/tower-resilience-executor" }
 tower-resilience-outlier = { path = "crates/tower-resilience-outlier" }
 tower = { workspace = true }
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util"] }
 tracing-subscriber = "0.3"
 futures = { workspace = true }
 

--- a/tests/stress/ratelimiter.rs
+++ b/tests/stress/ratelimiter.rs
@@ -2,12 +2,55 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::{Duration, Instant};
-use tokio::time::sleep;
+use std::time::Duration;
+use tokio::sync::Barrier;
+use tokio::time::{Instant, sleep};
 use tower::{Layer, Service, ServiceExt};
 use tower_resilience_ratelimiter::RateLimiterLayer;
 
 use super::{ConcurrencyTracker, get_memory_usage_mb};
+
+/// Starts a batch of cloned services at one virtual instant and reports outcomes.
+///
+/// A barrier makes the asserted admission window explicit: task-spawn
+/// latency cannot silently replenish permits before some callers arrive,
+/// and a paused virtual clock keeps the outcome independent of scheduler
+/// speed.
+async fn run_gated_batch<S>(service: &S, requests: std::ops::Range<u32>) -> (usize, usize)
+where
+    S: Service<u32> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    let barrier = Arc::new(Barrier::new(requests.len() + 1));
+    let mut handles = Vec::with_capacity(requests.len());
+
+    for request in requests {
+        let barrier = Arc::clone(&barrier);
+        let mut service = service.clone();
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            let ready = service
+                .ready()
+                .await
+                .unwrap_or_else(|_| panic!("rate limiter readiness failed"));
+            ready.call(request).await.is_ok()
+        }));
+    }
+
+    barrier.wait().await;
+
+    let mut admitted = 0;
+    let mut rejected = 0;
+    for handle in handles {
+        if handle.await.expect("rate-limit task panicked") {
+            admitted += 1;
+        } else {
+            rejected += 1;
+        }
+    }
+
+    (admitted, rejected)
+}
 
 /// Test: 1 million calls through rate limiter (high limit, no throttling)
 #[tokio::test]
@@ -49,11 +92,14 @@ async fn stress_one_million_calls_no_throttling() {
 }
 
 /// Test: Rate limiting enforcement with permit exhaustion
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 #[ignore]
 async fn stress_rate_limit_enforcement() {
+    const LIMIT: usize = 100;
+    const CALLERS: u32 = 1000;
+    const TIMEOUT: Duration = Duration::from_millis(10);
+
     let permitted_count = Arc::new(AtomicUsize::new(0));
-    let rejected_count = Arc::new(AtomicUsize::new(0));
     let permitted = Arc::clone(&permitted_count);
 
     let svc = tower::service_fn(move |_req: u32| {
@@ -62,36 +108,34 @@ async fn stress_rate_limit_enforcement() {
     });
 
     let layer = RateLimiterLayer::builder()
-        .limit_for_period(100)
+        .limit_for_period(LIMIT)
         .refresh_period(Duration::from_secs(1))
-        .timeout_duration(Duration::from_millis(10)) // Short timeout
+        .timeout_duration(TIMEOUT) // Short timeout
         .build();
 
-    let mut service = layer.layer(svc);
+    let service = layer.layer(svc);
 
     let start = Instant::now();
-
-    for i in 0..1000 {
-        match service.ready().await.unwrap().call(i).await {
-            Ok(_) => {}
-            Err(_) => {
-                rejected_count.fetch_add(1, Ordering::Relaxed);
-            }
-        }
-    }
-
+    let (admitted, rejected) = run_gated_batch(&service, 0..CALLERS).await;
     let elapsed = start.elapsed();
-    let permitted = permitted_count.load(Ordering::Relaxed);
-    let rejected = rejected_count.load(Ordering::Relaxed);
 
-    println!("1000 calls with rate limiting in {:?}", elapsed);
-    println!("Permitted: {}", permitted);
-    println!("Rejected (rate limited): {}", rejected);
-    println!("Rejection rate: {:.1}%", rejected as f64 / 1000.0 * 100.0);
+    println!("{CALLERS} simultaneous calls with rate limiting in {elapsed:?}");
+    println!("Permitted: {admitted}");
+    println!("Rejected (rate limited): {rejected}");
+    println!(
+        "Rejection rate: {:.1}%",
+        rejected as f64 / f64::from(CALLERS) * 100.0
+    );
 
-    // Should have significant rejections due to low timeout
-    assert!(rejected > 500, "Expected significant rate limiting");
-    assert_eq!(permitted + rejected, 1000);
+    // All callers arrive in the same fixed window (barrier-gated). Exactly
+    // LIMIT consume a permit; the short timeout rejects the rest before the
+    // next refresh -- deterministic under the paused clock, independent of
+    // scheduler speed.
+    assert_eq!(admitted, LIMIT);
+    assert_eq!(rejected, CALLERS as usize - LIMIT);
+    assert_eq!(permitted_count.load(Ordering::Relaxed), admitted);
+    assert_eq!(admitted + rejected, CALLERS as usize);
+    assert_eq!(elapsed, TIMEOUT);
 }
 
 /// Test: High concurrency with rate limiting
@@ -154,11 +198,15 @@ async fn stress_high_concurrency_rate_limited() {
 }
 
 /// Test: Burst traffic handling
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 #[ignore]
 async fn stress_burst_traffic() {
+    const BURSTS: u32 = 10;
+    const CALLERS_PER_BURST: u32 = 200;
+    const LIMIT: usize = 100;
+    const REFRESH_PERIOD: Duration = Duration::from_millis(100);
+
     let permitted_count = Arc::new(AtomicUsize::new(0));
-    let rejected_count = Arc::new(AtomicUsize::new(0));
     let permitted = Arc::clone(&permitted_count);
 
     let svc = tower::service_fn(move |_req: u32| {
@@ -167,48 +215,58 @@ async fn stress_burst_traffic() {
     });
 
     let layer = RateLimiterLayer::builder()
-        .limit_for_period(100)
-        .refresh_period(Duration::from_millis(100))
+        .limit_for_period(LIMIT)
+        .refresh_period(REFRESH_PERIOD)
         .timeout_duration(Duration::from_millis(5))
         .build();
 
-    let mut service = layer.layer(svc);
+    let service = layer.layer(svc);
 
     let start = Instant::now();
+    let mut admitted = 0;
+    let mut rejected = 0;
 
-    // 10 bursts of 200 requests each
-    for burst in 0..10 {
-        for i in 0..200 {
-            let req = burst * 200 + i;
-            match service.ready().await.unwrap().call(req).await {
-                Ok(_) => {}
-                Err(_) => {
-                    rejected_count.fetch_add(1, Ordering::Relaxed);
-                }
-            }
+    // 10 barrier-gated bursts of 200 concurrent requests, one full refresh
+    // period apart so each burst starts against a freshly reset window.
+    for burst in 0..BURSTS {
+        let first_request = burst * CALLERS_PER_BURST;
+        let (batch_admitted, batch_rejected) =
+            run_gated_batch(&service, first_request..first_request + CALLERS_PER_BURST).await;
+        assert_eq!(batch_admitted, LIMIT, "burst {burst} admission count");
+        assert_eq!(
+            batch_rejected,
+            CALLERS_PER_BURST as usize - LIMIT,
+            "burst {burst} rejection count"
+        );
+        admitted += batch_admitted;
+        rejected += batch_rejected;
+
+        if burst + 1 < BURSTS {
+            sleep(REFRESH_PERIOD).await;
         }
-        // Small delay between bursts
-        sleep(Duration::from_millis(150)).await;
     }
 
     let elapsed = start.elapsed();
-    let permitted = permitted_count.load(Ordering::Relaxed);
-    let rejected = rejected_count.load(Ordering::Relaxed);
 
-    println!("10 bursts of 200 requests in {:?}", elapsed);
-    println!("Permitted: {}", permitted);
-    println!("Rejected: {}", rejected);
-    println!("Total: {}", permitted + rejected);
+    println!("{BURSTS} bursts of {CALLERS_PER_BURST} requests in {elapsed:?}");
+    println!("Permitted: {admitted}");
+    println!("Rejected: {rejected}");
+    println!("Total: {}", admitted + rejected);
 
-    assert_eq!(permitted + rejected, 2000);
-    // With 100ms refresh and 100 limit, should permit ~1000-1500 over all bursts
-    assert!((800..=1600).contains(&permitted));
+    let total = (BURSTS * CALLERS_PER_BURST) as usize;
+    assert_eq!(admitted, BURSTS as usize * LIMIT);
+    assert_eq!(permitted_count.load(Ordering::Relaxed), admitted);
+    assert_eq!(admitted + rejected, total);
 }
 
 /// Test: Permit refresh over time
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 #[ignore]
 async fn stress_permit_refresh_timing() {
+    const LIMIT: usize = 100;
+    const CALLERS: u32 = 1000;
+    const REFRESH_PERIOD: Duration = Duration::from_millis(100);
+
     let call_count = Arc::new(AtomicUsize::new(0));
     let counter = Arc::clone(&call_count);
 
@@ -218,40 +276,36 @@ async fn stress_permit_refresh_timing() {
     });
 
     let layer = RateLimiterLayer::builder()
-        .limit_for_period(100)
-        .refresh_period(Duration::from_millis(100))
-        .timeout_duration(Duration::from_millis(200))
+        .limit_for_period(LIMIT)
+        .refresh_period(REFRESH_PERIOD)
+        // Wide enough that no caller times out while waiting out refreshes.
+        .timeout_duration(Duration::from_secs(2))
         .build();
 
-    let mut service = layer.layer(svc);
+    let service = layer.layer(svc);
 
     let start = Instant::now();
-    let mut success = 0;
-
-    // Run for 1 second
-    let mut i = 0u32;
-    while start.elapsed() < Duration::from_secs(1) {
-        if service.ready().await.unwrap().call(i).await.is_ok() {
-            success += 1;
-        }
-        i += 1;
-    }
-
+    let (admitted, rejected) = run_gated_batch(&service, 0..CALLERS).await;
     let elapsed = start.elapsed();
     let actual_calls = call_count.load(Ordering::Relaxed);
 
-    println!("Permit refresh test over {:?}", elapsed);
-    println!("Total requests attempted: {}", i);
-    println!("Successful requests: {}", success);
-    println!("Actual service calls: {}", actual_calls);
-    println!(
-        "Effective rate: {:.0} req/sec",
-        actual_calls as f64 / elapsed.as_secs_f64()
-    );
+    // The initial window admits LIMIT immediately; every following group of
+    // LIMIT callers needs one more complete refresh. With a timeout longer
+    // than the total wait, all callers are eventually admitted after nine
+    // refreshes -- deterministic under the paused clock, independent of
+    // scheduler or wall-clock speed.
+    let refreshes_needed = (CALLERS as usize - 1) / LIMIT;
+    let expected_elapsed = REFRESH_PERIOD.saturating_mul(refreshes_needed as u32);
 
-    // With 100ms refresh and 100 limit, should get ~1000 req/sec
-    assert!((800..=1200).contains(&actual_calls));
-    assert_eq!(success, actual_calls);
+    println!("Permit refresh test over {elapsed:?}");
+    println!("Total requests attempted: {CALLERS}");
+    println!("Successful requests: {admitted}");
+    println!("Actual service calls: {actual_calls}");
+
+    assert_eq!(admitted, CALLERS as usize);
+    assert_eq!(rejected, 0);
+    assert_eq!(actual_calls, admitted);
+    assert_eq!(elapsed, expected_elapsed);
 }
 
 /// Test: Memory stability over extended period
@@ -308,11 +362,14 @@ async fn stress_memory_stability() {
 }
 
 /// Test: Timeout behavior under load
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 #[ignore]
 async fn stress_timeout_behavior() {
+    const LIMIT: usize = 50;
+    const CALLERS: u32 = 1000;
+    const TIMEOUT: Duration = Duration::from_millis(1);
+
     let permitted_count = Arc::new(AtomicUsize::new(0));
-    let timeout_count = Arc::new(AtomicUsize::new(0));
     let permitted = Arc::clone(&permitted_count);
 
     let svc = tower::service_fn(move |_req: u32| {
@@ -321,37 +378,33 @@ async fn stress_timeout_behavior() {
     });
 
     let layer = RateLimiterLayer::builder()
-        .limit_for_period(50)
+        .limit_for_period(LIMIT)
         .refresh_period(Duration::from_secs(1))
-        .timeout_duration(Duration::from_millis(1)) // Very short timeout
+        .timeout_duration(TIMEOUT) // Very short timeout
         .build();
 
-    let mut service = layer.layer(svc);
+    let service = layer.layer(svc);
 
     let start = Instant::now();
-
-    for i in 0..1000 {
-        match service.ready().await.unwrap().call(i).await {
-            Ok(_) => {}
-            Err(_) => {
-                timeout_count.fetch_add(1, Ordering::Relaxed);
-            }
-        }
-    }
-
+    let (admitted, timeouts) = run_gated_batch(&service, 0..CALLERS).await;
     let elapsed = start.elapsed();
-    let permitted = permitted_count.load(Ordering::Relaxed);
-    let timeouts = timeout_count.load(Ordering::Relaxed);
 
-    println!("Timeout test: 1000 requests in {:?}", elapsed);
-    println!("Permitted: {}", permitted);
-    println!("Timed out: {}", timeouts);
-    println!("Timeout rate: {:.1}%", timeouts as f64 / 1000.0 * 100.0);
+    println!("Timeout test: {CALLERS} simultaneous requests in {elapsed:?}");
+    println!("Permitted: {admitted}");
+    println!("Timed out: {timeouts}");
+    println!(
+        "Timeout rate: {:.1}%",
+        timeouts as f64 / f64::from(CALLERS) * 100.0
+    );
 
-    // With 50 limit and very short timeout, most should timeout
-    assert!(timeouts > 900, "Expected most requests to timeout");
-    assert!(permitted < 100, "Expected few requests to be permitted");
-    assert_eq!(permitted + timeouts, 1000);
+    // All callers arrive together; exactly LIMIT consume a permit and the
+    // 1ms timeout rejects the rest before the next refresh -- deterministic
+    // under the paused clock.
+    assert_eq!(admitted, LIMIT);
+    assert_eq!(timeouts, CALLERS as usize - LIMIT);
+    assert_eq!(permitted_count.load(Ordering::Relaxed), admitted);
+    assert_eq!(admitted + timeouts, CALLERS as usize);
+    assert_eq!(elapsed, TIMEOUT);
 }
 
 /// Test: Multiple concurrent rate limiters


### PR DESCRIPTION
## Plan

The rate-limiter stress matrix asserts admission counts based on
sequential-request-loop timing, which makes the assertions depend on real
wall-clock scheduling rather than the rate limiter's actual admission
semantics. Three tests fail under CI load as a result:

- `stress_burst_traffic`: hard-coded `(800..=1600)` admission range, observed
  1,840 admitted (sequential timeouts stretch bursts across extra refresh
  windows).
- `stress_rate_limit_enforcement`: asserts `rejected > 500`, observed 450
  rejected over ~5 seconds spanning five separate refresh windows.
- `stress_timeout_behavior`: strict `timeouts > 900`, observed exactly
  900/1000 -- a valid boundary a strict `>` incorrectly rejects.

Fix: make requests within each asserted window arrive concurrently
(barrier-gated) and drive time with `tokio::time::pause()` /
`#[tokio::test(start_paused = true)]` so elapsed time within a window is
exact and deterministic instead of dependent on scheduler speed. This
mirrors the barrier + paused-clock pattern already used for the rate
limiter's own internal contention tests in
`crates/tower-resilience-ratelimiter/src/limiter.rs`.

A fourth test (`stress_permit_refresh_timing`) shares the same defect class
(a hard-coded real-time-throughput range) and gets the same treatment for
consistency with the acceptance criteria.

### Changes

- Add `test-util` to the root `Cargo.toml` tokio feature set (needed for
  paused-clock testing at the workspace-test level).
- Add a `run_gated_batch` helper in `tests/stress/ratelimiter.rs` that
  spawns cloned services behind a `tokio::sync::Barrier` and reports
  admitted/rejected counts.
- Convert `stress_rate_limit_enforcement`, `stress_burst_traffic`,
  `stress_timeout_behavior`, and `stress_permit_refresh_timing` to
  barrier-gated concurrent batches under paused virtual time, with exact
  `assert_eq!` on admission counts instead of fuzzy/strict-boundary ranges.
- Keep a contention check per test: the inner service's actual call count
  must equal the batch's reported `admitted` count, proving no caller
  reaches the inner service without consuming a permit.

### Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test --locked --test stress ratelimiter -- --ignored --nocapture --test-threads=1`
  run repeatedly (10x) to confirm reliability
- Full stress matrix run once to confirm no regressions elsewhere

closes #402
closes #404