### PR TITLE
docs: reconcile README, rustdoc, and examples with verified behavior (closes #380)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A comprehensive resilience and fault-tolerance toolkit for [Tower](https://githu
 
 ```toml
 [dependencies]
-tower-resilience = { version = "0.10", features = ["circuitbreaker", "bulkhead"] }
+tower-resilience = { version = "0.12", features = ["circuitbreaker", "bulkhead"] }
 tower = "0.5"
 ```
 
@@ -61,10 +61,10 @@ what you use. Enable patterns explicitly, or use `full` to get them all:
 
 ```toml
 # Pick specific patterns
-tower-resilience = { version = "0.10", features = ["circuitbreaker", "retry", "bulkhead"] }
+tower-resilience = { version = "0.12", features = ["circuitbreaker", "retry", "bulkhead"] }
 
 # Or enable everything (all patterns + observability)
-tower-resilience = { version = "0.10", features = ["full"] }
+tower-resilience = { version = "0.12", features = ["full"] }
 ```
 
 ### Pattern Features
@@ -93,17 +93,27 @@ tower-resilience = { version = "0.10", features = ["full"] }
 | Feature | Effect |
 |---------|--------|
 | `layer` | Unified error layer for composing patterns under one error type |
-| `metrics` | Prometheus metrics on every pattern you've enabled |
-| `tracing` | Structured `tracing` spans/events on every pattern you've enabled |
+| `metrics` | Prometheus metrics on the patterns that implement it (see below) |
+| `tracing` | Structured `tracing` spans/events on the patterns that implement it (see below) |
 | `full` | All patterns plus `layer`, `metrics`, and `tracing` |
 | `health-circuitbreaker` | Integration: health checks can open/close circuit breakers |
 
 `metrics` and `tracing` use weak feature activation, so they only turn on
 observability for the patterns you've already enabled - they never pull in a
-pattern on their own. To get all patterns with observability:
+pattern on their own. Not every pattern emits metrics or tracing yet:
+`bulkhead`, `cache`, `chaos`, `circuitbreaker`, `coalesce`, `fallback`,
+`ratelimiter`, `retry`, `router`, and `timelimiter` emit metrics today (see
+the [metrics guide](https://docs.rs/tower-resilience/latest/tower_resilience/observability/metrics/)
+for the full list of metric names per pattern); all of those except
+`bulkhead` also emit `tracing` spans/events. `adaptive`, `executor`, `hedge`,
+`outlier`, and `reconnect` accept the `metrics`/`tracing` Cargo features
+(they compile cleanly) but do not yet instrument any calls; see
+[#428](https://github.com/joshrotenberg/tower-resilience/issues/428).
+
+To get all patterns with observability:
 
 ```toml
-tower-resilience = { version = "0.10", features = ["full"] }
+tower-resilience = { version = "0.12", features = ["full"] }
 ```
 
 (`full` already includes `metrics` and `tracing`.)
@@ -376,10 +386,36 @@ let service = ServiceBuilder::new()
     .service(my_service);
 ```
 
+`ExecutorLayer::new(handle)`/`::current()` spawn each request as an ordinary
+task on that runtime's async core workers (`tokio::runtime::Handle::spawn`).
+That gives you task-level parallelism and isolation from whatever runtime
+the caller is on, but it does **not** protect the target runtime's core
+workers from a future that blocks without yielding -- a genuinely blocking
+or CPU-bound call still stalls whichever worker thread happens to run it.
+For that case, use [`BlockingExecutor`](https://docs.rs/tower-resilience-executor/latest/tower_resilience_executor/struct.BlockingExecutor.html),
+which reserves a thread from Tokio's dedicated blocking-task pool via
+`spawn_blocking` instead:
+
+```rust
+use tower_resilience::executor::{BlockingExecutor, ExecutorLayer};
+use tower::ServiceBuilder;
+
+// Runs each request on Tokio's blocking-task pool, off the async core
+// workers, so a service that calls blocking APIs directly cannot stall
+// the rest of the application.
+let layer = ExecutorLayer::new(BlockingExecutor::current());
+
+let service = ServiceBuilder::new()
+    .layer(layer)
+    .service(my_service);
+```
+
 Use cases:
 - **CPU-bound processing**: Parallelize CPU-intensive request handling
 - **Runtime isolation**: Process requests on a dedicated runtime
 - **Thread pool delegation**: Use specific thread pools for certain workloads
+- **Blocking operations**: Use `BlockingExecutor` to offload blocking I/O or
+  CPU-bound work without yield points to a dedicated thread
 
 ### Fallback
 
@@ -410,6 +446,13 @@ let layer = FallbackLayer::<Request, Response, MyError>::tower_service(
 
 let service = layer.layer(primary_service);
 ```
+
+`tower_service()` shares one backup instance across every clone of the
+layer (the backup need only be `Send`, not `Clone`), and `Request` must
+implement `Clone` since a backup attempt needs the same logical request the
+primary consumed. See the [generic fallback-service migration
+guide](docs/fallback-service-migration.md) for readiness, sharing, and
+error-selection details.
 
 ### Hedge
 
@@ -609,6 +652,43 @@ let layer = RetryLayer::<(), (), MyError>::builder()
 
 let service = layer.layer(my_service);
 ```
+
+**Retry budgets:** cap the total retry volume across all requests (not just
+per-request attempts), so a struggling downstream doesn't get amplified
+traffic from every caller retrying independently. A budget is shared across
+every clone of the layer; retries withdraw a token and successes deposit one
+back:
+
+```rust
+use tower_resilience::retry::{RetryLayer, RetryBudgetBuilder};
+use std::time::Duration;
+
+// Token bucket: allow up to 10 retries/sec, bursting to 100.
+let budget = RetryBudgetBuilder::new()
+    .token_bucket()
+    .tokens_per_second(10.0)
+    .max_tokens(100)
+    .build()
+    .unwrap();
+
+let layer = RetryLayer::<(), (), MyError>::builder()
+    .max_attempts(5)
+    .exponential_backoff(Duration::from_millis(100))
+    .budget(budget)
+    .on_budget_exhausted(|attempt| {
+        println!("Retry budget exhausted at attempt {}", attempt);
+    })
+    .build();
+
+let service = layer.layer(my_service);
+```
+
+An `AimdBudget` (additive-increase, multiplicative-decrease) is also
+available via `RetryBudgetBuilder::new().aimd()...` for a budget that shrinks
+under sustained exhaustion and slowly recovers, comparable to Tower's own
+transactions-per-second retry-budget concept
+([tower-rs/tower#857](https://github.com/tower-rs/tower/issues/857),
+[#863](https://github.com/tower-rs/tower/issues/863)).
 
 **Full examples:** [retry_example.rs](crates/tower-resilience-retry/examples/retry_example.rs)
 
@@ -834,6 +914,14 @@ let server = ServiceBuilder::new()
     .layer(timeout_layer)
     .service(handler);
 ```
+
+Layer order changes which attempts a circuit breaker observes when combined
+with retry: wrapping the breaker with retry (breaker innermost, closest to
+the transport) is the recommended default, since every retry attempt then
+counts toward the breaker's window. See [Composition with retry
+budgets](docs/circuitbreaker-tower-comparison.md#composition-with-retry-budgets)
+for the full tradeoff and the recommended `retry_on` predicate to exclude
+circuit-open rejections from consuming retry-budget tokens.
 
 For comprehensive guidance on composing patterns effectively, see:
 

--- a/crates/tower-resilience-reconnect/src/lib.rs
+++ b/crates/tower-resilience-reconnect/src/lib.rs
@@ -42,8 +42,7 @@
 //! #     }))
 //! # });
 //! let service = ServiceBuilder::new()
-//!     // Outer: Retry transient request errors
-//!     // (future: use tower_resilience_retry when available)
+//!     // Outer: Retry transient request errors (tower_resilience_retry::RetryLayer)
 //!     // Inner: Reconnect on connection failures
 //!     .layer(ReconnectLayer::new(
 //!         ReconnectConfig::builder()

--- a/crates/tower-resilience/src/composition.rs
+++ b/crates/tower-resilience/src/composition.rs
@@ -47,15 +47,18 @@ pub mod selection {
     //!
     //! ## Understanding ServiceBuilder Order
     //!
-    //! `ServiceBuilder` applies layers **inside-out**: the first `.layer()` call wraps
-    //! closest to the service (innermost), and the last `.layer()` call is outermost.
+    //! `ServiceBuilder` applies layers **outside-in**: the first `.layer()` call
+    //! becomes the outermost wrapper (it sees the request first), and the layer
+    //! closest to `.service(...)` is innermost, closest to the wrapped service.
+    //! ([`tower::ServiceBuilder`'s own docs](https://docs.rs/tower/latest/tower/struct.ServiceBuilder.html#order):
+    //! "Layers that are added first will be called with the request first.")
     //!
     //! ```text
     //! // Execution order: Fallback → Timeout → Retry → Service
     //! ServiceBuilder::new()
-    //!     .layer(fallback)   // 3rd added, outermost, executes 1st
-    //!     .layer(timeout)    // 2nd added, middle
-    //!     .layer(retry)      // 1st added, innermost, executes last (closest to service)
+    //!     .layer(fallback)   // added 1st, outermost, executes 1st
+    //!     .layer(timeout)    // added 2nd, middle
+    //!     .layer(retry)      // added 3rd, innermost, executes last (closest to service)
     //!     .service(svc)
     //! ```
     //!
@@ -299,8 +302,8 @@ pub mod stacks {
     //!     .layer(TimeLimiterLayer::new(Duration::from_secs(30)))  // Bound processing time
     //!     .layer(RetryLayer::builder()                            // Retry with backoff
     //!         .max_attempts(5)
-    //!         .exponential_backoff(Duration::from_secs(1))
-    //!         .max_backoff(Duration::from_secs(60))
+    //!         .backoff(ExponentialBackoff::new(Duration::from_secs(1))
+    //!             .max_interval(Duration::from_secs(60)))
     //!         .build())
     //!     .layer(CircuitBreakerLayer::builder()                   // Fail fast if handler broken
     //!         .failure_rate_threshold(0.5)
@@ -464,18 +467,21 @@ pub mod ordering {
     //!
     //! ## ServiceBuilder Order
     //!
-    //! `ServiceBuilder` applies layers **inside-out**: the first `.layer()` call wraps
-    //! closest to the service (innermost), and the last `.layer()` call is outermost.
+    //! `ServiceBuilder` applies layers **outside-in**: the first `.layer()` call becomes
+    //! the outermost wrapper (it sees the request first), and the layer closest to
+    //! `.service(...)` is innermost. Per
+    //! [`tower::ServiceBuilder`'s own docs](https://docs.rs/tower/latest/tower/struct.ServiceBuilder.html#order):
+    //! "Layers that are added first will be called with the request first."
     //!
     //! ```text
     //! // Build order vs Execution order:
     //! ServiceBuilder::new()
-    //!     .layer(A)  // Added 1st → Innermost  → Executes LAST  (closest to service)
+    //!     .layer(A)  // Added 1st → Outermost  → Executes FIRST (sees request first)
     //!     .layer(B)  // Added 2nd → Middle     → Executes 2nd
-    //!     .layer(C)  // Added 3rd → Outermost  → Executes FIRST (sees request first)
+    //!     .layer(C)  // Added 3rd → Innermost  → Executes LAST  (closest to service)
     //!     .service(svc)
     //!
-    //! // Execution: Request → C → B → A → Service → A → B → C → Response
+    //! // Execution: Request → A → B → C → Service → C → B → A → Response
     //! ```
     //!
     //! ## Recommended Layer Order
@@ -496,18 +502,20 @@ pub mod ordering {
     //!
     //! ## Client-Side (Outbound) - Correct Order
     //!
-    //! In `ServiceBuilder`, add layers from innermost to outermost:
+    //! In `ServiceBuilder`, add layers from outermost to innermost:
     //!
     //! ```text
     //! ServiceBuilder::new()
-    //!     // Added last → outermost → executes first
+    //!     // Added first → outermost → executes first
     //!     .layer(fallback)           // Catches all errors, provides degraded response
     //!     .layer(cache)              // Skips remaining layers on cache hit
     //!     .layer(total_timeout)      // Bounds entire operation including retries
     //!     // Middle layers
+    //!     .layer(retry)              // Retries individual failures; sees every circuit-breaker
+    //!                                // rejection too (exclude those via `retry_on` -- see
+    //!                                // "Circuit Breaker with Retry" below)
     //!     .layer(circuit_breaker)    // Fails fast if service is down
-    //!     .layer(retry)              // Retries individual failures
-    //!     // Added first → innermost → executes last (closest to service)
+    //!     // Added last → innermost → executes last (closest to service)
     //!     .layer(per_call_timeout)   // Bounds each attempt
     //!     .service(http_client);
     //! ```
@@ -516,10 +524,10 @@ pub mod ordering {
     //!
     //! ```text
     //! ServiceBuilder::new()
-    //!     // Added last → outermost → executes first
+    //!     // Added first → outermost → executes first
     //!     .layer(rate_limiter)       // Reject over-limit requests immediately
     //!     .layer(bulkhead)           // Isolate resources after rate limiting
-    //!     // Added first → innermost → executes last
+    //!     // Added last → innermost → executes last
     //!     .layer(timeout)            // Bound handler execution
     //!     .service(handler);
     //! ```
@@ -551,25 +559,35 @@ pub mod ordering {
     //!
     //! **Circuit Breaker with Retry:**
     //!
-    //! Both orderings are valid with different semantics:
+    //! Both orderings are valid, with different tradeoffs; see [the full
+    //! comparison](https://github.com/joshrotenberg/tower-resilience/blob/main/docs/circuitbreaker-tower-comparison.md#composition-with-retry-budgets)
+    //! for the complete reasoning:
     //!
     //! ```text
-    //! // CB outside retry (recommended for most cases):
-    //! // - Retries happen first, CB only sees final result
-    //! // - CB counts "did all retries fail?" not "did one attempt fail?"
-    //! // - Fewer CB state transitions
-    //! ServiceBuilder::new()
-    //!     .layer(CircuitBreakerLayer::new(cb_config))  // Outer
-    //!     .layer(RetryLayer::new(config))              // Inner
-    //!     .service(svc)
-    //!
-    //! // CB inside retry:
-    //! // - CB can open mid-retry, failing fast on subsequent attempts
-    //! // - More responsive to cascading failures
-    //! // - Each retry attempt is a separate CB call
+    //! // Retry outside CB (recommended default):
+    //! // - Every retry attempt -- including the first -- calls the breaker directly,
+    //! //   so the breaker's sliding window reflects real attempt volume against the
+    //! //   transport, not a smoothed per-request outcome
+    //! // - Pair with `.retry_on(...)` to exclude circuit-open rejections, so a local
+    //! //   rejection doesn't consume a retry-budget token or schedule a backoff sleep
+    //! //   for a call that never left the process
     //! ServiceBuilder::new()
     //!     .layer(RetryLayer::new(config))              // Outer
     //!     .layer(CircuitBreakerLayer::new(cb_config))  // Inner
+    //!     .service(svc)
+    //!
+    //! // CB outside retry:
+    //! // - The breaker only ever sees one call per external request -- Retry's own
+    //! //   internal attempts happen inside `Retry::call`'s future, so the breaker
+    //! //   observes the retry's fully-adjudicated final outcome, not individual
+    //! //   attempts
+    //! // - Appropriate when the retry's entire multi-attempt operation should count
+    //! //   as one unit of health for the breaker, but this does not gate individual
+    //! //   retry attempts on transport health -- choose this deliberately, not by
+    //! //   default
+    //! ServiceBuilder::new()
+    //!     .layer(CircuitBreakerLayer::new(cb_config))  // Outer
+    //!     .layer(RetryLayer::new(config))              // Inner
     //!     .service(svc)
     //! ```
 }
@@ -587,7 +605,7 @@ pub mod anti_patterns {
     //! // Bad: Immediate retries hammer the service
     //! RetryLayer::builder()
     //!     .max_attempts(5)
-    //!     .no_backoff()
+    //!     .fixed_backoff(Duration::ZERO)
     //!     .build()
     //! ```
     //!

--- a/crates/tower-resilience/src/lib.rs
+++ b/crates/tower-resilience/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tower-resilience = { version = "0.9", features = ["circuitbreaker", "bulkhead"] }
+//! tower-resilience = { version = "0.12", features = ["circuitbreaker", "bulkhead"] }
 //! ```
 //!
 //! ```rust,no_run
@@ -152,7 +152,7 @@
 //!
 //! ## Observability
 //!
-//! - **[Metrics](observability::metrics)** - Prometheus metrics for all patterns
+//! - **[Metrics](observability::metrics)** - Prometheus metrics for most patterns
 //! - **[Tracing](observability::tracing_guide)** - Structured logging setup
 //! - **[Events](observability::events)** - Custom event listeners
 //!

--- a/crates/tower-resilience/src/observability.rs
+++ b/crates/tower-resilience/src/observability.rs
@@ -5,13 +5,17 @@
 pub mod metrics {
     //! # Metrics Guide
     //!
-    //! All resilience patterns support optional Prometheus-compatible metrics via the `metrics` feature.
+    //! Most resilience patterns support optional Prometheus-compatible metrics via the
+    //! `metrics` feature; see [Available Metrics by Pattern](#available-metrics-by-pattern)
+    //! below for exactly which patterns currently emit metrics. `adaptive`, `executor`,
+    //! `hedge`, `outlier`, and `reconnect` accept the `metrics` Cargo feature (it compiles
+    //! cleanly) but do not yet emit any metrics of their own.
     //!
     //! ## Enabling Metrics
     //!
     //! ```toml
     //! [dependencies]
-    //! tower-resilience = { version = "0.3", features = ["circuitbreaker", "metrics"] }
+    //! tower-resilience = { version = "0.12", features = ["circuitbreaker", "metrics"] }
     //! metrics = "0.24"
     //! metrics-exporter-prometheus = "0.16"
     //! ```
@@ -79,6 +83,30 @@ pub mod metrics {
     //! - `cache_evictions_total{cache}` - Cache evictions
     //! - `cache_size{cache}` - Current cache size gauge
     //!
+    //! ### Chaos
+    //!
+    //! - `chaos.errors_injected{layer}` - Injected error counter
+    //! - `chaos.latency_injections{layer}` - Injected latency counter
+    //! - `chaos.injected_latency_ms{layer}` - Injected latency histogram
+    //! - `chaos.passed_through{layer}` - Requests passed through unmodified
+    //!
+    //! ### Coalesce
+    //!
+    //! - `coalesce_requests_total{coalesce, role}` - Requests processed, by role
+    //!   (`leader` executed the call, `waiter` joined an in-flight one)
+    //!
+    //! ### Fallback
+    //!
+    //! - `fallback_calls_total{fallback, result, strategy}` - Fallback invocations
+    //!   (`result` is `applied`/`failed`/`success`; `strategy` identifies which
+    //!   [`FallbackStrategy`](https://docs.rs/tower-resilience-fallback/latest/tower_resilience_fallback/enum.FallbackStrategy.html)
+    //!   produced the outcome)
+    //!
+    //! ### Router
+    //!
+    //! - `router_requests_routed_total{router, backend}` - Requests routed, by
+    //!   backend index
+    //!
     //! ## Example Prometheus Queries
     //!
     //! ```promql
@@ -139,7 +167,7 @@ pub mod tracing_guide {
     //!
     //! ```toml
     //! [dependencies]
-    //! tower-resilience = { version = "0.3", features = ["circuitbreaker", "tracing"] }
+    //! tower-resilience = { version = "0.12", features = ["circuitbreaker", "tracing"] }
     //! tracing-subscriber = "0.3"
     //! ```
     //!

--- a/crates/tower-resilience/src/patterns.rs
+++ b/crates/tower-resilience/src/patterns.rs
@@ -639,8 +639,11 @@ pub mod executor {
     //! ❌ **Too many runtimes**: Resource fragmentation
     //! ✅ Use 2-3 runtimes max, sized appropriately
     //!
-    //! ❌ **Blocking in executor**: Starves worker threads
-    //! ✅ Use spawn_blocking for blocking operations
+    //! ❌ **Blocking in a `Handle`-based executor**: `ExecutorLayer::new(handle)`/
+    //! `::current()` spawn on that runtime's ordinary async core workers, so a
+    //! future that blocks without yielding still starves whichever worker runs it
+    //! ✅ Use [`BlockingExecutor`](https://docs.rs/tower-resilience-executor/latest/tower_resilience_executor/struct.BlockingExecutor.html),
+    //! which reserves a thread from Tokio's `spawn_blocking` pool instead
     //!
     //! ## Example
     //!
@@ -687,6 +690,35 @@ pub mod executor {
     //! # }
     //! # }
     //! ```
+    //!
+    //! ## Example: Blocking Work
+    //!
+    //! `ExecutorLayer::new(handle)`/`::current()` spawn on the target runtime's
+    //! ordinary async core workers -- fine for I/O-bound work, but a service that
+    //! calls blocking APIs directly (synchronous file I/O, a blocking database
+    //! driver, CPU-bound work without yield points) still stalls whichever
+    //! worker thread runs it. [`BlockingExecutor`] runs each request on Tokio's
+    //! dedicated `spawn_blocking` pool instead, giving it a real thread-class
+    //! boundary from the rest of the application:
+    //!
+    //! ```rust,no_run
+    //! # #[cfg(feature = "executor")]
+    //! # {
+    //! use tower_resilience::executor::{BlockingExecutor, ExecutorLayer};
+    //! use tower::ServiceBuilder;
+    //!
+    //! # async fn example() {
+    //! # let my_service = tower::service_fn(|_req: ()| async { Ok::<_, std::io::Error>(()) });
+    //! let layer = ExecutorLayer::new(BlockingExecutor::current());
+    //!
+    //! let service = ServiceBuilder::new()
+    //!     .layer(layer)
+    //!     .service(my_service);
+    //! # }
+    //! # }
+    //! ```
+    //!
+    //! [`BlockingExecutor`]: https://docs.rs/tower-resilience-executor/latest/tower_resilience_executor/struct.BlockingExecutor.html
 }
 
 pub mod fallback {
@@ -1623,6 +1655,12 @@ pub mod retry {
     //! ❌ **Retrying 4xx errors**: Client errors won't succeed on retry
     //! ✅ Use retry predicate to only retry 5xx, network errors
     //!
+    //! ❌ **Uncapped total retry volume**: Every caller retrying independently
+    //! amplifies load exactly when a downstream is struggling
+    //! ✅ Attach a `.budget(...)` (token-bucket or AIMD, shared across every
+    //! clone of the layer) so retries are capped in aggregate, not just per
+    //! request -- see [`RetryBudgetBuilder`](https://docs.rs/tower-resilience-retry/latest/tower_resilience_retry/struct.RetryBudgetBuilder.html)
+    //!
     //! ## Example
     //!
     //! ```rust,no_run
@@ -1772,6 +1810,19 @@ pub mod time_limiter {
     //!
     //! ❌ **Same timeout everywhere**: Different operations need different limits
     //! ✅ Configure per-endpoint or per-operation
+    //!
+    //! ## What the timeout covers
+    //!
+    //! The timer starts when `Service::call` is invoked and stops as soon as the
+    //! service future resolves -- for an HTTP client or server that typically means
+    //! response status and headers, not response-body frames produced afterward.
+    //! `cancel_running_future` only controls that service-call future; it does not
+    //! bound how long a streamed body takes to finish. Compose with `tower-http`
+    //! 0.7+'s `RequestBodyTimeoutLayer`/`ResponseBodyTimeoutLayer` (idle detection,
+    //! resets per frame) and `RequestBodyDeadlineLayer`/`ResponseBodyDeadlineLayer`
+    //! (wall-clock cap on total transfer time) to bound body frames independently.
+    //! See the [crate-level docs](https://docs.rs/tower-resilience-timelimiter) for
+    //! the full phase breakdown and a composed example.
     //!
     //! ## Presets
     //!

--- a/examples/composition_outbound.rs
+++ b/examples/composition_outbound.rs
@@ -1,13 +1,22 @@
 //! Outbound client with full resilience stack
 //!
-//! This example demonstrates best practices for composing resilience patterns
-//! in an outbound HTTP/API client. The pattern composition order matters!
+//! This example demonstrates composing resilience patterns in an outbound
+//! HTTP/API client. The pattern composition order matters!
 //!
-//! Recommended client stack (outside to inside):
+//! Client stack used below (outside to inside):
 //! 1. Cache - Try cache first to avoid unnecessary calls
 //! 2. Timeout - Don't wait forever for responses
 //! 3. Circuit Breaker - Fail fast when service is down
 //! 4. Retry - Handle transient failures
+//!
+//! This puts the circuit breaker outside retry (retry innermost), so the
+//! breaker only sees each request's fully-adjudicated final outcome, not
+//! individual retry attempts. `docs/circuitbreaker-tower-comparison.md`'s
+//! "Recommended default ordering" instead recommends retry wrapping the
+//! breaker (breaker innermost) as the default, so every retry attempt counts
+//! toward the breaker's window -- see that doc for the full tradeoff. This
+//! example keeps circuit breaker outside retry because it composes more
+//! simply here; treat it as one valid ordering, not the default recommendation.
 //!
 //! Run with: cargo run --example composition_outbound
 

--- a/examples/executor.rs
+++ b/examples/executor.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use tower::{Service, ServiceBuilder, ServiceExt};
-use tower_resilience_executor::ExecutorLayer;
+use tower_resilience_executor::{BlockingExecutor, ExecutorLayer};
 
 #[derive(Clone)]
 struct ComputeService {
@@ -165,11 +165,46 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // inside `#[tokio::main]`), so use the non-blocking variant instead.
     compute_runtime.shutdown_background();
 
+    println!();
+
+    // Example 4: BlockingExecutor for genuinely blocking work
+    println!("--- BlockingExecutor ---");
+    println!(
+        "ExecutorLayer::new(handle)/::current() spawn on that runtime's ordinary\n\
+         async core workers -- fine for work that yields, but a future that calls\n\
+         a blocking API directly still stalls whichever worker runs it.\n\
+         BlockingExecutor runs each request on Tokio's spawn_blocking pool instead,\n\
+         off the async core workers entirely.\n"
+    );
+
+    let blocking_layer = ExecutorLayer::new(BlockingExecutor::current());
+    let mut blocking_service =
+        ServiceBuilder::new()
+            .layer(blocking_layer)
+            .service(tower::service_fn(|ms: u64| async move {
+                // A real blocking call (not tokio::time::sleep, which yields).
+                // BlockingExecutor already runs this future on a dedicated
+                // blocking-pool OS thread, so blocking it directly is safe and
+                // does not stall the runtime's async core workers.
+                std::thread::sleep(Duration::from_millis(ms));
+                Ok::<_, std::io::Error>(ms)
+            }));
+
+    let start = std::time::Instant::now();
+    let result = blocking_service.ready().await?.call(50).await?;
+    println!(
+        "  Blocked for {}ms on the blocking pool, returned {:?} after {:?}",
+        result,
+        result,
+        start.elapsed()
+    );
+
     println!("\n=== Example Complete ===");
     println!("\nKey takeaways:");
     println!("- ExecutorLayer spawns each request as a separate task");
     println!("- Unlike Buffer, requests are processed in parallel, not serially");
-    println!("- Use a dedicated runtime for CPU-bound or blocking work");
+    println!("- Use a dedicated runtime for isolation from the caller's runtime");
+    println!("- Use BlockingExecutor specifically for blocking or non-yielding CPU work");
     println!("- Combine with Bulkhead for bounded parallelism");
 
     Ok(())

--- a/examples/observability_metrics.rs
+++ b/examples/observability_metrics.rs
@@ -1,9 +1,16 @@
-//! Comprehensive metrics example showing all resilience patterns.
+//! Metrics example covering the patterns with the richest metric coverage.
 //!
 //! This example demonstrates:
-//! - Enabling metrics for all patterns
+//! - Enabling metrics for several resilience patterns
 //! - Instance naming for multi-instance tracking
 //! - How metrics are recorded during operations
+//!
+//! Not every pattern is demonstrated here (this keeps the example short); see
+//! the [full metrics guide](https://docs.rs/tower-resilience/latest/tower_resilience/observability/metrics/)
+//! for the complete list of metric names per pattern, including `chaos`,
+//! `coalesce`, `fallback`, and `router`, which also emit metrics but aren't
+//! demoed below. `adaptive`, `executor`, `hedge`, `outlier`, and `reconnect`
+//! accept the `metrics` feature but do not yet emit metrics of their own.
 //!
 //! Run with:
 //! ```sh
@@ -92,6 +99,15 @@ async fn main() {
     println!("   Cache:");
     println!("     - cache_requests_total{{cache=\"data-cache\",result=\"hit|miss\"}}");
     println!("     - cache_size{{cache=\"data-cache\"}}");
+    println!("\n   Not demonstrated above, but also instrumented (see the metrics guide):");
+    println!("   Chaos:");
+    println!("     - chaos.errors_injected{{layer}}, chaos.latency_injections{{layer}}");
+    println!("   Coalesce:");
+    println!("     - coalesce_requests_total{{coalesce,role=\"leader|waiter\"}}");
+    println!("   Fallback:");
+    println!("     - fallback_calls_total{{fallback,result,strategy}}");
+    println!("   Router:");
+    println!("     - router_requests_routed_total{{router,backend}}");
     println!("\n📊 Example Prometheus Queries:");
     println!("   Failure Rate:");
     println!(


### PR DESCRIPTION
## Summary

Reconciles public-facing docs (README, facade-crate rustdoc, per-crate
rustdoc, and examples) against the verified ground truth already merged to
main: `docs/tower-contract-matrix.md`, `docs/tower-api-surface-audit.md`,
`docs/circuitbreaker-tower-comparison.md`, the truthful executor semantics
from #371/PR #415, the real retry TPS budgets from #370/PR #411, and the
streamed-HTTP timelimiter phases from #403.

## What changed and why

- **Composition Guide ordering bug** (`crates/tower-resilience/src/composition.rs`):
  the "Understanding ServiceBuilder Order" explanation had the direction
  backwards in two places -- it claimed the *first* `.layer()` call becomes
  the *innermost* wrapper, which is the opposite of Tower's own documented
  behavior ("Layers that are added first will be called with the request
  first"). Several downstream examples inherited backwards inline labels.
  Also fixed: the "Circuit Breaker with Retry" section recommended CB-outside-
  retry as the default, directly contradicting
  `circuitbreaker-tower-comparison.md`'s verified "Recommended default
  ordering" (retry wrapping breaker). Reconciled to the verified doc.
- **Two non-existent RetryLayer methods** (`no_backoff`, `max_backoff`)
  referenced in composition.rs examples, replaced with real builder calls
  (`fixed_backoff(Duration::ZERO)`, `ExponentialBackoff::new(...).max_interval(...)`).
- **Executor behavior**: documented `BlockingExecutor` (README, facade
  rustdoc, patterns guide, and a new runnable example section) as the actual
  answer for blocking/CPU-bound work -- `ExecutorLayer::new(handle)`/`::current()`
  only spawn on that runtime's ordinary async core workers and do not
  protect them from a non-yielding blocking call.
- **Retry capabilities**: documented retry budgets (README, patterns guide)
  with a working token-bucket example. The feature existed and is
  contract-tested in `budget.rs`, but was undocumented outside internal
  rustdoc.
- **Metrics coverage**: corrected the "Prometheus metrics on every pattern
  you've enabled" claim (README, facade rustdoc, metrics guide). Five crates
  (`adaptive`, `executor`, `hedge`, `outlier`, `reconnect`) declare the
  `metrics`/`tracing` Cargo features but implement neither -- filed as
  [#428](https://github.com/joshrotenberg/tower-resilience/issues/428) rather
  than expanding this PR. Added the missing Chaos/Coalesce/Fallback/Router
  entries to the metrics guide and `observability_metrics.rs` example, which
  already emit real metrics but weren't documented anywhere.
- **Reconnect**: fixed a stale rustdoc comment referencing
  `tower_resilience_retry` as "not yet available" (it has been for a long
  time).
- **Tower comparisons**: added a composition note to `composition_outbound.rs`
  and the README's Pattern Composition section pointing at
  `circuitbreaker-tower-comparison.md`'s recommended retry/circuit-breaker
  ordering; linked the previously-orphaned `fallback-service-migration.md`
  from the README's Fallback section.
- **Stale versions**: fixed `0.9`/`0.10`/`0.3` version references in README
  and facade rustdoc to `0.12` (current).
- Timeout streaming scope, hedge cancellation, and reconnect's factory model
  were already accurately documented from prior work (#403, hedge's own
  cancellation contract tests, `reconnect-factory-migration.md`) -- verified
  against source, no changes needed there.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test -p tower-resilience --all-features --doc`: 47 passed, 0 failed
- `cargo run --example executor` / `--example observability_metrics`: verified output manually
- Full `cargo test --workspace --all-features` run before marking ready

Closes #380.