### PR TITLE
ci: bound protoc install and replace apt-get with pinned setup-protoc (closes #419)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 
@@ -68,8 +69,15 @@ jobs:
 
       # The tonic workspace example compiles protobufs from source. Keep this
       # explicit until the examples audit in #388 decides whether it remains.
+      # Installed from GitHub releases rather than apt: untimed apt-get here
+      # stalled CI for 30-70 minutes on four runs on 2026-08-18 (#419). The
+      # step timeout bounds any residual hang.
       - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        uses: arduino/setup-protoc@v3
+        timeout-minutes: 5
+        with:
+          version: "35.1"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run clippy
         run: cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
@@ -126,14 +134,20 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      # See the protoc note on the clippy job (#419, #388).
       - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        uses: arduino/setup-protoc@v3
+        timeout-minutes: 5
+        with:
+          version: "35.1"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check documentation
         run: cargo doc --locked --workspace --all-features --no-deps


### PR DESCRIPTION
## Problem

The `Install protoc` step in the `clippy` and `docs` jobs runs `sudo apt-get update && sudo apt-get install -y protobuf-compiler` with no timeout. An apt mirror or lock stall on the GitHub-hosted runner hangs the step indefinitely, and the default job timeout is 6 hours. This hit four separate runs on 2026-08-18, stalling Clippy and Documentation jobs for 30 to 70 minutes each until they were manually cancelled and re-run (#414, #419).

## Plan

- Replace the apt-get install in both jobs with `arduino/setup-protoc@v3`, pinned to protoc `35.1` (current stable release). The action downloads a single release archive from GitHub instead of touching apt mirrors, adds it to the tool cache, and passes `repo-token` to avoid anonymous API rate limits.
- Add a step-level `timeout-minutes` guard to both `Install protoc` steps so any residual stall fails fast instead of hanging.
- Add job-level `timeout-minutes` to the `clippy` and `docs` jobs, as suggested in #414, so a stall anywhere in those jobs is bounded.
- Keep the existing comment tying the protoc dependency to the examples audit in #388.

Auditing the remaining jobs (test matrix, msrv, security-audit) for job-level timeouts is a possible follow-up, left out of scope here.

Closes #419. Closes #414 (duplicate, same root cause).