### PR TITLE
docs(circuitbreaker): validate circuit breaker against tower-rs/tower#855 (closes #375)

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,10 @@ let layer = CircuitBreakerLayer::builder()
 let service = layer.layer(my_service);
 ```
 
+See the [Tower circuit breaker comparison](docs/circuitbreaker-tower-comparison.md)
+for how this compares to the upstream `tower-rs/tower#855` proposal, and for
+recommended composition with retry budgets.
+
 **Full examples:** [circuitbreaker.rs](examples/circuitbreaker.rs) | [circuitbreaker_fallback.rs](crates/tower-resilience-circuitbreaker/examples/circuitbreaker_fallback.rs) | [circuitbreaker_health_check.rs](crates/tower-resilience-circuitbreaker/examples/circuitbreaker_health_check.rs)
 
 ### Coalesce

--- a/crates/tower-resilience-circuitbreaker/tests/contract.rs
+++ b/crates/tower-resilience-circuitbreaker/tests/contract.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use tower::limit::ConcurrencyLimit;
 use tower::{Layer, Service, ServiceExt};
 use tower_resilience_circuitbreaker::CircuitBreakerLayer;
-use tower_resilience_circuitbreaker::{CircuitBreakerError, DefaultClassifier};
+use tower_resilience_circuitbreaker::{CircuitBreakerError, CircuitState, DefaultClassifier};
 use tower_resilience_core::testing::StatefulInner;
 use tower_resilience_core::testing::{ControlledService, ControlledServiceClosed, ServiceProbe};
 
@@ -407,4 +407,246 @@ async fn half_open_backpressure_waiter_wakes_promptly_when_a_slot_frees() {
         elapsed < WAIT_DURATION_IN_OPEN,
         "waiter took {elapsed:?}, no faster than the open-circuit cooldown of {WAIT_DURATION_IN_OPEN:?}"
     );
+}
+
+// ─── Contract coverage for #375: trip-condition and pending-inner paths ───
+//
+// The tests above cover open-circuit gating (#381) and half-open admission
+// (#382). These add the trip-condition contract gaps #375 calls out
+// specifically: failure-rate trip, the consecutive-failure model (a
+// distinct trip path from the sliding window), slow-call detection, and a
+// permanently `Pending` inner service under a `Closed` circuit.
+
+/// Contract coverage for #375: the failure-rate sliding window admits calls
+/// while below threshold, trips once the window fills and the rate crosses
+/// `failure_rate_threshold`, and a subsequent `poll_ready` reflects `Open`
+/// without polling inner again.
+#[tokio::test]
+async fn failure_rate_threshold_trips_after_window_fills_and_then_rejects_without_polling_inner() {
+    let (controlled, controller) = ControlledService::new(true);
+    let probe = ServiceProbe::new(controlled);
+    let handle = probe.handle();
+    let mut service = CircuitBreakerLayer::builder()
+        .failure_classifier(|result: &Result<&'static str, ControlledServiceClosed>| {
+            matches!(result, Ok(response) if *response == "fail")
+        })
+        .failure_rate_threshold(0.5)
+        .sliding_window_size(4)
+        .minimum_number_of_calls(4)
+        .wait_duration_in_open(Duration::from_secs(60))
+        .build()
+        .layer(probe);
+
+    controller.allow(4);
+
+    // Below the window size, the circuit must stay Closed even though the
+    // failures seen so far already exceed the rate threshold.
+    for request in ["fail", "fail"] {
+        let response = ServiceExt::<&'static str>::ready(&mut service)
+            .await
+            .unwrap()
+            .call(request)
+            .await;
+        assert_eq!(response.unwrap(), request);
+    }
+    assert_eq!(service.state().await, CircuitState::Closed);
+
+    // The window fills on the 4th call: 2 successes + 2 failures = 50%,
+    // meeting (>=) the configured 50% threshold.
+    for request in ["ok", "ok"] {
+        let response = ServiceExt::<&'static str>::ready(&mut service)
+            .await
+            .unwrap()
+            .call(request)
+            .await;
+        assert_eq!(response.unwrap(), request);
+    }
+    assert_eq!(service.state().await, CircuitState::Open);
+
+    let polls_before = handle.snapshot().readiness_polls;
+    let calls_before = handle.snapshot().calls;
+
+    // A subsequent poll_ready/call observes Open directly; inner is never
+    // polled or called again.
+    ServiceExt::<&'static str>::ready(&mut service)
+        .await
+        .unwrap();
+    let result = service.call("would-be-fine").await;
+
+    assert!(matches!(result, Err(CircuitBreakerError::OpenCircuit)));
+    assert_eq!(handle.snapshot().readiness_polls, polls_before);
+    assert_eq!(handle.snapshot().calls, calls_before);
+}
+
+/// Contract coverage for #375: `FailureModel::ConsecutiveFailures` (the
+/// `.consecutive_failures(k)` shortcut) trips on `k` failures in a row,
+/// independent of the sliding-window rate path -- it ignores
+/// `failure_rate_threshold` and the window/minimum-calls gating entirely.
+#[tokio::test]
+async fn consecutive_failures_model_trips_independent_of_sliding_window_gating() {
+    let (controlled, controller) = ControlledService::new(true);
+    let probe = ServiceProbe::new(controlled);
+    let mut service = CircuitBreakerLayer::builder()
+        .failure_classifier(|result: &Result<&'static str, ControlledServiceClosed>| {
+            matches!(result, Ok(response) if *response == "fail")
+        })
+        .consecutive_failures(3)
+        .wait_duration_in_open(Duration::from_secs(60))
+        .build()
+        .layer(probe);
+
+    controller.allow(10);
+
+    // A leading success, then two failures: only 2 consecutive failures so
+    // far -- below k=3. This is also only 3 total calls, nowhere near the
+    // default sliding-window minimum_number_of_calls (100), proving this
+    // model does not depend on that gating at all.
+    for request in ["ok", "fail", "fail"] {
+        let response = ServiceExt::<&'static str>::ready(&mut service)
+            .await
+            .unwrap()
+            .call(request)
+            .await;
+        assert_eq!(response.unwrap(), request);
+    }
+    assert_eq!(service.state().await, CircuitState::Closed);
+
+    // The 3rd consecutive failure trips immediately, at 4 total calls --
+    // far below the sliding-window model's default 100-call minimum.
+    let response = ServiceExt::<&'static str>::ready(&mut service)
+        .await
+        .unwrap()
+        .call("fail")
+        .await;
+    assert_eq!(response.unwrap(), "fail");
+    assert_eq!(service.state().await, CircuitState::Open);
+}
+
+/// Contract coverage for #375: `slow_call_duration_threshold` /
+/// `slow_call_rate_threshold` trip the circuit on latency alone -- every
+/// call in this test succeeds (0% failure rate), so only the slow-call path
+/// can be responsible for the trip.
+#[tokio::test]
+async fn slow_call_threshold_trips_independent_of_failure_rate() {
+    const SLOW_THRESHOLD: Duration = Duration::from_millis(20);
+
+    let (controlled, controller) = ControlledService::new(true);
+    let probe = ServiceProbe::new(controlled);
+    let service = CircuitBreakerLayer::builder()
+        .slow_call_duration_threshold(SLOW_THRESHOLD)
+        .slow_call_rate_threshold(0.5)
+        .sliding_window_size(2)
+        .minimum_number_of_calls(2)
+        .wait_duration_in_open(Duration::from_secs(60))
+        .build()
+        .layer(probe);
+
+    // First call completes immediately: fast, and (trivially) a success.
+    controller.allow(1);
+    let mut fast = service.clone();
+    let response = ServiceExt::<&'static str>::ready(&mut fast)
+        .await
+        .unwrap()
+        .call("fast")
+        .await;
+    assert_eq!(response.unwrap(), "fast");
+    assert_eq!(service.state().await, CircuitState::Closed);
+
+    // Second call: also a success, but held past SLOW_THRESHOLD before its
+    // permit is released, so its recorded duration crosses the slow-call
+    // threshold. The future must actually be polled (spawned) for the
+    // in-breaker start Instant to begin ticking.
+    let mut slow = service.clone();
+    let call = tokio::spawn(async move {
+        ServiceExt::<&'static str>::ready(&mut slow)
+            .await
+            .unwrap()
+            .call("slow")
+            .await
+    });
+    tokio::time::sleep(SLOW_THRESHOLD * 2).await;
+    controller.allow(1);
+    let response = call.await.unwrap();
+    assert_eq!(response.unwrap(), "slow");
+
+    // 2 calls, 0 failures, 1 slow call: failure rate stays 0% (well under
+    // the default 50% failure_rate_threshold) while the slow-call rate hits
+    // 50%, meeting slow_call_rate_threshold and tripping the circuit.
+    assert_eq!(service.state().await, CircuitState::Open);
+}
+
+/// Contract coverage for #375: while the circuit is `Closed`, an inner
+/// service that never becomes ready must have its `Pending` forwarded
+/// as-is -- no busy-polling (evidenced by the pending-poll count plateauing
+/// under repeated scheduler yields, not a sleep), a waker is registered and
+/// honored on wake, and dropping a caller's readiness future while inner is
+/// still pending is safe and leaves the breaker usable for the next caller.
+#[tokio::test]
+async fn closed_circuit_forwards_permanently_pending_inner_without_busy_polling() {
+    let (controlled, controller) = ControlledService::new(false);
+    let probe = ServiceProbe::new(controlled);
+    let handle = probe.handle();
+    let service = CircuitBreakerLayer::builder().build().layer(probe);
+
+    // First caller: registers a readiness waker but is never woken.
+    let mut first = service.clone();
+    let first_task = tokio::spawn(async move {
+        let _ = ServiceExt::<&'static str>::ready(&mut first).await;
+    });
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while handle.snapshot().readiness_pending == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("readiness was never polled");
+
+    let pending_after_registration = handle.snapshot().readiness_pending;
+
+    // Give the executor many chances to re-poll on its own. Nothing ever
+    // wakes this task, so a conforming Closed-state gate must not
+    // busy-poll: the pending count must not advance past the single poll
+    // that registered the waker. No wall-clock sleep is used here -- the
+    // plateau under repeated yields is the evidence.
+    for _ in 0..1000 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(
+        handle.snapshot().readiness_pending,
+        pending_after_registration,
+        "circuit breaker busy-polled a permanently pending inner service"
+    );
+    assert_eq!(handle.snapshot().calls, 0);
+
+    // Drop the first caller's readiness future while inner is still
+    // pending. This must be safe and must not corrupt state for the next
+    // caller.
+    first_task.abort();
+    let _ = first_task.await;
+
+    // Second caller, on a fresh clone: registers its own waker and is woken
+    // once inner becomes ready, proving the breaker forwards both the
+    // Pending readiness and the eventual wake-up correctly.
+    let mut second = service.clone();
+    let second_task = tokio::spawn(async move {
+        ServiceExt::<&'static str>::ready(&mut second)
+            .await
+            .unwrap();
+    });
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while handle.snapshot().readiness_pending <= pending_after_registration {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("second readiness waiter never registered");
+
+    controller.set_ready(true);
+    tokio::time::timeout(Duration::from_secs(1), second_task)
+        .await
+        .expect("registered readiness waiter was not woken")
+        .unwrap();
+
+    handle.assert_quiescent();
 }

--- a/docs/circuitbreaker-tower-comparison.md
+++ b/docs/circuitbreaker-tower-comparison.md
@@ -1,0 +1,360 @@
+# Circuit breaker vs. tower-rs/tower#855
+
+This is the durable comparison checklist for `tower-resilience-circuitbreaker`
+against the upstream circuit-breaker proposal at
+[tower-rs/tower#855](https://github.com/tower-rs/tower/pull/855) (a
+`tower::circuit_breaker::CircuitBreakerLayer` / `CircuitBreaker<S, P>` /
+`CircuitPolicy` trait, authored by Matthew Busel, with design feedback from
+Sean Monstar at
+[#855#issuecomment-4039743246](https://github.com/tower-rs/tower/pull/855#issuecomment-4039743246)).
+It exists so a reviewer can walk a future diff of that PR against this project
+without redoing the analysis from scratch. This document reflects the
+upstream diff as of commit `ddb88ba` (the `CircuitPolicy`-trait revision
+pushed in response to the linked review comment) and the local API on `main`
+after #381, #382 (PR #407), and #384 (PR #412).
+
+Trait-bound, boxing, allocation, and runtime-coupling analysis (`Send`/`Sync`
+requirements, `Arc<Mutex<_>>` vs. lock-free state, executor assumptions) is
+tracked separately in #376 and is **not** duplicated here.
+
+See the [Tower contract matrix](tower-contract-matrix.md) for the
+regression-test-level view of the same coverage.
+
+## API and state-machine comparison
+
+Both projects converge on the same three-state model:
+
+| | Local (`tower-resilience-circuitbreaker`) | Upstream `tower::circuit_breaker` (PR #855, commit `ddb88ba`) |
+| --- | --- | --- |
+| States | `CircuitState::{Closed, Open, HalfOpen}` (`circuit.rs`) | `CircuitStatus::{Closed, Open, HalfOpen}` (`service.rs`) -- same three states, different type name |
+| Default trip condition | Failure **rate** over a count- or time-based sliding window (`FailureModel::SlidingWindow`, the default) | Consecutive-failure count only (`ConsecutiveFailures`, the only built-in `CircuitPolicy` impl) |
+| Alternate trip condition | `FailureModel::ConsecutiveFailures { k }` -- k failures in a row, ignoring the sliding window entirely (`.consecutive_failures(k)`) | None built in; a custom `CircuitPolicy` impl would be required |
+| Latency-based trip condition | `slow_call_duration_threshold` + `slow_call_rate_threshold`, evaluated independent of the failure-rate/consecutive path | None; would require a custom `CircuitPolicy` |
+| Recovery timer | `wait_duration_in_open`; `Open -> HalfOpen` once elapsed (or never, in `manual_mode()`) | `timeout` constructor argument, same semantics (`ConsecutiveFailures::should_probe`) |
+| Half-open admission size | `permitted_calls_in_half_open` (configurable, default 1), atomically reserved per cycle (#382) | Effectively unbounded per cycle in the current diff -- see [Admission semantics](#admission-semantics) |
+| Half-open close condition | `success_count >= permitted_calls_in_half_open` within the current cycle; **any** failure reopens immediately | Rolling success-rate over up to 100 probe outcomes crosses `success_threshold`; **any** failure reopens immediately regardless of the rate (`future.rs`: "Any failure during a probe reopens immediately") |
+| Config surface entry point | `CircuitBreakerConfigBuilder` (builder pattern, `.build()` / `.build_with_handle()`) plus `standard()` / `fast_fail()` / `tolerant()` presets | `CircuitBreakerLayer::new(failure_threshold, success_threshold, timeout)` (positional, `ConsecutiveFailures`-only) or `::with_policy(policy)` for a custom `CircuitPolicy` |
+| Failure classification | `FailureClassifier<Res, Err>` trait, applied to the full `Result` (or just `Res` via `classify_response`) -- pluggable per call site, independent of the trip-condition model | None -- `on_success`/`on_failure` are called directly from whatever `Result` the inner service returned; there is no classifier seam distinguishing "this `Err` doesn't count as unhealthy" from "this `Err` does" |
+
+## Admission semantics
+
+- **Circuit state is checked before inner readiness.** Yes, since #381. The
+  `Service` impl's `poll_ready` calls `poll_circuit_gate` first; for the
+  common `Closed` case this is a lock-free atomic load with no mutex
+  acquisition at all (`lib.rs`, `poll_circuit_gate`'s fast path). Contract
+  coverage: `open_rejection_does_not_poll_pending_inner`,
+  `cloned_open_breakers_reject_without_polling_inner`,
+  `backpressure_waits_on_circuit_before_pending_inner` in
+  `crates/tower-resilience-circuitbreaker/tests/contract.rs`.
+
+- **Open-circuit rejection surfaces via `call`, not `poll_ready`, in the
+  default (rejection) mode.** `poll_ready` grants readiness
+  (`Poll::Ready(Ok(()))`) once the circuit gate decides to reject, recording
+  the grant in a `reject_next_call` flag; the actual
+  `CircuitBreakerError::OpenCircuit` is only returned from the following
+  `call()` (`lib.rs`, `CircuitBreaker::poll_ready`/`call`). This matches how
+  this crate's other rejecting layers (bulkhead, ratelimiter) behave, and
+  avoids a `poll_ready` error tearing down stacks (e.g. `Buffer`) that treat a
+  readiness error as fatal. In `.backpressure()` mode, rejection instead
+  surfaces as `Poll::Pending` from `poll_ready` (never `Err`), covered by
+  `backpressure_waits_on_circuit_before_pending_inner`. Upstream's diff takes
+  the opposite default: `poll_ready` itself returns
+  `Poll::Ready(Err(CircuitError::Open))` directly (`service.rs`), with no
+  backpressure-style alternative.
+
+- **Behavior across cloned services.** Circuit state is shared via
+  `Arc<Mutex<Circuit>>` plus an `Arc<AtomicU8>` fast-path state cache;
+  clones and every service produced by a `build_with_handle()` layer observe
+  the same circuit. Covered by `cloned_open_breakers_reject_without_polling_inner`
+  (#381) and by `test_handle_shared_across_cloned_services` /
+  `test_handle_controls_boxed_and_moved_service` (#384, `handle.rs`) for the
+  handle-decoupled case. Upstream's `CircuitBreaker<S, P>` is `#[derive(Clone)]`
+  over an `Arc<Mutex<SharedState<P>>>`, giving the same shared-state property
+  for direct clones, but has no service-independent handle type (see the
+  [operator-control table](#operator-control-capability-comparison) below).
+
+- **Concurrent half-open probes.** Reserved atomically: `Circuit::try_acquire`
+  reserves a slot from a `tokio::sync::Semaphore` that is recreated fresh
+  every time the circuit transitions into `HalfOpen` (so a permit released
+  late by a probe from a stale cycle can never leak capacity into the current
+  one), and dropping an admitted probe's future without completing it returns
+  the reservation without recording a result (#382, PR #407). Covered by
+  `half_open_admission_never_exceeds_permitted_calls_under_contention`,
+  `dropped_half_open_probe_future_releases_its_slot_without_recording_a_result`,
+  and `half_open_backpressure_waiter_wakes_promptly_when_a_slot_frees`.
+  **Upstream's current diff does not gate concurrent half-open admission at
+  all.** Once `SharedState.status` is set to `HalfOpen`, `poll_ready` falls
+  through unconditionally to `self.inner.poll_ready(cx)` with no per-cycle
+  admission check (`service.rs`) -- every concurrent caller is admitted
+  during `HalfOpen`, limited only by whatever concurrency the caller
+  otherwise has. This contradicts the module doc's own framing ("one probe
+  request is allowed through"); the code does not currently enforce it.
+
+## Does upstream `CircuitPolicy` support externally triggered circuits?
+
+**Partial.** The built-in surface supports one direction only:
+`CircuitBreaker::reset()` (service.rs) manually forces the circuit closed
+(via the policy's `on_half_open()` window-clear hook), reachable only by
+holding or cloning the concrete `CircuitBreaker<S, P>` value -- there is no
+decoupled handle type, and no `force_open()` at all anywhere in the diff. A
+custom `CircuitPolicy` implementation *could* be written to consult an
+externally-set flag (e.g. an `Arc<AtomicBool>` captured in the policy struct)
+from `should_probe()` / `on_failure()`, achieving a hand-rolled external
+on/off switch -- which is exactly the "simple shared on-off switch" scope
+Sean Monstar's review comment described as in-scope for a circuit breaker
+concept. But that construction is left entirely to the policy author; it is
+not a first-class API the trait or service provides. This project's
+`.manual_mode()` + `CircuitBreakerHandle::force_open()`/`force_closed()`/`reset()`
+(#384, PR #412) is the equivalent finished feature.
+
+## Separation of concerns
+
+Three conceptually distinct questions, deliberately kept in different places:
+
+1. **Failure classification** -- "was this completed call's outcome a
+   failure?" Lives in `classifier.rs` (re-exporting
+   `tower_resilience_core::classifier::{FailureClassifier, DefaultClassifier, FnClassifier}`).
+   Invoked once per completed call from `CircuitBreaker::call()` in `lib.rs`
+   (`config.failure_classifier.classify(&result)`), independent of the
+   trip-condition model below.
+2. **State-transition policy** -- "given recorded outcomes (and elapsed
+   time), should the circuit move `Closed -> Open`, `Open -> HalfOpen`, or
+   `HalfOpen -> {Closed, Open}`?" Lives in `circuit.rs`
+   (`Circuit::record_success` / `record_failure` / `evaluate_window` /
+   `transition_to`), driven by `FailureModel`, the sliding-window
+   configuration, and the slow-call thresholds.
+3. **Request-admission policy** -- "given the *current* state, is this
+   specific request allowed through right now?" Lives in `circuit.rs`
+   (`Circuit::try_acquire` / `check_permitted`, including the half-open
+   `Semaphore` reservation) and in the `Service` impl's `poll_circuit_gate` /
+   `poll_ready` / `call` in `lib.rs`, which is also where rejection-mode vs.
+   backpressure-mode is decided.
+
+Upstream's `CircuitPolicy` trait bundles (1) and (2) together (a policy's
+`on_success`/`on_failure` both classify *and* decide whether to trip, since
+there is no separate classifier seam) and leaves (3) entirely inside
+`CircuitBreaker::poll_ready`/`ResponseFuture::poll`, with no separately
+testable admission type analogous to `Circuit::try_acquire`.
+
+## Operator-control capability comparison
+
+| Capability | Local | Upstream (PR #855, commit `ddb88ba`) |
+| --- | --- | --- |
+| Force-open | Yes -- `CircuitBreaker::force_open()` / `CircuitBreakerWithFallback::force_open()` / `CircuitBreakerHandle::force_open()` (`handle.rs`), deterministic: `Release`-ordered store before the call returns, so a subsequent `Acquire`-ordered read is guaranteed to observe it | No -- no force-open method anywhere in the diff |
+| Force-closed | Yes -- `force_closed()` on all three surfaces above | No -- only `reset()`, which is a plain close, not a distinct "force closed" |
+| Reset | Yes -- `reset()` on all three surfaces; also clears sliding-window counters | Partial -- `CircuitBreaker::reset()` exists (calls the policy's `on_half_open()` hook, then sets `Closed`) |
+| Shared handle decoupled from the service instance | Yes -- `CircuitBreakerHandle` (`build_with_handle()`) holds its own `Arc` to the shared circuit and keeps controlling every service the layer produced after they are moved, boxed, or dropped (#384, PR #412; `test_handle_controls_boxed_and_moved_service`) | No -- the only control surface is `CircuitBreaker<S, P>` itself; cloning it still carries a clone of the inner service `S` |
+| External health signals | Yes -- `HealthTriggerable` impl for `CircuitBreaker` / `CircuitBreakerWithFallback` / `CircuitBreakerHandle` under the `health-integration` feature (`health_integration.rs`), plus the deterministic, awaitable `force_open`/`force_closed` alternative | No built-in integration; would require a custom `CircuitPolicy` reading an external flag |
+| External-only / manual operation | Yes -- `.manual_mode()` (#384, PR #412): counters/events still recorded for observability, but state changes only via explicit `force_open`/`force_closed`/`reset` | No equivalent mode; would require a custom `CircuitPolicy` whose `on_success`/`on_failure`/`should_probe` always return `false` |
+
+## RMQTT and GovCraft/Acton integration review
+
+**RMQTT** ([rmqtt/rmqtt](https://github.com/rmqtt/rmqtt),
+`rmqtt/src/grpc.rs` + `rmqtt/src/context.rs`) and
+**rmqtt-storage** ([rmqtt/rmqtt-storage](https://github.com/rmqtt/rmqtt-storage),
+`src/circuit_breaker.rs`) both wrap the crate around outbound gRPC/storage
+calls the same way:
+
+- Build a `CircuitBreakerLayer` from a small internal config struct via
+  `failure_rate_threshold`, `sliding_window_size`/`sliding_window_duration`,
+  `wait_duration_in_open`, `slow_call_duration_threshold`, and
+  `slow_call_rate_threshold` -- the sliding-window rate and slow-call axes,
+  no `consecutive_failures`.
+- Hold the concrete `CircuitBreaker<S, DefaultClassifier>` value directly
+  (`TowerCB<GrpcSendService, DefaultClassifier>` in RMQTT) and read state via
+  its own sync/async inspection methods (`state_sync()`, `is_open()`,
+  `metrics()`) rather than `build_with_handle()` / `CircuitBreakerHandle` --
+  workable because they never type-erase the service away from the code that
+  needs to inspect it.
+- Neither uses `force_open`/`force_closed`/`reset`/`manual_mode` (all
+  predate #384 by less than a day at the time of this review, so this is not
+  surprising) or a custom `failure_classifier`.
+
+**GovCraft/Acton** ([Govcraft/acton-service](https://github.com/Govcraft/acton-service),
+`acton-service/src/middleware/resilience.rs`) wraps the crate for **inbound**
+axum HTTP middleware, which is a materially different integration shape:
+
+- Two separate layer builders: `circuit_breaker_layer()` for outbound client
+  stacks (default `Err`-only classification) and
+  `http_circuit_breaker_layer()` for the inbound router, which supplies a
+  custom `failure_classifier` (via `FnClassifier`) that treats any 5xx
+  `Response` as a failure -- necessary because an axum route handler is
+  `Infallible` (a 500 arrives as `Ok(Response)`, not `Err`), so the default
+  classifier would never trip on an inbound stack.
+- Always calls `build_with_handle()` and discards the handle (`.0`), because
+  axum's `Router::layer` / `HandleErrorLayer` composition re-invokes
+  `Layer::layer` per request in their setup, and a plain `build()` would mint
+  fresh (i.e., never-tripping) circuit state on every request. This is a
+  general Tower-layer-with-axum caveat (their own `bulkhead_layer()` has the
+  identical comment), not specific to the circuit breaker.
+- Also does not use `force_open`/`force_closed`/`manual_mode` or a shared
+  `CircuitBreakerHandle`.
+
+**Finding: no genuine API friction identified.** Both integrations configure
+the rate/slow-call axes directly, and RMQTT's direct-service-inspection
+pattern and Acton's custom-classifier-for-infallible-inbound-routes pattern
+are both first-class, documented ways to use this crate today (the latter is
+exactly what `classify_response`/`failure_classifier` exist for). No
+workaround, wrapper-around-a-gap, or unsupported-need was found in either
+codebase. No issue was filed.
+
+## Ideas worth adopting from upstream
+
+- Upstream's `on_half_open()` policy hook is an explicit, separately named
+  callback for "clear stale pre-outage history when a recovery probe
+  starts." Locally this happens implicitly inside `Circuit::transition_to`
+  (unconditional counter/window reset on every transition). The behavior is
+  equivalent, but a named hook is a slightly more readable place to hang
+  future customization (e.g. a policy that wants to *keep* some
+  pre-outage history) if `FailureModel` ever grows a fully pluggable variant.
+- Upstream's `CircuitPolicy` trait (four small methods:
+  `on_success`/`on_failure`/`should_probe`/`on_half_open`) is a reasonable
+  reference shape *if* this project ever wants a fully custom, user-supplied
+  trip policy beyond the `FailureModel` enum's rate/consecutive/slow-call
+  axes. Nothing here currently requires it -- `FailureModel` plus the
+  classifier seam already cover the practical cases -- but it's a clean
+  small-trait design worth remembering if that need arises.
+
+## Intentional capability differences
+
+- **Slow-call detection** (`slow_call_duration_threshold` +
+  `slow_call_rate_threshold`) as a first-class, independently-evaluated trip
+  axis. Upstream's built-in `ConsecutiveFailures` policy has no latency
+  concept at all.
+- **Sliding-window failure *rate*** (count- or time-based) as the default
+  trip model, vs. upstream's built-in policy being consecutive-count-only
+  (a rate policy would have to be hand-written against `CircuitPolicy`).
+- **Atomic per-cycle half-open admission** via a `Semaphore` recreated on
+  every `Open -> HalfOpen` transition (#382), enforced at admission time --
+  vs. upstream's current diff not gating concurrent `HalfOpen` admission at
+  all (see [Admission semantics](#admission-semantics)).
+- **`CircuitBreakerHandle`**: a fully decoupled, `Clone + Send + Sync`
+  external control/observation surface independent of the wrapped service
+  instance -- vs. upstream's only surface being the `Service` value itself.
+- **`.manual_mode()`**: a first-class, declarative external-only mode --
+  upstream would require hand-writing a `CircuitPolicy` that never trips or
+  recovers on its own.
+- **Fallback composition** (`with_fallback`): an open circuit can return an
+  alternative response instead of an error. Upstream has no fallback
+  concept; callers would layer their own.
+- **Observability**: event listeners (`on_state_transition`,
+  `on_call_permitted`, `on_call_rejected`, `on_success`, `on_failure`,
+  `on_slow_call`) plus `metrics`/`tracing` feature integration. None of this
+  exists in the upstream diff.
+- **Preset configurations** (`standard()`, `fast_fail()`, `tolerant()`) for
+  zero-tuning startup. Upstream's constructor is three positional arguments
+  with no presets.
+- **Pluggable failure classification** independent of the trip-condition
+  model (see [Separation of concerns](#separation-of-concerns)). Upstream
+  has no classifier seam.
+
+## Composition with retry budgets
+
+This section documents how circuit breaker and retry-budget (#370, PR #411)
+composition works when both are layered on the same client stack, per this
+issue's requirement to coordinate with #370.
+
+### Layer order changes which attempts the breaker counts
+
+Tower layers wrap from the outside in; the order below is
+`ServiceBuilder::new().layer(A).layer(B).service(inner)`, where `A` is
+outermost (sees the request first) and `B` is innermost (closest to
+`inner`).
+
+**Retry wrapping breaker** (breaker innermost, closest to the transport):
+
+```rust,ignore
+let service = ServiceBuilder::new()
+    .layer(retry_layer)      // outermost
+    .layer(circuit_breaker_layer)
+    .service(transport);
+```
+
+Every retry attempt -- the initial attempt and every subsequent retry --
+calls `poll_ready`/`call` on the breaker directly. Each attempt therefore
+increments the breaker's sliding window independently: a request that fails
+twice and succeeds on its third attempt records **two failures and one
+success** in the breaker's window, exactly as if three independent calls had
+been made. This is the natural, common ordering: the breaker protects the
+transport from retry amplification, and it sees (and can trip on) the actual
+retry volume hitting the backend.
+
+**Breaker wrapping retry** (breaker outermost, sees only the retry's final
+outcome):
+
+```rust,ignore
+let service = ServiceBuilder::new()
+    .layer(circuit_breaker_layer) // outermost
+    .layer(retry_layer)
+    .service(transport);
+```
+
+The breaker only ever sees one call per external request: `Retry`'s own
+`Service::call` future runs the entire retry loop internally and resolves
+once, so the breaker's classifier and sliding window observe exactly one
+outcome per external request -- a request that failed twice internally but
+eventually succeeded records **one success**, not two failures and a
+success. The breaker is effectively blind to the actual attempt volume
+against the transport and can only react to the retry policy's fully
+adjudicated final answer. This ordering also does not gate individual retry
+attempts on transport health at all -- if the breaker is closed based on
+the smoothed final-outcome view, every internal retry attempt still reaches
+the transport even while it is actively failing.
+
+### Interaction with the retry budget's token accounting
+
+Reading `crates/tower-resilience-retry/src/lib.rs` and
+`crates/tower-resilience-retry/src/budget.rs`: the retry budget is
+consulted only inside `Retry::call`'s loop, at the point a *subsequent*
+attempt is being considered (never for the first attempt of a request), via
+`budget.try_withdraw()`, and is only replenished via `budget.deposit()` on
+eventual success. `try_withdraw`/`deposit` do not distinguish *why* an
+attempt failed -- there is no special case for a `CircuitBreakerError`.
+
+This matters differently depending on layer order:
+
+- **Retry wrapping breaker** (breaker innermost): a breaker-rejected attempt
+  (`CircuitBreakerError::OpenCircuit`) is indistinguishable from any other
+  retryable error to `Retry`'s default `RetryPolicy` (which retries all
+  errors by default -- `should_retry` returns `true` unless a
+  `.retry_on(predicate)` builder call says otherwise). By default, an open
+  circuit therefore **does consume a retry-budget token per rejected
+  attempt**, even though the rejection never reached the network and cost
+  nothing but a mutex lock and an atomic load. Left unconfigured, this can
+  drain the budget on rejections alone during an outage, starving budget for
+  requests that would otherwise succeed once the circuit half-opens.
+- **Breaker wrapping retry** (breaker outermost): the breaker's rejection
+  happens before `Retry` is ever reached (it fails at the breaker's own
+  `poll_ready`/`call`, never entering the retry loop), so no budget
+  token is withdrawn or deposited for a breaker rejection at all -- the
+  retry budget only ever sees fully-adjudicated final outcomes from
+  requests the breaker actually admitted.
+
+**Recommendation for the retry-wraps-breaker ordering:** configure
+`RetryLayer::builder().retry_on(predicate)` to return `false` for
+`CircuitBreakerError::OpenCircuit` (check via
+`CircuitBreakerError::is_circuit_open()`), so open-circuit rejections fail
+the current attempt immediately without consuming a budget token or
+scheduling a backoff sleep for a call that never left the process. The
+current code does not do this automatically; it is a per-integration
+configuration decision, not a bug -- `Retry` has no way to know that a given
+`E` came from a wrapped circuit breaker without the caller telling it via
+the predicate.
+
+### Recommended default ordering
+
+**Retry wrapping breaker (breaker innermost) is the recommended default**,
+with the retry predicate excluding circuit-open rejections as described
+above. This ordering lets the breaker observe and react to the actual retry
+volume against the transport (the thing it exists to protect), keeps the
+breaker's sliding window meaningful (it reflects real attempts, not
+smoothed per-request outcomes), and -- once the predicate exclusion is
+configured -- avoids wasting retry budget and backoff delay on calls that
+were rejected locally rather than failing against the backend. The
+alternative ordering (breaker outermost) is appropriate only when the
+retry's *entire* multi-attempt operation should be treated as one unit of
+health for the breaker's purposes (for example, when downstream jitter makes
+individual-attempt failure rate a noisy signal and only the request-level
+success/failure matters) -- but that reduced attempt-level visibility, and
+the fact that it does not gate individual internal retry attempts on
+transport health, should be a deliberate choice, not the default.

--- a/docs/tower-contract-matrix.md
+++ b/docs/tower-contract-matrix.md
@@ -19,7 +19,7 @@ into a regression test. It does **not** mean the behavior is assumed correct.
 | bulkhead | Covered in rejection and backpressure modes | N/A | Waiting clone, readied clone, and response-future drop release queue position/permits ([#367]) | Direct `PollSemaphore` reservation matches Tower; fail-fast and bounded-wait modes are additional ([#367]) | Inner readiness and closed-semaphore errors release reservations | Audit in [#372] | `tower::limit::ConcurrencyLimit` |
 | cache | Covered on forced misses | N/A | Pass-through cancellation; probe regression not yet added | Covered by existing concurrency tests | Covered on hits/misses | Audit in [#372] | `tower::Service` pass-through |
 | chaos | Covered | N/A | Pass-through cancellation; probe regression not yet added | N/A | Covered by behavior tests | Audit in [#372] | `tower::Service` pass-through |
-| circuitbreaker | Covered, including state-first open-circuit gating ([#381]) | N/A | Half-open probe drop returns its reservation and records no result ([#382]) | Half-open admission is reserved with a per-cycle `Semaphore` shared across clones; open rejection/backpressure gate covered ([#381], [#382]) | Inner readiness errors covered | Audit in [#372] | Tower circuit breaker [#855] |
+| circuitbreaker | Covered, including state-first open-circuit gating ([#381]) | N/A | Half-open probe drop returns its reservation and records no result ([#382]); permanently-pending inner under `Closed` forwards `Pending`, registers a waker, and is drop-safe, with no busy-poll ([#375]) | Half-open admission is reserved with a per-cycle `Semaphore` shared across clones; open rejection/backpressure gate covered ([#381], [#382]) | Inner readiness errors covered | Failure-rate window fill/trip, `ConsecutiveFailures` model (independent of window gating), and slow-call-rate trip are each covered as distinct paths ([#375]) | Tower circuit breaker [#855]; comparison and RMQTT/GovCraft integration review in [circuitbreaker-tower-comparison.md] |
 | coalesce | Covered on leader path | N/A | Leader/waiter cancellation has behavior coverage; probe regression not yet added | Covered by concurrency/stress tests | Covered for leaders/waiters | Audit in [#372] | Singleflight semantics |
 | executor | Covered | N/A | Executor cancellation semantics tracked in [#371] | N/A | Covered by contract/behavior tests | Audit in [#372] | `tower::Service` pass-through |
 | fallback | Covered for primary and generic backup services ([#374]) | Backup readiness is driven after primary failure on the exact shared service instance ([#374]) | Pending readiness and backup-call cancellation release shared state and drop owned work ([#374]) | Backup readiness registers its service waker; readiness errors are typed fallback failures ([#374]) | Primary skip and heterogeneous backup-error selection covered ([#374]) | Request cloning and shared-backup topology documented; broader audit in [#372] | Tower [#413] service-to-service fallback; [#870] is pre-primary interception |
@@ -61,8 +61,10 @@ Every new execution path must demonstrate, where applicable:
 [#372]: https://github.com/joshrotenberg/tower-resilience/issues/372
 [#373]: https://github.com/joshrotenberg/tower-resilience/issues/373
 [#374]: https://github.com/joshrotenberg/tower-resilience/issues/374
+[#375]: https://github.com/joshrotenberg/tower-resilience/issues/375
 [#381]: https://github.com/joshrotenberg/tower-resilience/issues/381
 [#382]: https://github.com/joshrotenberg/tower-resilience/issues/382
 [#413]: https://github.com/tower-rs/tower/issues/413
 [#855]: https://github.com/tower-rs/tower/pull/855
 [#870]: https://github.com/tower-rs/tower/issues/870
+[circuitbreaker-tower-comparison.md]: circuitbreaker-tower-comparison.md


### PR DESCRIPTION
## Setup

cwd: /Users/joshrotenberg/Code/github.com/joshrotenberg/tower-resilience

You are on branch `docs/circuitbreaker-tower-comparison-375`, already
created off a fresh `origin/main` and pushed with an empty initial commit.
Do NOT create a new branch. Verify with a single Bash call:

    git branch --show-current

Output must be `docs/circuitbreaker-tower-comparison-375`.

## Context

Issue #375 asks the project to validate its circuit breaker's leadership
claim against tower-rs/tower#855 (Sean Monstar's proposed upstream
`CircuitPolicy`) and against real adopters (RMQTT uses the crate directly;
GovCraft/Acton integrates it with bulkhead). This is a documentation +
test-authoring task, not a correctness-fix task: all three owned
correctness issues referenced from #375 have already landed on `main`:

- #381 -- open circuits are gated before inner readiness is polled.
- #382 (PR #407) -- half-open probe capacity is reserved atomically across
  clones, with drop-safety on cancellation.
- #384 (PR #412) -- `CircuitBreakerHandle` is a deterministic shared
  controller (`force_open`, `force_closed`, `reset`, `manual_mode`).

The retry-budget work from #370 (PR #411) is also merged, which you need
for the composition documentation (layer order determines which attempts
the breaker counts vs. which attempts the retry budget accounts for).

Deliverables must be **concrete artifacts**: compatibility/contract tests
that would fail if a regression reintroduced a gap, a documented comparison
checklist an upstream-change reviewer can walk without redoing analysis,
and composition docs. Do not write an analysis-only summary with no
tests or docs changes -- that does not satisfy the issue's acceptance
criteria.

## Existing structures to extend (do not invent new ones)

- `crates/tower-resilience-circuitbreaker/tests/contract.rs` -- the
  compatibility-test harness. It already covers: open-circuit gating
  before inner readiness (single service and cloned), backpressure mode
  waiting on the circuit before pending inner, admitted inner-readiness
  error preservation, half-open admission exclusivity under concurrent
  clone contention, half-open probe drop releasing its reservation without
  recording a result, and half-open backpressure waiter wake-on-release.
  Uses `tower_resilience_core::testing::{ServiceProbe, ControlledService,
  StatefulInner}`.
- `docs/tower-contract-matrix.md` -- the crate-by-crate Tower contract
  comparison table (the circuitbreaker row already links #381/#382 and
  cites Tower circuit breaker `[#855]`). This is the file the "comparison
  is captured in ... documentation" acceptance criterion is about.
- `docs/tower-service-review-checklist.md` -- companion human-review
  checklist; read for the shape/tone conventions but you are not required
  to edit it unless a new checklist item genuinely belongs there.
- `crates/tower-resilience-circuitbreaker/src/handle.rs`,
  `src/config.rs`, `src/circuit.rs`, `src/classifier.rs` -- read these for
  the actual current API (`force_open`/`force_closed`/`reset`,
  `manual_mode()`, `consecutive_failures()`, `slow_call_duration_threshold`
  / `slow_call_rate_threshold`, `sliding_window_type`
  (`CountBased`/`TimeBased`)) so the comparison document describes what is
  actually on `main`, not a stale or imagined API.

## Task

### 1. Compatibility tests in `tests/contract.rs`

Add tests for the specific coverage gaps the issue calls out that are NOT
already covered by the existing tests listed above:

- **Failure-rate threshold** admission/trip behavior at the contract level
  (sliding window fills, rate threshold trips the circuit, subsequent
  `poll_ready` reflects `Open` without polling inner).
- **Consecutive-failure** threshold trip behavior (`consecutive_failures()`
  config), distinct from the rate-based path.
- **Slow-call** detection (`slow_call_duration_threshold` /
  `slow_call_rate_threshold`) tripping the circuit independent of hard
  failures.
- **An inner service that remains permanently `Pending`** while the
  circuit is `Closed` -- confirm the breaker does not busy-poll, forwards
  `Pending` correctly, registers a waker, and that dropping the caller's
  future while inner is still pending releases resources cleanly (use
  `ControlledService`/`ServiceProbe` the way the existing tests do; no
  wall-clock sleeps for the busy-poll assertion -- poll count is the
  evidence).

Do not duplicate the half-open/cancellation/cloned-service coverage that
already exists -- extend, don't replace. If, while writing these, you find
an actual behavioral gap (not just a missing test), do NOT silently fix it
in this PR beyond what's needed to make the test meaningfully pass -- file
a separate issue instead and note it in the PR description, since the
correctness-fix issues (#381/#382/#384) are explicitly already closed and
out of this PR's scope.

### 2. `docs/tower-contract-matrix.md`

Update the circuitbreaker row (and matrix intro text if warranted) to
reflect the new compatibility-test coverage added in step 1. Keep the
existing `Gap`/link conventions.

### 3. New comparison doc: `docs/circuitbreaker-tower-comparison.md`

Create this file (link it from `README.md` near the existing
`docs/reconnect-factory-migration.md` reference, following that file's
linking convention). Structure it as the durable checklist the issue's
acceptance criteria describe -- something a reviewer can walk against a
future tower-rs/tower#855 diff without redoing the analysis. Cover, with
explicit checklist-style entries (checkbox or table rows), each of:

- **API and state-machine comparison**: local `CircuitState`
  (Closed/Open/HalfOpen) and config surface vs. upstream `CircuitPolicy`
  as proposed in tower-rs/tower#855 (fetch/read the PR discussion --
  https://github.com/tower-rs/tower/pull/855#issuecomment-4039743246 -- and
  the PR itself via `gh` or WebFetch for the actual proposed shape; do not
  guess).
- **Admission semantics**, not just state transitions:
  - whether circuit state is checked before inner readiness (yes, since
    #381 -- cite the specific contract test),
  - whether open-circuit rejection surfaces via `poll_ready` or `call`
    (cite the actual code path),
  - behavior across cloned services (shared circuit state via `Arc`,
    cite #382's contract tests),
  - concurrent half-open probes (atomic per-cycle reservation, cite
    #382/PR #407 and its contract tests).
- **Whether upstream `CircuitPolicy` (as proposed) actually supports
  externally triggered circuits** -- an explicit yes/no/partial finding
  with justification, not a hedge.
- A short section keeping **failure classification, state-transition
  policy, and request-admission policy conceptually separate** as three
  distinct concerns, and stating where each lives in the local
  implementation (`classifier.rs` / `circuit.rs` / the `Service` impl).
- **Operator-control capability comparison table**: force-open,
  force-closed, reset, shared handles, external health signals,
  external-only/manual operation -- local support (cite `handle.rs`
  and `manual_mode()`) vs. upstream support as proposed.
- **RMQTT and GovCraft/Acton integration review**: use `gh search code` or
  WebFetch against their public repos to find where/how they consume this
  crate's circuit breaker (construction patterns, which config knobs they
  set, whether they use `CircuitBreakerHandle`, any workarounds suggesting
  API friction). Summarize findings inline. If you find genuine API
  friction (something the integration had to work around), file a
  separate GitHub issue for it (`gh issue create`) rather than expanding
  this PR's scope, and link the filed issue number from this doc.
- **Ideas worth adopting from upstream** without losing this project's
  differentiators (handles, events, fallback, windows, classifiers) --
  a short explicit list, or "none identified" if genuinely none.
- **Intentional capability differences** -- a short explicit list of
  where this project deliberately diverges from the upstream proposal and
  why.
- A one-line pointer that trait-bound/boxing/allocation/runtime-coupling
  analysis is tracked separately in #376, not duplicated here.

### 4. Composition doc: circuit breaker + retry budget

Document how circuit breaker and retry-budget (#370/PR #411) composition
works, specifically:

- How Tower layer order changes which attempts the breaker counts: retry
  wrapping breaker (breaker innermost, closest to the transport) vs.
  breaker wrapping retry (breaker outermost, sees only the retry's final
  outcome). Be concrete about which attempts increment the breaker's
  sliding window in each order.
- How this interacts with the retry budget's token accounting
  (`crates/tower-resilience-retry/src/budget.rs`) -- whether a
  breaker-rejected attempt should or should not consume/deposit a retry
  budget token, and what the current code actually does (read
  `crates/tower-resilience-retry/src/policy.rs` and `budget.rs`).
- A recommended default ordering with a one-paragraph rationale.

Put this in the same `docs/circuitbreaker-tower-comparison.md` file as a
clearly delineated `## Composition with retry budgets` section (per the
issue: "Document circuit breaker and retry-budget composition ...
coordinate with #370") rather than a separate file, since it is a small,
tightly related section -- unless you find the doc is getting unwieldy, in
which case a separate `docs/circuitbreaker-retry-composition.md` linked
from the comparison doc is fine. Use your judgment; either shape satisfies
the issue.

## Tool-call discipline

- Setup verification (branch check) must run before any exploration or
  edits, not batched in parallel with them.
- If tool calls return `<tool_use_error>Cancelled: parallel tool call
  Bash(...) errored</tool_use_error>` errors, do NOT retry blindly and do
  NOT issue "flush" echo commands. Read the actual failing call, decide if
  it matters, fix or continue.
- If a write (Edit/Write tool) is blocked by a permission/approval gate --
  message contains "haven't granted" or similar -- STOP immediately and
  report the exact gate message. Do NOT attempt mechanical bypasses
  (touch + git apply heredocs, perl redirect, tee, python). The launch
  configuration is wrong; no workaround will fix it.

## Steps

1. Read `crates/tower-resilience-circuitbreaker/tests/contract.rs`,
   `docs/tower-contract-matrix.md`, `src/handle.rs`, `src/config.rs`,
   `src/circuit.rs`, `src/classifier.rs` in full.
2. Fetch the upstream PR discussion (tower-rs/tower#855, and the specific
   comment https://github.com/tower-rs/tower/pull/855#issuecomment-4039743246)
   via `gh api` / `gh pr view --repo tower-rs/tower 855` / WebFetch, to
   ground the comparison doc in what upstream actually proposes.
3. Research RMQTT's and GovCraft/Acton's usage of this crate's circuit
   breaker via `gh search code` or WebFetch against their public repos.
4. Add the compatibility tests in `tests/contract.rs` (section 1 above).
5. Update `docs/tower-contract-matrix.md` (section 2).
6. Write `docs/circuitbreaker-tower-comparison.md` (sections 3 and 4).
7. Add a link to the new doc from `README.md`.
8. File a separate GitHub issue for any genuine API friction found in
   RMQTT/Acton usage, and for any behavioral gap found in step 4 that
   is out of this PR's scope. Reference the filed issue number(s) in the
   doc and in your final commit message / PR summary.
9. `cargo fmt --all -- --check`
10. `cargo clippy --all-targets -- -D warnings`
11. `cargo test -p tower-resilience-circuitbreaker`
12. `cargo test` (full workspace, to confirm nothing else broke)
13. If all green: `git add` the changed files and commit with
    `docs(circuitbreaker): compare against tower-rs/tower#855 and document retry-budget composition (closes #375)`
    (a single commit for your changes is fine; do not worry about the
    earlier empty `chore: start work on #375` commit already on the
    branch).
14. Print `git log --oneline -3`, `git diff origin/main --stat`, and the
    current branch name.

## Constraints

- Do NOT push (the runner pushes after you return).
- Do NOT amend the existing empty commit.
- Do NOT touch `main`.
- Do NOT run `gh pr create` or `gh pr merge` (the runner owns the PR
  lifecycle) -- but DO run `gh issue create` for any friction/gap issues
  per step 8, and `gh api` / `gh pr view --repo tower-rs/tower` /
  WebFetch for research per steps 2-3.
- Do NOT reopen or duplicate the correctness work already closed by
  #381/#382/#384 -- this PR is documentation and compatibility tests only.
  If you find a genuine new correctness gap, file an issue; do not fix it
  here beyond what's needed for a test to be meaningful.
- Do NOT expand scope into the trait-bound/boxing/runtime-coupling
  analysis -- that is #376's job; a one-line pointer is enough.
- Style references (`docs/reconnect-factory-migration.md`,
  `docs/fallback-service-migration.md`) are for tone/structure reference
  ONLY -- do not copy their content.
