### PR TITLE
ci(release): split release-plz into release + release-pr jobs (closes #377)

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,18 +1,29 @@
 name: Release
 
-permissions:
-  pull-requests: write
-  contents: write
-
 on:
   push:
     branches:
       - main
 
+# Split into two jobs (release, release-pr) per the release-plz maintainers'
+# recommended layout, instead of running both commands in a single job.
+# The combined-job form does not carry a concurrency group, so two rapid
+# pushes to main (e.g. successive PR merges) could each start their own
+# release-pr step and race each other, both concluding no release PR was
+# open yet and each opening its own -- producing the kind of stale
+# duplicate release PR cleaned up in #377. Splitting the jobs lets the
+# release-pr job carry its own concurrency group (below) while keeping the
+# release (publish) job unthrottled, since cancelling a pending publish
+# run would risk skipping a release outright.
 jobs:
-  release-plz:
-    name: Release-plz
+  # Publish already-versioned packages: crates.io, git tags, GitHub
+  # releases. No concurrency group here -- see comment above.
+  release-plz-release:
+    name: Release-plz release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -24,6 +35,39 @@ jobs:
 
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # Open or update the PR that prepares the next release (version bumps +
+  # changelogs). Serialized via the concurrency group so that overlapping
+  # pushes to main queue instead of racing: only one release-pr run is
+  # ever in flight per ref, and it always sees the previous run's result
+  # before deciding whether a new PR is needed.
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-pr-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        with:
+          command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -262,6 +262,61 @@ Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
 5. Ensure all tests pass
 6. Submit a pull request
 
+## Release Process
+
+Releases are automated by [release-plz](https://release-plz.dev) via
+`.github/workflows/release-plz.yml`, which runs on every push to `main` as
+two independent jobs:
+
+- `release-plz-release` publishes any packages whose `Cargo.toml` version has
+  already been bumped on `main` (crates.io, git tags, GitHub releases).
+- `release-plz-pr` opens or updates the PR that prepares the *next* release
+  (version bumps + changelog entries), serialized with a `concurrency` group
+  so overlapping pushes to `main` queue instead of racing each other into
+  opening duplicate release PRs.
+
+All 18 publishable crates under `crates/` use release-plz's default
+per-crate changelog path (`crates/<name>/CHANGELOG.md`). `release-plz.toml`
+sets `changelog_path` explicitly for `tower-resilience-core`,
+`tower-resilience-circuitbreaker`, and `tower-resilience-bulkhead` for
+clarity only; every other crate relies on the default, which resolves to the
+same location. If a crate is added, confirm its changelog lands at that
+default path (or add an explicit `[[package]]` entry if it needs a
+different one).
+
+### Runbook: checking for stale release branches/PRs
+
+Run this check whenever the release automation looks off (e.g. a release PR
+sits open longer than expected, or `main` gets multiple release-plz pushes
+in quick succession), and periodically as part of release hygiene:
+
+1. List open release-plz PRs:
+
+   ```bash
+   gh pr list --search "head:release-plz-" --state open
+   ```
+
+   At most one should be open at a time -- it represents the one active
+   release train. If more than one is open, or an open one targets a
+   version that is already published (check `gh release list` for a
+   matching tag, or query crates.io), the extra PR is stale.
+
+2. Close a stale PR with a factual explanatory comment (state why: the
+   version is already published and on `main` via another PR), and do
+   **not** delete its branch unless you've confirmed it's fully merged or
+   the changes it contains are already obsolete. See PR #355 for the
+   precedent (closed as a stale duplicate of the v0.10.1 release already
+   published and merged via PR #345, tracked in #377).
+
+3. Check for release-plz branches with no corresponding open PR:
+
+   ```bash
+   git branch -r --list 'origin/release-plz-*'
+   ```
+
+   Delete only branches whose PR is merged or closed and whose commits are
+   already fully contained in `main`.
+
 ## Questions?
 
 Feel free to open an issue for questions or discussions.


### PR DESCRIPTION
## Summary

Fixes the duplicate release-PR automation issue tracked in #377.

## Findings

- v0.10.1 was confirmed fully published: all 18 crates have matching
  git tags, GitHub releases, and `Cargo.toml` history at `-v0.10.1`.
- PR #355 (the stale v0.10.1 release PR) was already closed with an
  explanatory comment prior to this PR, per the issue's precedent.
- Root cause of the duplicate release PRs (#355, #390, #398): the
  workflow ran `release-plz release-pr` then `release-plz release`
  sequentially inside a single job, with no `concurrency` group. Since
  every merged PR in this repo triggers this workflow (push to
  `main`), rapid successive merges can trigger overlapping workflow
  runs; each run's `release-pr` step independently checks "is a
  release PR already open" and, without serialization, two runs can
  both answer "no" and each open its own PR.
- release-plz's own maintainers document exactly this failure mode and
  recommend splitting `release` and `release-pr` into two jobs, with a
  `concurrency` group scoped to the `release-pr` job only (not the
  publish job, since cancelling a pending publish could skip a
  release).
- Verified changelog paths: all 18 publishable crates under `crates/`
  resolve to release-plz's default per-crate changelog path
  (`crates/<name>/CHANGELOG.md`). `release-plz.toml` has explicit
  `changelog_path` entries for 3 crates (clarity only); confirmed the
  other 15 rely correctly on the same default location.

## Changes

- `.github/workflows/release-plz.yml`: split the single `release-plz`
  job into `release-plz-release` (runs `command: release`, no
  concurrency group) and `release-plz-pr` (runs `command: release-pr`,
  with `concurrency: { group: release-plz-pr-${{ github.ref }},
  cancel-in-progress: false }`), matching the release-plz maintainers'
  documented layout.
- `CONTRIBUTING.md`: documents the release automation split, the
  changelog-path verification, and a runbook check for stale
  release-plz branches/PRs (how to spot one, how to close it with a
  factual comment, when it's safe to delete the branch).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on the new workflow file
- [ ] Next real release-plz run on `main` should produce exactly one
      open release PR (observability only; can't be verified in CI on
      this branch since the workflow only runs on push to `main`)