### PR TITLE
feat(circuitbreaker): make CircuitBreakerHandle a deterministic shared controller (closes #384)

### DIFF
--- a/crates/tower-resilience-circuitbreaker/CHANGELOG.md
+++ b/crates/tower-resilience-circuitbreaker/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Deterministic `force_open()`, `force_closed()`, and `reset()` control
+  operations on `CircuitBreakerHandle`. Previously these existed only on
+  the service (`CircuitBreaker`/`CircuitBreakerWithFallback`), which could
+  already have been moved, boxed, or dropped by the time external control
+  was needed. The handle holds its own `Arc` to the circuit shared by
+  every service the associated layer produces, so a retained handle
+  controls all of them deterministically: once a call completes, every
+  subsequent state inspection or admission check observes the new state,
+  with no sleep or poll loop required. Externally initiated transitions
+  emit the same `StateTransition` event and metrics as automatic ones.
+- `manual_mode()` builder option for a manual/external-only circuit that
+  never trips or recovers automatically from inner-service results (or
+  from the `wait_duration_in_open` recovery timer). State changes only via
+  an explicit `force_open`/`force_closed`/`reset` call -- a simple external
+  on/off switch, matching the broader circuit-breaker scope requested in
+  [tower-rs/tower#855](https://github.com/tower-rs/tower/pull/855).
+- `CircuitBreakerHandle` now also implements `HealthTriggerable` (under the
+  `health-integration` feature), so a handle retained after the original
+  service was moved or boxed can still serve as a health-check trigger
+  target. `CircuitBreakerHandle::force_open()`/`force_closed()` are
+  documented as the deterministic, awaitable alternative to the
+  fire-and-forget `HealthTriggerable::trigger_unhealthy()`/
+  `trigger_healthy()` methods.
+
 ### Fixed
 
 - Reserve half-open probe admission atomically with a per-cycle semaphore

--- a/crates/tower-resilience-circuitbreaker/src/circuit.rs
+++ b/crates/tower-resilience-circuitbreaker/src/circuit.rs
@@ -282,18 +282,24 @@ impl Circuit {
                 .record(duration.as_secs_f64());
         }
 
-        match self.state {
-            CircuitState::HalfOpen => {
-                let success_count = match config.sliding_window_type {
-                    SlidingWindowType::CountBased => self.success_count,
-                    SlidingWindowType::TimeBased => self.time_based_stats().2,
-                };
-                if success_count >= config.permitted_calls_in_half_open {
-                    self.transition_to(CircuitState::Closed, config);
+        // Manual/external-only mode: the counters, events, and metrics above
+        // are still recorded for observability, but the circuit never trips
+        // or recovers based on the outcome. State only changes via an
+        // explicit force_open/force_closed/reset call.
+        if !config.manual_mode {
+            match self.state {
+                CircuitState::HalfOpen => {
+                    let success_count = match config.sliding_window_type {
+                        SlidingWindowType::CountBased => self.success_count,
+                        SlidingWindowType::TimeBased => self.time_based_stats().2,
+                    };
+                    if success_count >= config.permitted_calls_in_half_open {
+                        self.transition_to(CircuitState::Closed, config);
+                    }
                 }
-            }
-            _ => {
-                self.evaluate_window(config);
+                _ => {
+                    self.evaluate_window(config);
+                }
             }
         }
     }
@@ -366,12 +372,16 @@ impl Circuit {
                 .record(duration.as_secs_f64());
         }
 
-        match self.state {
-            CircuitState::HalfOpen => {
-                self.transition_to(CircuitState::Open, config);
-            }
-            _ => {
-                self.evaluate_window(config);
+        // See the identical guard in `record_success` -- manual/external-only
+        // mode never trips or recovers based on inner-service results.
+        if !config.manual_mode {
+            match self.state {
+                CircuitState::HalfOpen => {
+                    self.transition_to(CircuitState::Open, config);
+                }
+                _ => {
+                    self.evaluate_window(config);
+                }
             }
         }
     }
@@ -389,7 +399,12 @@ impl Circuit {
                 Admission::Admitted(None)
             }
             CircuitState::Open => {
-                if self.last_state_change.elapsed() >= config.wait_duration_in_open {
+                // In manual mode the `wait_duration_in_open` recovery timer
+                // is disabled: the circuit stays open (rejecting) until
+                // something explicitly closes or resets it.
+                if !config.manual_mode
+                    && self.last_state_change.elapsed() >= config.wait_duration_in_open
+                {
                     self.transition_to(CircuitState::HalfOpen, config);
                     // `transition_to` just allocated a fresh half-open
                     // semaphore; evaluate admission again against the new
@@ -447,6 +462,13 @@ impl Circuit {
         match self.state {
             CircuitState::Closed => Ok(()),
             CircuitState::Open => {
+                if config.manual_mode {
+                    // The recovery timer is disabled in manual mode; report
+                    // the configured wait as a heartbeat interval for
+                    // backpressure callers, but the circuit will not open up
+                    // on its own no matter how long they wait.
+                    return Err(config.wait_duration_in_open);
+                }
                 let elapsed = self.last_state_change.elapsed();
                 if elapsed >= config.wait_duration_in_open {
                     // Wait has elapsed; try_acquire will transition to HalfOpen

--- a/crates/tower-resilience-circuitbreaker/src/config.rs
+++ b/crates/tower-resilience-circuitbreaker/src/config.rs
@@ -101,6 +101,7 @@ pub struct CircuitBreakerConfig<C> {
     pub(crate) event_listeners: EventListeners<CircuitBreakerEvent>,
     pub(crate) name: String,
     pub(crate) backpressure: bool,
+    pub(crate) manual_mode: bool,
 }
 
 /// Builder for configuring and constructing a circuit breaker.
@@ -152,6 +153,7 @@ pub struct CircuitBreakerConfigBuilder<C = DefaultClassifier> {
     event_listeners: EventListeners<CircuitBreakerEvent>,
     name: String,
     backpressure: bool,
+    manual_mode: bool,
 }
 
 impl Default for CircuitBreakerConfigBuilder<DefaultClassifier> {
@@ -181,6 +183,7 @@ impl CircuitBreakerConfigBuilder<DefaultClassifier> {
             event_listeners: EventListeners::new(),
             name: String::from("<unnamed>"),
             backpressure: false,
+            manual_mode: false,
         }
     }
 }
@@ -349,6 +352,48 @@ impl<C> CircuitBreakerConfigBuilder<C> {
         self
     }
 
+    /// Enables manual/external-only control mode.
+    ///
+    /// In manual mode the circuit never trips or recovers on its own:
+    /// `record_success`/`record_failure` still update counters and emit
+    /// their usual [`CircuitBreakerEvent`](crate::CircuitBreakerEvent)s and
+    /// metrics for observability, but the sliding-window evaluation, the
+    /// half-open success/failure thresholds, and the `Open -> HalfOpen`
+    /// recovery timer (`wait_duration_in_open`) are all disabled. Once the
+    /// circuit is opened, it stays open until something explicitly closes
+    /// or resets it.
+    ///
+    /// State changes only in response to an explicit
+    /// [`force_open`](crate::CircuitBreaker::force_open),
+    /// [`force_closed`](crate::CircuitBreaker::force_closed), or
+    /// [`reset`](crate::CircuitBreaker::reset) call -- typically issued
+    /// through a [`CircuitBreakerHandle`](crate::CircuitBreakerHandle)
+    /// shared with an external controller (health checks, admin APIs,
+    /// fleet control). This gives a simple external on/off switch, matching
+    /// the broader circuit-breaker scope requested in
+    /// [tower-rs/tower#855](https://github.com/tower-rs/tower/pull/855).
+    ///
+    /// Default: `false` (automatic trip/recovery)
+    ///
+    /// # Example
+    /// ```rust
+    /// use tower_resilience_circuitbreaker::CircuitBreakerLayer;
+    ///
+    /// let (layer, handle) = CircuitBreakerLayer::builder()
+    ///     .manual_mode()
+    ///     .build_with_handle();
+    ///
+    /// // Apply `layer` to a service...
+    /// // The circuit stays closed no matter how the inner service behaves,
+    /// // until something calls `handle.force_open()`.
+    /// let _ = layer;
+    /// let _ = handle;
+    /// ```
+    pub fn manual_mode(mut self) -> Self {
+        self.manual_mode = true;
+        self
+    }
+
     /// Sets a custom failure classifier function.
     ///
     /// The classifier determines which results should be counted as failures
@@ -421,6 +466,7 @@ impl<C> CircuitBreakerConfigBuilder<C> {
             event_listeners: self.event_listeners,
             name: self.name,
             backpressure: self.backpressure,
+            manual_mode: self.manual_mode,
         }
     }
 
@@ -492,6 +538,7 @@ impl<C> CircuitBreakerConfigBuilder<C> {
             event_listeners: self.event_listeners,
             name: self.name,
             backpressure: self.backpressure,
+            manual_mode: self.manual_mode,
         }
     }
 
@@ -886,6 +933,7 @@ impl<C> CircuitBreakerConfigBuilder<C> {
             event_listeners: self.event_listeners,
             name: self.name,
             backpressure: self.backpressure,
+            manual_mode: self.manual_mode,
         }
     }
 }

--- a/crates/tower-resilience-circuitbreaker/src/handle.rs
+++ b/crates/tower-resilience-circuitbreaker/src/handle.rs
@@ -6,20 +6,35 @@ use tokio::sync::Mutex;
 use crate::circuit::{Circuit, CircuitMetrics, CircuitState};
 use crate::config::CircuitBreakerConfig;
 
-/// A read-only handle for observing circuit breaker state.
+/// A deterministic shared handle for observing and controlling circuit
+/// breaker state from outside the service.
 ///
 /// Obtained from [`crate::CircuitBreakerConfigBuilder::build_with_handle()`]. The handle
 /// is cheap to clone and safe to share across threads (`Clone + Send + Sync`).
 ///
 /// This is useful when the circuit breaker service is consumed by middleware
 /// (e.g., wrapped in `BoxCloneService`) and direct access to state inspection
-/// methods on [`CircuitBreaker`](crate::CircuitBreaker) is no longer available.
+/// or control methods on [`CircuitBreaker`](crate::CircuitBreaker) is no
+/// longer available: the handle holds its own `Arc` to the circuit shared by
+/// every service the associated layer produces, so it keeps working after
+/// those services are moved, boxed, or dropped.
+///
+/// In addition to the read-only inspection methods below,
+/// [`Self::force_open`], [`Self::force_closed`], and [`Self::reset`] give a
+/// deterministic, awaitable control API: once a call to one of them
+/// completes, every subsequent state inspection or admission check across
+/// every clone of every service produced by the layer observes the new
+/// state, with no sleep or poll loop required. Combine with
+/// [`CircuitBreakerConfigBuilder::manual_mode()`](crate::CircuitBreakerConfigBuilder::manual_mode)
+/// for a circuit that changes state only in response to these explicit
+/// calls -- a simple external on/off switch.
 ///
 /// # Example
 ///
 /// ```rust
 /// use tower_resilience_circuitbreaker::CircuitBreakerLayer;
 ///
+/// # async fn example() {
 /// let (layer, handle) = CircuitBreakerLayer::builder()
 ///     .failure_rate_threshold(0.5)
 ///     .build_with_handle();
@@ -31,6 +46,12 @@ use crate::config::CircuitBreakerConfig;
 /// let state = handle.state();
 /// let health = handle.health_status();
 /// assert_eq!(health, "healthy");
+///
+/// // Or take deterministic external control, even though the original
+/// // service may have since been moved or boxed:
+/// handle.force_open().await;
+/// assert!(handle.is_open());
+/// # }
 /// ```
 #[derive(Clone)]
 pub struct CircuitBreakerHandle<C = crate::classifier::DefaultClassifier> {
@@ -83,6 +104,66 @@ impl<C> CircuitBreakerHandle<C> {
     pub async fn metrics(&self) -> CircuitMetrics {
         let circuit = self.circuit.lock().await;
         circuit.metrics(&self.config)
+    }
+
+    /// Forces the circuit into the open state.
+    ///
+    /// This is deterministic: the underlying state is updated (with
+    /// `Release` ordering) before this call returns, so any subsequent
+    /// `state()`/`is_open()`/`health_status()` call (which loads with
+    /// `Acquire` ordering) is guaranteed to observe `Open` -- no sleep or
+    /// poll loop is needed. Because the handle holds its own `Arc` to the
+    /// circuit shared by [`crate::CircuitBreakerConfigBuilder::build_with_handle()`],
+    /// every service produced by that layer -- including clones made before
+    /// or after this call, and services already moved or boxed into another
+    /// stack -- observes the new state on their very next admission check.
+    ///
+    /// Emits the same [`crate::CircuitBreakerEvent::StateTransition`] event
+    /// and metrics as an automatic trip.
+    ///
+    /// # Example
+    /// ```rust
+    /// use tower_resilience_circuitbreaker::CircuitBreakerLayer;
+    ///
+    /// # async fn example() {
+    /// let (_layer, handle) = CircuitBreakerLayer::builder().build_with_handle();
+    /// handle.force_open().await;
+    /// assert!(handle.is_open());
+    /// # }
+    /// ```
+    pub async fn force_open(&self) {
+        let mut circuit = self.circuit.lock().await;
+        circuit.force_open(&self.config);
+    }
+
+    /// Forces the circuit into the closed state.
+    ///
+    /// See [`Self::force_open`] for the determinism, cross-clone, and
+    /// observability guarantees, which apply equally here.
+    ///
+    /// # Example
+    /// ```rust
+    /// use tower_resilience_circuitbreaker::CircuitBreakerLayer;
+    ///
+    /// # async fn example() {
+    /// let (_layer, handle) = CircuitBreakerLayer::builder().build_with_handle();
+    /// handle.force_open().await;
+    /// handle.force_closed().await;
+    /// assert!(!handle.is_open());
+    /// # }
+    /// ```
+    pub async fn force_closed(&self) {
+        let mut circuit = self.circuit.lock().await;
+        circuit.force_closed(&self.config);
+    }
+
+    /// Resets the circuit to the closed state and clears counts.
+    ///
+    /// See [`Self::force_open`] for the determinism, cross-clone, and
+    /// observability guarantees, which apply equally here.
+    pub async fn reset(&self) {
+        let mut circuit = self.circuit.lock().await;
+        circuit.reset(&self.config);
     }
 }
 
@@ -219,5 +300,123 @@ mod tests {
         // Both observe the same state
         assert_eq!(handle.state(), handle2.state());
         assert_eq!(handle.health_status(), handle2.health_status());
+    }
+
+    #[tokio::test]
+    async fn test_handle_force_open_is_immediately_observable() {
+        let (_layer, handle) = CircuitBreakerLayer::builder().build_with_handle();
+
+        assert_eq!(handle.state(), CircuitState::Closed);
+
+        handle.force_open().await;
+
+        // No sleep or poll loop -- the state is guaranteed visible as soon
+        // as `force_open().await` returns.
+        assert_eq!(handle.state(), CircuitState::Open);
+        assert!(handle.is_open());
+        assert_eq!(handle.health_status(), "unhealthy");
+        assert_eq!(handle.http_status(), 503);
+    }
+
+    #[tokio::test]
+    async fn test_handle_force_closed_is_immediately_observable() {
+        let (_layer, handle) = CircuitBreakerLayer::builder().build_with_handle();
+
+        handle.force_open().await;
+        assert_eq!(handle.state(), CircuitState::Open);
+
+        handle.force_closed().await;
+        assert_eq!(handle.state(), CircuitState::Closed);
+        assert!(!handle.is_open());
+    }
+
+    #[tokio::test]
+    async fn test_handle_reset_clears_counts_and_closes() {
+        let (layer, handle) = CircuitBreakerLayer::builder()
+            .failure_rate_threshold(0.5)
+            .sliding_window_size(4)
+            .minimum_number_of_calls(4)
+            .build_with_handle();
+
+        let mut svc = layer.layer(ErrService);
+        for _ in 0..4 {
+            let _ = svc.call("x".to_string()).await;
+        }
+        assert_eq!(handle.state(), CircuitState::Open);
+
+        handle.reset().await;
+
+        assert_eq!(handle.state(), CircuitState::Closed);
+        let metrics = handle.metrics().await;
+        assert_eq!(metrics.total_calls, 0);
+        assert_eq!(metrics.failure_count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_handle_force_open_rejects_calls_on_every_clone() {
+        let (layer, handle) = CircuitBreakerLayer::builder().build_with_handle();
+
+        // Two independently created services from the same layer.
+        let mut svc1 = layer.layer(OkService);
+        let mut svc2 = layer.layer(OkService);
+
+        handle.force_open().await;
+
+        // Every service produced by the layer -- including ones created
+        // before this call -- observes the new state on its very next
+        // admission check, with no sleep required.
+        let err1 = svc1.call("a".to_string()).await.unwrap_err();
+        let err2 = svc2.call("b".to_string()).await.unwrap_err();
+        assert!(matches!(err1, crate::CircuitBreakerError::OpenCircuit));
+        assert!(matches!(err2, crate::CircuitBreakerError::OpenCircuit));
+    }
+
+    #[tokio::test]
+    async fn test_handle_controls_boxed_and_moved_service() {
+        use tower::util::BoxCloneService;
+
+        let (layer, handle) = CircuitBreakerLayer::builder().build_with_handle();
+
+        // Apply the layer, then erase the concrete type and move it away --
+        // the only remaining way to reach the circuit is through `handle`.
+        let svc = layer.layer(OkService);
+        let mut boxed: BoxCloneService<String, String, crate::CircuitBreakerError<String>> =
+            BoxCloneService::new(svc);
+        drop(layer);
+
+        handle.force_open().await;
+
+        let err = boxed.call("x".to_string()).await.unwrap_err();
+        assert!(matches!(err, crate::CircuitBreakerError::OpenCircuit));
+
+        handle.force_closed().await;
+        let ok = boxed.call("x".to_string()).await.unwrap();
+        assert_eq!(ok, "x");
+    }
+
+    #[tokio::test]
+    async fn test_handle_force_open_emits_same_state_transition_event_as_automatic_trip() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let transitions = Arc::new(AtomicUsize::new(0));
+        let observed_to_open = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let t_clone = Arc::clone(&transitions);
+        let o_clone = Arc::clone(&observed_to_open);
+
+        let (_layer, handle) = CircuitBreakerLayer::builder()
+            .on_state_transition(move |from, to| {
+                t_clone.fetch_add(1, Ordering::SeqCst);
+                if from == CircuitState::Closed && to == CircuitState::Open {
+                    o_clone.store(true, Ordering::SeqCst);
+                }
+            })
+            .build_with_handle();
+
+        handle.force_open().await;
+
+        // Externally initiated transitions emit the exact same
+        // StateTransition event an automatic trip would.
+        assert_eq!(transitions.load(Ordering::SeqCst), 1);
+        assert!(observed_to_open.load(Ordering::SeqCst));
     }
 }

--- a/crates/tower-resilience-circuitbreaker/src/health_integration.rs
+++ b/crates/tower-resilience-circuitbreaker/src/health_integration.rs
@@ -3,8 +3,22 @@
 //! This module provides `HealthTriggerable` implementations that allow
 //! health check systems to proactively open or close the circuit breaker
 //! based on external health signals.
+//!
+//! `HealthTriggerable`'s `trigger_unhealthy`/`trigger_healthy` methods are
+//! synchronous by contract (callers may not be in an async context), so the
+//! implementations here spawn a detached task to perform the transition:
+//! `trigger_unhealthy()`/`trigger_healthy()` return before the state change
+//! is guaranteed to have happened. When the caller can await completion,
+//! prefer the deterministic, awaitable alternative instead:
+//! [`CircuitBreakerHandle::force_open()`](crate::CircuitBreakerHandle::force_open) /
+//! [`CircuitBreakerHandle::force_closed()`](crate::CircuitBreakerHandle::force_closed)
+//! (or the equivalent methods on [`CircuitBreaker`]/[`CircuitBreakerWithFallback`]
+//! themselves). Awaiting one of those completes only once the underlying
+//! state has actually transitioned, so a subsequent state inspection or
+//! admission check is guaranteed to observe it -- no sleep or poll loop
+//! needed.
 
-use crate::{CircuitBreaker, CircuitBreakerWithFallback};
+use crate::{CircuitBreaker, CircuitBreakerHandle, CircuitBreakerWithFallback};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tower_resilience_core::HealthTriggerable;
@@ -65,11 +79,31 @@ where
     }
 }
 
+/// Implemented so a [`CircuitBreakerHandle`] retained after the original
+/// service was moved or boxed can still act as a trait-object health
+/// trigger target, matching [`CircuitBreaker`]/[`CircuitBreakerWithFallback`].
+///
+/// See the module docs for why this is fire-and-forget, and
+/// [`CircuitBreakerHandle::force_open`]/[`CircuitBreakerHandle::force_closed`]
+/// for the deterministic, awaitable alternative.
+impl<C> HealthTriggerable for CircuitBreakerHandle<C>
+where
+    C: Send + Sync + 'static,
+{
+    fn trigger_unhealthy(&self) {
+        trigger_unhealthy_impl(Arc::clone(&self.circuit), Arc::clone(&self.config));
+    }
+
+    fn trigger_healthy(&self) {
+        trigger_healthy_impl(Arc::clone(&self.circuit), Arc::clone(&self.config));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::classifier::DefaultClassifier;
-    use crate::CircuitState;
+    use crate::{CircuitBreakerLayer, CircuitState};
     use std::time::Duration;
     use tower_resilience_core::EventListeners;
 
@@ -89,6 +123,7 @@ mod tests {
             event_listeners: EventListeners::new(),
             name: "test".into(),
             backpressure: false,
+            manual_mode: false,
         }
     }
 
@@ -144,5 +179,33 @@ mod tests {
         trigger.trigger_healthy();
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert_eq!(breaker.state_sync(), CircuitState::Closed);
+    }
+
+    /// The deterministic `CircuitBreakerHandle` also implements
+    /// `HealthTriggerable`, so a handle retained after the original service
+    /// was moved or boxed can still serve as a trait-object health trigger.
+    #[tokio::test]
+    async fn test_health_triggerable_on_handle_opens_and_closes() {
+        let (_layer, handle) = CircuitBreakerLayer::builder().build_with_handle();
+
+        assert_eq!(handle.state(), CircuitState::Closed);
+
+        handle.trigger_unhealthy();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(handle.state(), CircuitState::Open);
+
+        handle.trigger_healthy();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(handle.state(), CircuitState::Closed);
+    }
+
+    #[tokio::test]
+    async fn test_health_triggerable_on_handle_via_trait_object() {
+        let (_layer, handle) = CircuitBreakerLayer::builder().build_with_handle();
+
+        let trigger: Arc<dyn HealthTriggerable> = Arc::new(handle.clone());
+        trigger.trigger_unhealthy();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(handle.state(), CircuitState::Open);
     }
 }

--- a/crates/tower-resilience-circuitbreaker/src/lib.rs
+++ b/crates/tower-resilience-circuitbreaker/src/lib.rs
@@ -297,6 +297,48 @@
 //! # }
 //! ```
 //!
+//! ## Deterministic Shared Control
+//!
+//! [`CircuitBreakerConfigBuilder::build_with_handle()`] returns a
+//! [`CircuitBreakerHandle`] alongside the layer. The handle can `force_open()`,
+//! `force_closed()`, and `reset()` the circuit deterministically -- once the
+//! call completes, every service produced by the layer observes the new
+//! state, even if the original service has since been moved, boxed, or
+//! dropped:
+//!
+//! ```rust
+//! use tower_resilience_circuitbreaker::CircuitBreakerLayer;
+//!
+//! # async fn example() {
+//! let (layer, handle) = CircuitBreakerLayer::builder()
+//!     .failure_rate_threshold(0.5)
+//!     .build_with_handle();
+//!
+//! // Apply the layer, then move/box the resulting service away...
+//! // let service: BoxCloneService<_, _, _> = ...;
+//!
+//! // The handle still controls it deterministically:
+//! handle.force_open().await;
+//! assert!(handle.is_open());
+//! handle.reset().await;
+//! assert!(!handle.is_open());
+//! # let _ = layer;
+//! # }
+//! ```
+//!
+//! Combine with [`CircuitBreakerConfigBuilder::manual_mode()`] for a circuit
+//! that changes state only in response to these explicit calls, never
+//! automatically from inner-service results -- a simple external on/off
+//! switch:
+//!
+//! ```rust
+//! use tower_resilience_circuitbreaker::CircuitBreakerLayer;
+//!
+//! let (_layer, _handle) = CircuitBreakerLayer::builder()
+//!     .manual_mode()
+//!     .build_with_handle();
+//! ```
+//!
 //! ## Features
 //! - Count-based and time-based sliding windows
 //! - Configurable failure rate threshold
@@ -304,7 +346,10 @@
 //! - Half-open state for gradual recovery
 //! - Event system for observability
 //! - Optional fallback handling
-//! - Manual state control (force_open, force_closed, reset)
+//! - Manual state control (force_open, force_closed, reset) on the service
+//!   and on the deterministic, shareable [`CircuitBreakerHandle`]
+//! - Manual/external-only mode (`manual_mode()`) for a simple external
+//!   on/off switch that never trips or recovers automatically
 //! - Sync state inspection with `state_sync()`, `is_open()`, and `metrics()`
 //! - Metrics integration via `metrics` feature
 //! - Tracing support via `tracing` feature
@@ -1024,6 +1069,7 @@ mod tests {
             event_listeners: EventListeners::new(),
             name: "test".into(),
             backpressure: false,
+            manual_mode: false,
         }
     }
 
@@ -1067,6 +1113,95 @@ mod tests {
 
         breaker.force_closed().await;
         assert_eq!(breaker.state().await, CircuitState::Closed);
+    }
+
+    #[test]
+    fn manual_mode_ignores_automatic_trip_on_failures() {
+        let mut circuit = Circuit::new();
+        let mut config = dummy_config();
+        config.manual_mode = true;
+
+        // Enough failures (100% rate over a full window) to trip the
+        // circuit automatically under the default sliding-window model.
+        // Manual mode must ignore them.
+        for _ in 0..10 {
+            circuit.record_failure(&config, Duration::from_millis(10));
+        }
+
+        assert_eq!(circuit.state(), CircuitState::Closed);
+    }
+
+    #[test]
+    fn manual_mode_ignores_automatic_recovery_timer() {
+        let mut circuit = Circuit::new();
+        let mut config = dummy_config();
+        config.manual_mode = true;
+        config.wait_duration_in_open = Duration::from_millis(1);
+
+        circuit.force_open(&config);
+        assert_eq!(circuit.state(), CircuitState::Open);
+
+        std::thread::sleep(Duration::from_millis(20));
+
+        // Outside manual mode, `try_acquire` would auto-transition to
+        // HalfOpen once `wait_duration_in_open` elapses. In manual mode the
+        // circuit must stay open (rejecting) regardless of elapsed time.
+        assert!(matches!(circuit.try_acquire(&config), Admission::Rejected));
+        assert_eq!(circuit.state(), CircuitState::Open);
+
+        // check_permitted (the read-only variant used by backpressure mode)
+        // must agree: it never reports the wait as satisfied in manual mode.
+        assert!(circuit.check_permitted(&config).is_err());
+    }
+
+    #[test]
+    fn manual_mode_still_supports_explicit_force_and_reset() {
+        let mut circuit = Circuit::new();
+        let mut config = dummy_config();
+        config.manual_mode = true;
+
+        circuit.force_open(&config);
+        assert_eq!(circuit.state(), CircuitState::Open);
+
+        circuit.reset(&config);
+        assert_eq!(circuit.state(), CircuitState::Closed);
+
+        circuit.force_closed(&config); // no-op, already closed
+        assert_eq!(circuit.state(), CircuitState::Closed);
+    }
+
+    #[tokio::test]
+    async fn manual_mode_end_to_end_via_builder_and_handle() {
+        let (layer, handle) = CircuitBreakerLayer::builder()
+            // Would trip on the very first failure in automatic mode.
+            .failure_rate_threshold(0.01)
+            .sliding_window_size(1)
+            .minimum_number_of_calls(1)
+            .manual_mode()
+            .build_with_handle();
+
+        let mut svc = layer.layer_fn(tower::service_fn(|_req: String| async move {
+            Err::<String, String>("boom".to_string())
+        }));
+
+        for _ in 0..10 {
+            let _ = tower::Service::call(&mut svc, "x".to_string()).await;
+        }
+
+        // Manual mode: results alone never move the circuit.
+        assert_eq!(handle.state(), CircuitState::Closed);
+
+        handle.force_open().await;
+        assert_eq!(handle.state(), CircuitState::Open);
+
+        // Still open after another failing call and after the (default)
+        // wait_duration_in_open would have elapsed -- only an explicit
+        // handle call changes state in manual mode.
+        let _ = tower::Service::call(&mut svc, "y".to_string()).await;
+        assert_eq!(handle.state(), CircuitState::Open);
+
+        handle.force_closed().await;
+        assert_eq!(handle.state(), CircuitState::Closed);
     }
 
     #[test]
@@ -1135,6 +1270,7 @@ mod tests {
             },
             name: "test".into(),
             backpressure: false,
+            manual_mode: false,
         };
 
         let mut circuit = Circuit::new();
@@ -1190,6 +1326,7 @@ mod tests {
             },
             name: "test".into(),
             backpressure: false,
+            manual_mode: false,
         };
 
         let mut circuit = Circuit::new();


### PR DESCRIPTION
## Summary

Closes #384. `CircuitBreakerLayer::build_with_handle()` gives the right shared
topology for admin APIs and fleet control, but `CircuitBreakerHandle` was
read-only -- `force_open`/`force_closed`/`reset` existed only on
`CircuitBreaker`/`CircuitBreakerWithFallback`, which may already have been
moved, boxed, or dropped by the time external control is actually needed.

## What changed

- **Deterministic handle control.** `CircuitBreakerHandle` gains
  `force_open()`, `force_closed()`, and `reset()`, backed by the same shared
  circuit state used by `build_with_handle()`. Because the underlying atomic
  state is updated with `Release` ordering before the call returns, a
  subsequent `state()`/`is_open()` call (`Acquire` ordering) is guaranteed to
  observe the new state -- no sleep or poll loop needed. This works
  regardless of what happened to the original service (moved, boxed,
  dropped), and affects every service the associated layer produces,
  including clones made before or after the call.
- **Manual/external-only mode.** New `manual_mode()` builder option: the
  circuit never trips or recovers automatically from inner-service results
  (`record_success`/`record_failure` still update counters/events/metrics for
  observability, but never evaluate the sliding window or half-open
  thresholds) and the `Open -> HalfOpen` recovery timer
  (`wait_duration_in_open`) is disabled too. State only changes via an
  explicit `force_open`/`force_closed`/`reset` call -- a simple external
  on/off switch, matching the scope discussed in
  [tower-rs/tower#855](https://github.com/tower-rs/tower/pull/855).
- **Health integration.** `CircuitBreakerHandle` now also implements
  `HealthTriggerable` (under the `health-integration` feature), so a handle
  retained after the original service was moved or boxed can still serve as a
  trait-object health-check trigger target, matching
  `CircuitBreaker`/`CircuitBreakerWithFallback`. The module docs now point to
  the handle's `force_open()`/`force_closed()` as the deterministic,
  awaitable alternative to the trait's fire-and-forget
  `tokio::spawn`-based transitions (the trait's `trigger_unhealthy`/
  `trigger_healthy` methods stay synchronous by contract, so they can't
  themselves become deterministic without a breaking trait-signature change;
  this PR doesn't touch that signature).
- **Observability parity.** Externally initiated transitions (via
  `force_open`/`force_closed`/`reset`, whether on the handle or the service)
  emit the exact same `StateTransition` event and metrics as an automatic
  trip -- no special-casing was needed since `transition_to` was already
  trigger-source-agnostic; a regression test locks this in.
- **Existing read-only handle APIs are unchanged** (`state`, `is_open`,
  `health_status`, `http_status`, `metrics`) -- purely additive.

## Tests

Added to the circuit breaker crate's own test suite (per the stacked-PR
constraint, nothing under `tests/stress/**` or
`.github/workflows/stress-tests.yml` was touched):

- `handle.rs`: deterministic `force_open`/`force_closed` observability,
  `reset` clearing counts, control affecting every clone from the layer,
  control surviving a service moved into `BoxCloneService`, and
  externally-triggered transitions emitting the same event as automatic
  ones.
- `lib.rs`: `manual_mode` ignoring automatic trip-on-failure, ignoring the
  automatic recovery timer (including the read-only `check_permitted` path
  used by backpressure mode), still supporting explicit
  force/reset, and an end-to-end test through the public builder + handle.
- `health_integration.rs`: `CircuitBreakerHandle`'s `HealthTriggerable` impl,
  directly and via trait object.

`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`,
`cargo clippy --all-targets --all-features -- -D warnings`, and
`cargo test --workspace` / `cargo test --workspace --all-features` all pass.

## Follow-up (not in this PR)

Per the dispatcher's constraint, stress-suite coverage for concurrent
handle-control contention (many clones observing a handle-forced transition
under sustained load) was intentionally left out of scope here; flagged as a
possible `tests/stress/**` follow-up alongside the existing half-open
contention follow-up from #382/#407.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy -p tower-resilience-circuitbreaker --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p tower-resilience-circuitbreaker --all-features --no-deps`

All pass locally.