### PR TITLE
fix(retry): implement TPS-based budget replenishment with atomic accounting (closes #370)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2832,6 +2832,7 @@ dependencies = [
  "futures",
  "metrics",
  "rand 0.9.2",
+ "thiserror 2.0.17",
  "tokio",
  "tower",
  "tower-resilience-core",

--- a/crates/tower-resilience-retry/Cargo.toml
+++ b/crates/tower-resilience-retry/Cargo.toml
@@ -17,6 +17,7 @@ tower = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true }
 rand = "0.9"
+thiserror = { workspace = true }
 
 # Optional dependencies
 metrics = { workspace = true, optional = true }

--- a/crates/tower-resilience-retry/src/budget.rs
+++ b/crates/tower-resilience-retry/src/budget.rs
@@ -3,9 +3,35 @@
 //! Retry budgets limit the total number of retries across all requests,
 //! preventing cascading failures when a downstream service is struggling.
 
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
-use tower_resilience_core::aimd::{AimdConfig, AimdController};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tower_resilience_core::aimd::{AimdConfig, AimdConfigError, AimdController};
+
+/// Errors that can occur when constructing a retry budget.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+#[non_exhaustive]
+pub enum RetryBudgetConfigError {
+    /// `tokens_per_second` is not finite, or is negative.
+    #[error("tokens_per_second ({0}) must be finite and non-negative")]
+    InvalidTokensPerSecond(f64),
+    /// `initial_tokens` exceeds `max_tokens`.
+    #[error("initial_tokens ({initial_tokens}) must not exceed max_tokens ({max_tokens})")]
+    InitialExceedsMax {
+        /// The configured initial token count.
+        initial_tokens: usize,
+        /// The configured maximum token count.
+        max_tokens: usize,
+    },
+    /// `deposit_amount` is zero, which would make deposits a no-op.
+    #[error("deposit_amount must be greater than zero")]
+    ZeroDepositAmount,
+    /// `withdraw_amount` is zero, which would make withdrawals free.
+    #[error("withdraw_amount must be greater than zero")]
+    ZeroWithdrawAmount,
+    /// The underlying AIMD controller configuration is invalid.
+    #[error(transparent)]
+    Aimd(#[from] AimdConfigError),
+}
 
 /// A budget that controls how many retries are allowed.
 ///
@@ -46,11 +72,14 @@ impl RetryBudgetBuilder {
     /// ```rust
     /// use tower_resilience_retry::RetryBudgetBuilder;
     ///
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let budget = RetryBudgetBuilder::new()
     ///     .token_bucket()
     ///     .tokens_per_second(10.0)
     ///     .max_tokens(100)
-    ///     .build();
+    ///     .build()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn token_bucket(self) -> TokenBucketBuilder {
         TokenBucketBuilder {
@@ -72,11 +101,14 @@ impl RetryBudgetBuilder {
     /// ```rust
     /// use tower_resilience_retry::RetryBudgetBuilder;
     ///
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let budget = RetryBudgetBuilder::new()
     ///     .aimd()
     ///     .min_budget(10)
     ///     .max_budget(1000)
-    ///     .build();
+    ///     .build()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn aimd(self) -> AimdBudgetBuilder {
         AimdBudgetBuilder {
@@ -122,12 +154,18 @@ impl TokenBucketBuilder {
     }
 
     /// Build the token bucket budget.
-    pub fn build(self) -> Arc<dyn RetryBudget> {
-        Arc::new(TokenBucketBudget::new(
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RetryBudgetConfigError::InvalidTokensPerSecond`] if the rate is not
+    /// finite or is negative, or [`RetryBudgetConfigError::InitialExceedsMax`] if
+    /// `initial_tokens` exceeds `max_tokens`.
+    pub fn build(self) -> Result<Arc<dyn RetryBudget>, RetryBudgetConfigError> {
+        Ok(Arc::new(TokenBucketBudget::new(
             self.tokens_per_second,
             self.max_tokens,
             self.initial_tokens.unwrap_or(self.max_tokens),
-        ))
+        )?))
     }
 }
 
@@ -186,72 +224,211 @@ impl AimdBudgetBuilder {
     }
 
     /// Build the AIMD budget.
-    pub fn build(self) -> Arc<dyn RetryBudget> {
-        Arc::new(AimdBudget::new(
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RetryBudgetConfigError::ZeroDepositAmount`] or
+    /// [`RetryBudgetConfigError::ZeroWithdrawAmount`] if either amount is zero, or
+    /// [`RetryBudgetConfigError::Aimd`] if the derived AIMD controller configuration
+    /// is invalid (for example, `min_budget` exceeds `max_budget`).
+    pub fn build(self) -> Result<Arc<dyn RetryBudget>, RetryBudgetConfigError> {
+        Ok(Arc::new(AimdBudget::new(
             self.min_budget,
             self.max_budget,
             self.deposit_amount,
             self.withdraw_amount,
             self.decrease_factor,
-        ))
+        )?))
+    }
+}
+
+/// A source of elapsed time, used to drive time-based token refill.
+///
+/// Production budgets use [`MonotonicClock`]. Tests inject a manual clock so
+/// refill behavior can be verified deterministically without real sleeps.
+trait BudgetClock: Send + Sync {
+    /// Elapsed time since the clock was created.
+    fn now(&self) -> Duration;
+}
+
+/// [`BudgetClock`] implementation backed by [`Instant`].
+struct MonotonicClock {
+    start: Instant,
+}
+
+impl MonotonicClock {
+    fn new() -> Self {
+        Self {
+            start: Instant::now(),
+        }
+    }
+}
+
+impl BudgetClock for MonotonicClock {
+    fn now(&self) -> Duration {
+        self.start.elapsed()
+    }
+}
+
+/// Mutable, mutex-guarded state for a [`TokenBucketBudget`].
+///
+/// All fields are read, refilled, and mutated under a single lock acquisition
+/// so concurrent `try_withdraw`/`deposit`/`balance` calls cannot race.
+struct TokenBucketState {
+    /// Whole tokens currently available.
+    tokens: usize,
+    /// Fractional token credit carried between refills, always in `[0.0, 1.0)`.
+    fractional: f64,
+    /// Elapsed time (per the budget's clock) at the last refill.
+    last_refill: Duration,
+}
+
+impl TokenBucketState {
+    /// Lazily apply time-based refill up to `now`, capped at `max_tokens`.
+    ///
+    /// Fractional token credit is preserved across calls (and across the cap)
+    /// so a slow rate like 0.5/sec still eventually yields whole tokens.
+    fn refill(&mut self, now: Duration, tokens_per_second: f64, max_tokens: usize) {
+        if tokens_per_second > 0.0 {
+            let elapsed = now.saturating_sub(self.last_refill);
+            if elapsed > Duration::ZERO {
+                let gained = self.fractional + elapsed.as_secs_f64() * tokens_per_second;
+                let whole_gained = gained.floor();
+                self.fractional = gained - whole_gained;
+                let capacity_left = max_tokens.saturating_sub(self.tokens) as f64;
+                let whole_gained = whole_gained.min(capacity_left).max(0.0) as usize;
+                self.tokens = self.tokens.saturating_add(whole_gained).min(max_tokens);
+            }
+        }
+        self.last_refill = now;
     }
 }
 
 /// Token bucket retry budget.
 ///
-/// Tokens are consumed by retries and replenished by successful requests.
-/// This provides a simple way to limit retry storms.
+/// Tokens are replenished continuously at `tokens_per_second` (elapsed-time
+/// based refill, computed lazily on each access) and are additionally
+/// deposited by successful requests. Tokens are consumed by retries. This
+/// provides a simple way to limit retry storms.
+///
+/// This budget is intentionally comparable to Tower's own transactions-per-second
+/// (TPS) retry budget concept; see the upstream tracking issues
+/// [tower-rs/tower#857](https://github.com/tower-rs/tower/issues/857) and
+/// [tower-rs/tower#863](https://github.com/tower-rs/tower/issues/863) for
+/// discussion of TPS budget semantics parity.
 pub struct TokenBucketBudget {
-    /// Current token balance (scaled by 1000 for precision)
-    tokens: AtomicU64,
-    /// Maximum tokens (scaled)
-    max_tokens: u64,
+    /// Token balance and refill bookkeeping, serialized under one lock.
+    state: Mutex<TokenBucketState>,
+    /// Token refill rate, in tokens per second. `0.0` disables time-based refill.
+    tokens_per_second: f64,
+    /// Maximum tokens (burst capacity).
+    max_tokens: usize,
+    /// Source of elapsed time driving refill.
+    clock: Arc<dyn BudgetClock>,
+}
+
+impl std::fmt::Debug for TokenBucketBudget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        f.debug_struct("TokenBucketBudget")
+            .field("tokens", &state.tokens)
+            .field("fractional", &state.fractional)
+            .field("tokens_per_second", &self.tokens_per_second)
+            .field("max_tokens", &self.max_tokens)
+            .finish()
+    }
 }
 
 impl TokenBucketBudget {
     /// Create a new token bucket budget.
     ///
-    /// Note: `tokens_per_second` is currently unused - tokens are only
-    /// replenished via `deposit()` calls on successful requests.
-    pub fn new(_tokens_per_second: f64, max_tokens: usize, initial_tokens: usize) -> Self {
-        const SCALE: u64 = 1000;
-        Self {
-            tokens: AtomicU64::new((initial_tokens as u64) * SCALE),
-            max_tokens: (max_tokens as u64) * SCALE,
+    /// # Errors
+    ///
+    /// Returns [`RetryBudgetConfigError::InvalidTokensPerSecond`] if `tokens_per_second`
+    /// is not finite or is negative, or [`RetryBudgetConfigError::InitialExceedsMax`]
+    /// if `initial_tokens` exceeds `max_tokens`.
+    pub fn new(
+        tokens_per_second: f64,
+        max_tokens: usize,
+        initial_tokens: usize,
+    ) -> Result<Self, RetryBudgetConfigError> {
+        Self::with_clock(
+            tokens_per_second,
+            max_tokens,
+            initial_tokens,
+            Arc::new(MonotonicClock::new()),
+        )
+    }
+
+    /// Test-only constructor that injects a manual clock instead of wall-clock time.
+    #[cfg(test)]
+    fn new_with_clock(
+        tokens_per_second: f64,
+        max_tokens: usize,
+        initial_tokens: usize,
+        clock: Arc<dyn BudgetClock>,
+    ) -> Result<Self, RetryBudgetConfigError> {
+        Self::with_clock(tokens_per_second, max_tokens, initial_tokens, clock)
+    }
+
+    fn with_clock(
+        tokens_per_second: f64,
+        max_tokens: usize,
+        initial_tokens: usize,
+        clock: Arc<dyn BudgetClock>,
+    ) -> Result<Self, RetryBudgetConfigError> {
+        if !tokens_per_second.is_finite() || tokens_per_second < 0.0 {
+            return Err(RetryBudgetConfigError::InvalidTokensPerSecond(
+                tokens_per_second,
+            ));
         }
+        if initial_tokens > max_tokens {
+            return Err(RetryBudgetConfigError::InitialExceedsMax {
+                initial_tokens,
+                max_tokens,
+            });
+        }
+
+        let now = clock.now();
+        Ok(Self {
+            state: Mutex::new(TokenBucketState {
+                tokens: initial_tokens,
+                fractional: 0.0,
+                last_refill: now,
+            }),
+            tokens_per_second,
+            max_tokens,
+            clock,
+        })
     }
 }
 
 impl RetryBudget for TokenBucketBudget {
     fn try_withdraw(&self) -> bool {
-        const SCALE: u64 = 1000;
+        let now = self.clock.now();
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.refill(now, self.tokens_per_second, self.max_tokens);
 
-        loop {
-            let current = self.tokens.load(Ordering::Relaxed);
-            if current < SCALE {
-                return false;
-            }
-            let new_tokens = current - SCALE;
-            if self
-                .tokens
-                .compare_exchange_weak(current, new_tokens, Ordering::Relaxed, Ordering::Relaxed)
-                .is_ok()
-            {
-                return true;
-            }
+        if state.tokens >= 1 {
+            state.tokens -= 1;
+            true
+        } else {
+            false
         }
     }
 
     fn deposit(&self) {
-        const SCALE: u64 = 1000;
-        let current = self.tokens.load(Ordering::Relaxed);
-        let new_tokens = (current + SCALE).min(self.max_tokens);
-        self.tokens.store(new_tokens, Ordering::Relaxed);
+        let now = self.clock.now();
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.refill(now, self.tokens_per_second, self.max_tokens);
+        state.tokens = (state.tokens + 1).min(self.max_tokens);
     }
 
     fn balance(&self) -> usize {
-        const SCALE: u64 = 1000;
-        (self.tokens.load(Ordering::Relaxed) / SCALE) as usize
+        let now = self.clock.now();
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.refill(now, self.tokens_per_second, self.max_tokens);
+        state.tokens
     }
 }
 
@@ -262,27 +439,42 @@ impl RetryBudget for TokenBucketBudget {
 ///
 /// This implementation uses the shared [`AimdController`] from `tower-resilience-core`
 /// to manage the dynamic maximum limit, while tracking the current token balance
-/// separately.
+/// separately under its own lock.
+#[derive(Debug)]
 pub struct AimdBudget {
-    /// Current token balance
-    tokens: AtomicU64,
-    /// AIMD controller for the maximum budget limit
+    /// Current token balance, serialized under one lock.
+    tokens: Mutex<usize>,
+    /// AIMD controller for the maximum budget limit.
     limit_controller: AimdController,
-    /// Tokens to add on deposit
-    deposit_amount: u64,
-    /// Tokens to remove on withdraw
-    withdraw_amount: u64,
+    /// Tokens to add on deposit.
+    deposit_amount: usize,
+    /// Tokens to remove on withdraw.
+    withdraw_amount: usize,
 }
 
 impl AimdBudget {
     /// Create a new AIMD budget.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RetryBudgetConfigError::ZeroDepositAmount`] if `deposit_amount` is
+    /// zero, [`RetryBudgetConfigError::ZeroWithdrawAmount`] if `withdraw_amount` is
+    /// zero, or [`RetryBudgetConfigError::Aimd`] if the derived [`AimdConfig`] is
+    /// invalid (for example, `min_budget` exceeds `max_budget`).
     pub fn new(
         min_budget: usize,
         max_budget: usize,
         deposit_amount: usize,
         withdraw_amount: usize,
         decrease_factor: f64,
-    ) -> Self {
+    ) -> Result<Self, RetryBudgetConfigError> {
+        if deposit_amount == 0 {
+            return Err(RetryBudgetConfigError::ZeroDepositAmount);
+        }
+        if withdraw_amount == 0 {
+            return Err(RetryBudgetConfigError::ZeroWithdrawAmount);
+        }
+
         let config = AimdConfig::new()
             .with_initial_limit(max_budget)
             .with_min_limit(min_budget)
@@ -290,13 +482,14 @@ impl AimdBudget {
             .with_increase_by(1) // Slowly recover the max limit
             .with_decrease_factor(decrease_factor);
 
-        Self {
-            tokens: AtomicU64::new(max_budget as u64),
-            limit_controller: AimdController::new(config)
-                .expect("invalid AIMD budget configuration"),
-            deposit_amount: deposit_amount as u64,
-            withdraw_amount: withdraw_amount as u64,
-        }
+        let limit_controller = AimdController::new(config)?;
+
+        Ok(Self {
+            tokens: Mutex::new(max_budget),
+            limit_controller,
+            deposit_amount,
+            withdraw_amount,
+        })
     }
 
     /// Get the current maximum limit (controlled by AIMD).
@@ -307,60 +500,85 @@ impl AimdBudget {
 
 impl RetryBudget for AimdBudget {
     fn try_withdraw(&self) -> bool {
-        loop {
-            let current = self.tokens.load(Ordering::Relaxed);
-            if current < self.withdraw_amount {
-                // Budget exhausted - apply multiplicative decrease to max via controller
-                self.limit_controller.record_failure();
-                return false;
+        let mut tokens = self.tokens.lock().unwrap_or_else(|e| e.into_inner());
+
+        if *tokens >= self.withdraw_amount {
+            *tokens -= self.withdraw_amount;
+            true
+        } else {
+            // Budget exhausted - apply multiplicative decrease to max via controller,
+            // then clamp the balance to the (possibly lower) new max.
+            self.limit_controller.record_failure();
+            let new_max = self.limit_controller.limit();
+            if *tokens > new_max {
+                *tokens = new_max;
             }
-            let new_tokens = current - self.withdraw_amount;
-            if self
-                .tokens
-                .compare_exchange_weak(current, new_tokens, Ordering::Relaxed, Ordering::Relaxed)
-                .is_ok()
-            {
-                return true;
-            }
+            false
         }
     }
 
     fn deposit(&self) {
-        let current_max = self.limit_controller.limit() as u64;
-        let current = self.tokens.load(Ordering::Relaxed);
+        let mut tokens = self.tokens.lock().unwrap_or_else(|e| e.into_inner());
 
-        // Additive increase: add deposit amount, cap at current max
-        let new_tokens = (current + self.deposit_amount).min(current_max);
-        self.tokens.store(new_tokens, Ordering::Relaxed);
-
-        // Also slowly increase the max back toward absolute max via controller
+        // Slowly increase the max back toward the absolute max via the controller.
         self.limit_controller.record_success();
+        let current_max = self.limit_controller.limit();
+
+        // Additive increase: add deposit amount, cap at current max.
+        *tokens = (*tokens + self.deposit_amount).min(current_max);
     }
 
     fn balance(&self) -> usize {
-        self.tokens.load(Ordering::Relaxed) as usize
+        *self.tokens.lock().unwrap_or_else(|e| e.into_inner())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread;
+
+    /// Manual [`BudgetClock`] for deterministic, virtual-time tests.
+    struct ManualClock {
+        now: Mutex<Duration>,
+    }
+
+    impl ManualClock {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                now: Mutex::new(Duration::ZERO),
+            })
+        }
+
+        fn advance(&self, delta: Duration) {
+            let mut now = self.now.lock().unwrap();
+            *now += delta;
+        }
+    }
+
+    impl BudgetClock for ManualClock {
+        fn now(&self) -> Duration {
+            *self.now.lock().unwrap()
+        }
+    }
+
+    // --- Basic behavior (virtual time, no drift) -----------------------
 
     #[test]
-    fn test_token_bucket_basic() {
-        let budget = TokenBucketBudget::new(10.0, 5, 5);
+    fn test_token_bucket_initial_burst_and_success_deposit() {
+        let clock = ManualClock::new();
+        let budget = TokenBucketBudget::new_with_clock(0.0, 5, 5, clock).unwrap();
 
-        // Should allow 5 withdrawals
-        assert!(budget.try_withdraw());
-        assert!(budget.try_withdraw());
-        assert!(budget.try_withdraw());
-        assert!(budget.try_withdraw());
-        assert!(budget.try_withdraw());
+        // Should allow 5 withdrawals (initial burst).
+        for _ in 0..5 {
+            assert!(budget.try_withdraw());
+        }
 
-        // 6th should fail
+        // 6th should fail - budget exhausted, no time-based refill (rate is 0).
         assert!(!budget.try_withdraw());
 
-        // Deposit should allow one more
+        // A success deposit allows exactly one more withdrawal.
         budget.deposit();
         assert!(budget.try_withdraw());
         assert!(!budget.try_withdraw());
@@ -368,7 +586,8 @@ mod tests {
 
     #[test]
     fn test_token_bucket_balance() {
-        let budget = TokenBucketBudget::new(10.0, 100, 50);
+        let clock = ManualClock::new();
+        let budget = TokenBucketBudget::new_with_clock(0.0, 100, 50, clock).unwrap();
         assert_eq!(budget.balance(), 50);
 
         budget.try_withdraw();
@@ -379,8 +598,71 @@ mod tests {
     }
 
     #[test]
+    fn test_token_bucket_zero_rate_disables_time_refill_but_allows_deposit() {
+        let clock = ManualClock::new();
+        let budget = TokenBucketBudget::new_with_clock(0.0, 10, 0, clock.clone()).unwrap();
+        assert_eq!(budget.balance(), 0);
+
+        // Elapsed time alone must not replenish when the rate is zero.
+        clock.advance(Duration::from_secs(3600));
+        assert_eq!(budget.balance(), 0);
+
+        // Deposits still work.
+        budget.deposit();
+        assert_eq!(budget.balance(), 1);
+    }
+
+    #[test]
+    fn test_token_bucket_fractional_rate_refill_accrues_over_several_advances() {
+        let clock = ManualClock::new();
+        // 0.5 tokens/sec: every 2 seconds of elapsed time yields exactly 1 token.
+        let budget = TokenBucketBudget::new_with_clock(0.5, 10, 0, clock.clone()).unwrap();
+        assert_eq!(budget.balance(), 0);
+
+        clock.advance(Duration::from_secs(2));
+        assert_eq!(budget.balance(), 1);
+
+        clock.advance(Duration::from_secs(2));
+        assert_eq!(budget.balance(), 2);
+
+        // Two 1-second advances (each sub-token on their own) sum to one more
+        // whole token, demonstrating the fractional carry is retained across
+        // separate calls rather than being reset or truncated away.
+        clock.advance(Duration::from_secs(1));
+        assert_eq!(budget.balance(), 2);
+        clock.advance(Duration::from_secs(1));
+        assert_eq!(budget.balance(), 3);
+
+        // A very large elapsed time caps at max_tokens rather than overflowing.
+        clock.advance(Duration::from_secs(1000));
+        assert_eq!(budget.balance(), 10);
+    }
+
+    #[test]
+    fn test_token_bucket_success_deposit_preserves_fractional_credit() {
+        let clock = ManualClock::new();
+        let budget = TokenBucketBudget::new_with_clock(0.5, 10, 0, clock.clone()).unwrap();
+
+        // Accrue half a token (rate 0.5/sec over 1 second).
+        clock.advance(Duration::from_secs(1));
+        assert_eq!(budget.balance(), 0);
+
+        // A success deposit adds one whole token on top of time-based refill,
+        // without discarding the pending fractional credit.
+        budget.deposit();
+        assert_eq!(budget.balance(), 1);
+
+        // The other half of the original second's credit is still pending;
+        // one more second completes it into a second whole token.
+        clock.advance(Duration::from_secs(1));
+        assert_eq!(budget.balance(), 2);
+    }
+
+    // --- AIMD basic behavior ---------------------------------------------
+
+    #[test]
     fn test_aimd_basic() {
-        let budget = AimdBudget::new(5, 10, 1, 1, 0.5);
+        let budget = AimdBudget::new(5, 10, 1, 1, 0.5).unwrap();
 
         // Should allow 10 withdrawals
         for _ in 0..10 {
@@ -401,7 +683,7 @@ mod tests {
 
     #[test]
     fn test_aimd_min_budget_floor() {
-        let budget = AimdBudget::new(5, 10, 1, 1, 0.1);
+        let budget = AimdBudget::new(5, 10, 1, 1, 0.1).unwrap();
 
         // Exhaust budget multiple times
         for _ in 0..10 {
@@ -431,7 +713,7 @@ mod tests {
 
     #[test]
     fn test_aimd_current_max() {
-        let budget = AimdBudget::new(5, 100, 1, 1, 0.5);
+        let budget = AimdBudget::new(5, 100, 1, 1, 0.5).unwrap();
         assert_eq!(budget.current_max(), 100);
 
         // Exhaust and trigger decrease
@@ -446,7 +728,7 @@ mod tests {
     #[test]
     fn test_aimd_uses_shared_controller() {
         // Verify that the AIMD budget correctly uses the shared controller
-        let budget = AimdBudget::new(1, 10, 1, 1, 0.5);
+        let budget = AimdBudget::new(1, 10, 1, 1, 0.5).unwrap();
 
         // Exhaust tokens
         for _ in 0..10 {
@@ -471,7 +753,8 @@ mod tests {
             .tokens_per_second(100.0)
             .max_tokens(50)
             .initial_tokens(25)
-            .build();
+            .build()
+            .unwrap();
 
         assert_eq!(budget.balance(), 25);
     }
@@ -484,8 +767,203 @@ mod tests {
             .max_budget(100)
             .deposit_amount(2)
             .withdraw_amount(1)
-            .build();
+            .build()
+            .unwrap();
 
         assert_eq!(budget.balance(), 100);
+    }
+
+    // --- Configuration errors --------------------------------------------
+
+    #[test]
+    fn test_token_bucket_rejects_nan_rate() {
+        let err = TokenBucketBudget::new(f64::NAN, 10, 5).unwrap_err();
+        match err {
+            RetryBudgetConfigError::InvalidTokensPerSecond(rate) => assert!(rate.is_nan()),
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_token_bucket_rejects_negative_rate() {
+        let err = TokenBucketBudget::new(-1.0, 10, 5).unwrap_err();
+        assert_eq!(err, RetryBudgetConfigError::InvalidTokensPerSecond(-1.0));
+    }
+
+    #[test]
+    fn test_token_bucket_rejects_initial_exceeding_max() {
+        let err = TokenBucketBudget::new(1.0, 5, 10).unwrap_err();
+        assert_eq!(
+            err,
+            RetryBudgetConfigError::InitialExceedsMax {
+                initial_tokens: 10,
+                max_tokens: 5,
+            }
+        );
+    }
+
+    #[test]
+    fn test_aimd_rejects_zero_deposit_amount() {
+        let err = AimdBudget::new(1, 10, 0, 1, 0.5).unwrap_err();
+        assert_eq!(err, RetryBudgetConfigError::ZeroDepositAmount);
+    }
+
+    #[test]
+    fn test_aimd_rejects_zero_withdraw_amount() {
+        let err = AimdBudget::new(1, 10, 1, 0, 0.5).unwrap_err();
+        assert_eq!(err, RetryBudgetConfigError::ZeroWithdrawAmount);
+    }
+
+    #[test]
+    fn test_aimd_propagates_min_exceeds_max_config_error() {
+        let err = AimdBudget::new(50, 10, 1, 1, 0.5).unwrap_err();
+        assert_eq!(
+            err,
+            RetryBudgetConfigError::Aimd(AimdConfigError::MinExceedsMax {
+                min_limit: 50,
+                max_limit: 10,
+            })
+        );
+    }
+
+    // --- Contention (real threads, no manual clock) ----------------------
+
+    #[test]
+    fn test_token_bucket_concurrent_deposits_are_not_lost() {
+        const THREADS: usize = 16;
+        const CALLS_PER_THREAD: usize = 1000;
+
+        let budget = Arc::new(TokenBucketBudget::new(0.0, 100_000, 0).unwrap());
+        let barrier = Arc::new(std::sync::Barrier::new(THREADS));
+
+        thread::scope(|s| {
+            for _ in 0..THREADS {
+                let budget = Arc::clone(&budget);
+                let barrier = Arc::clone(&barrier);
+                s.spawn(move || {
+                    barrier.wait();
+                    for _ in 0..CALLS_PER_THREAD {
+                        budget.deposit();
+                    }
+                });
+            }
+        });
+
+        assert_eq!(budget.balance(), THREADS * CALLS_PER_THREAD);
+    }
+
+    #[test]
+    fn test_token_bucket_concurrent_withdrawals_never_exceed_available_balance() {
+        const THREADS: usize = 16;
+        const CALLS_PER_THREAD: usize = 200;
+        const INITIAL_TOKENS: usize = 1000;
+
+        let budget = Arc::new(TokenBucketBudget::new(0.0, INITIAL_TOKENS, INITIAL_TOKENS).unwrap());
+        let barrier = Arc::new(std::sync::Barrier::new(THREADS));
+        let successes = Arc::new(AtomicUsize::new(0));
+
+        thread::scope(|s| {
+            for _ in 0..THREADS {
+                let budget = Arc::clone(&budget);
+                let barrier = Arc::clone(&barrier);
+                let successes = Arc::clone(&successes);
+                s.spawn(move || {
+                    barrier.wait();
+                    for _ in 0..CALLS_PER_THREAD {
+                        if budget.try_withdraw() {
+                            successes.fetch_add(1, Ordering::SeqCst);
+                        }
+                    }
+                });
+            }
+        });
+
+        // THREADS * CALLS_PER_THREAD attempts exceed INITIAL_TOKENS, so exactly
+        // INITIAL_TOKENS withdrawals must succeed - never more, never fewer.
+        assert_eq!(successes.load(Ordering::SeqCst), INITIAL_TOKENS);
+        assert_eq!(budget.balance(), 0);
+    }
+
+    #[test]
+    fn test_token_bucket_concurrent_mixed_deposit_withdraw_nets_out() {
+        const DEPOSIT_THREADS: usize = 8;
+        const DEPOSITS_PER_THREAD: usize = 500;
+        const WITHDRAW_THREADS: usize = 8;
+        const WITHDRAW_ATTEMPTS_PER_THREAD: usize = 100;
+        const INITIAL_TOKENS: usize = 500;
+
+        let budget = Arc::new(TokenBucketBudget::new(0.0, 1_000_000, INITIAL_TOKENS).unwrap());
+        let barrier = Arc::new(std::sync::Barrier::new(DEPOSIT_THREADS + WITHDRAW_THREADS));
+        let successful_withdrawals = Arc::new(AtomicUsize::new(0));
+
+        thread::scope(|s| {
+            for _ in 0..DEPOSIT_THREADS {
+                let budget = Arc::clone(&budget);
+                let barrier = Arc::clone(&barrier);
+                s.spawn(move || {
+                    barrier.wait();
+                    for _ in 0..DEPOSITS_PER_THREAD {
+                        budget.deposit();
+                    }
+                });
+            }
+
+            for _ in 0..WITHDRAW_THREADS {
+                let budget = Arc::clone(&budget);
+                let barrier = Arc::clone(&barrier);
+                let successful_withdrawals = Arc::clone(&successful_withdrawals);
+                s.spawn(move || {
+                    barrier.wait();
+                    for _ in 0..WITHDRAW_ATTEMPTS_PER_THREAD {
+                        if budget.try_withdraw() {
+                            successful_withdrawals.fetch_add(1, Ordering::SeqCst);
+                        }
+                    }
+                });
+            }
+        });
+
+        let total_deposits = DEPOSIT_THREADS * DEPOSITS_PER_THREAD;
+        let expected =
+            INITIAL_TOKENS + total_deposits - successful_withdrawals.load(Ordering::SeqCst);
+        assert_eq!(budget.balance(), expected);
+    }
+
+    #[test]
+    fn test_aimd_concurrent_deposits_are_not_lost_and_stay_within_current_max() {
+        const THREADS: usize = 16;
+        const CALLS_PER_THREAD: usize = 300;
+        const MAX_BUDGET: usize = 20_000;
+        const INITIAL_WITHDRAWALS: usize = 5_000;
+
+        let budget = Arc::new(AimdBudget::new(1, MAX_BUDGET, 1, 1, 0.5).unwrap());
+
+        // Drain some tokens serially, without exhausting the budget, so the
+        // AIMD max stays at MAX_BUDGET (no record_failure triggered) while
+        // leaving headroom for the concurrent deposits below.
+        for _ in 0..INITIAL_WITHDRAWALS {
+            assert!(budget.try_withdraw());
+        }
+        assert_eq!(budget.current_max(), MAX_BUDGET);
+
+        let barrier = Arc::new(std::sync::Barrier::new(THREADS));
+
+        thread::scope(|s| {
+            for _ in 0..THREADS {
+                let budget = Arc::clone(&budget);
+                let barrier = Arc::clone(&barrier);
+                s.spawn(move || {
+                    barrier.wait();
+                    for _ in 0..CALLS_PER_THREAD {
+                        budget.deposit();
+                    }
+                });
+            }
+        });
+
+        let expected = MAX_BUDGET - INITIAL_WITHDRAWALS + THREADS * CALLS_PER_THREAD;
+        assert_eq!(budget.current_max(), MAX_BUDGET);
+        assert_eq!(budget.balance(), expected);
+        assert!(budget.balance() <= budget.current_max());
     }
 }

--- a/crates/tower-resilience-retry/src/config.rs
+++ b/crates/tower-resilience-retry/src/config.rs
@@ -228,18 +228,21 @@ impl<Req, Res, E> RetryConfigBuilder<Req, Res, E> {
     /// use tower_resilience_retry::{RetryLayer, RetryBudgetBuilder};
     /// use std::time::Duration;
     ///
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// // Create a token bucket budget: 10 retries/sec, max burst of 100
     /// let budget = RetryBudgetBuilder::new()
     ///     .token_bucket()
     ///     .tokens_per_second(10.0)
     ///     .max_tokens(100)
-    ///     .build();
+    ///     .build()?;
     ///
     /// let layer = RetryLayer::<(), (), std::io::Error>::builder()
     ///     .max_attempts(5)
     ///     .exponential_backoff(Duration::from_millis(100))
     ///     .budget(budget)
     ///     .build();
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn budget(mut self, budget: Arc<dyn RetryBudget>) -> Self {
         self.budget = Some(budget);

--- a/crates/tower-resilience-retry/src/lib.rs
+++ b/crates/tower-resilience-retry/src/lib.rs
@@ -164,7 +164,9 @@ mod policy;
 pub use backoff::{
     ExponentialBackoff, ExponentialRandomBackoff, FixedInterval, FnInterval, IntervalFunction,
 };
-pub use budget::{AimdBudget, RetryBudget, RetryBudgetBuilder, TokenBucketBudget};
+pub use budget::{
+    AimdBudget, RetryBudget, RetryBudgetBuilder, RetryBudgetConfigError, TokenBucketBudget,
+};
 pub use config::{MaxAttemptsSource, RetryConfig, RetryConfigBuilder};
 pub use events::RetryEvent;
 pub use layer::RetryLayer;
@@ -667,12 +669,15 @@ mod tests {
         let cc = Arc::clone(&call_count);
         let bec = Arc::clone(&budget_exhausted_count);
 
-        // Create a budget with only 1 token
+        // Create a budget with only 1 token. Disable time-based refill so the
+        // test only exercises token-count accounting, not elapsed-time refill.
         let budget = RetryBudgetBuilder::new()
             .token_bucket()
+            .tokens_per_second(0.0)
             .max_tokens(1)
             .initial_tokens(1)
-            .build();
+            .build()
+            .unwrap();
 
         let service = service_fn(move |_req: String| {
             let cc = Arc::clone(&cc);
@@ -711,9 +716,11 @@ mod tests {
     async fn budget_replenishes_on_success() {
         let budget = RetryBudgetBuilder::new()
             .token_bucket()
+            .tokens_per_second(0.0) // Only exercise deposit()/try_withdraw() accounting
             .max_tokens(10)
             .initial_tokens(0) // Start empty
-            .build();
+            .build()
+            .unwrap();
 
         // Budget starts empty
         assert_eq!(budget.balance(), 0);


### PR DESCRIPTION
## Plan

Issue #370: the retry budget's `tokens_per_second` is currently unused, and concurrent consumption/deposit accounting on `TokenBucketBudget` and `AimdBudget` uses racy load-then-store sequences instead of atomic read-modify-write.

This PR reuses the atomic `AimdController` from PR #406 (closes #368) and:

- Implements real time-based token-bucket replenishment (`tokens_per_second`) via an internal testable clock, with fractional-rate carry between calls.
- Serializes token balance + refill state under a single mutex per budget instance so concurrent `try_withdraw`/`deposit`/`balance` calls cannot lose updates.
- Applies the same single-lock treatment to `AimdBudget`'s token balance (paired with the already-atomic `AimdController` for the dynamic max).
- Makes budget construction fallible (`RetryBudgetConfigError`) instead of panicking/silently clamping on invalid config (NaN/negative rate, initial > max, zero AIMD deposit/withdraw amounts).
- Adds deterministic virtual-time tests (manual clock) for fractional-rate refill and success-deposit interaction, plus real-thread contention tests for concurrent deposits/withdrawals.
- Notes `tower-rs/tower#857` and `tower-rs/tower#863` as upstream tracking issues for TPS budget semantics parity.

Scope: `crates/tower-resilience-retry/` only; `crates/tower-resilience-core/src/aimd.rs` is reused as-is. No changes under `tests/stress/**` or `.github/workflows/stress-tests.yml` -- if stress-suite coverage is warranted, that's a follow-up issue, not this PR.

Closes #370.