### PR TITLE
fix: validate bulkhead/adaptive/outlier configuration at construction time (closes #422)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2628,6 +2628,7 @@ version = "0.12.0"
 dependencies = [
  "metrics",
  "pin-project-lite",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-util",
  "tower",

--- a/benches/comprehensive_benchmarks.rs
+++ b/benches/comprehensive_benchmarks.rs
@@ -259,7 +259,8 @@ fn bench_bulkhead_full(c: &mut Criterion) {
             let config = BulkheadLayer::builder()
                 .max_concurrent_calls(1) // Very limited
                 .max_wait_duration(Duration::from_millis(1)) // Short timeout
-                .build();
+                .build()
+                .unwrap();
 
             let mut service = ServiceBuilder::new().layer(config).service(BaselineService);
 
@@ -482,7 +483,10 @@ fn bench_full_stack_composition(c: &mut Criterion) {
 
     c.bench_function("composition_three_layers", |b| {
         b.to_async(&runtime).iter(|| async {
-            let bh_layer = BulkheadLayer::builder().max_concurrent_calls(100).build();
+            let bh_layer = BulkheadLayer::builder()
+                .max_concurrent_calls(100)
+                .build()
+                .unwrap();
 
             let rl_layer = RateLimiterLayer::builder()
                 .limit_for_period(1000)

--- a/benches/happy_path_overhead.rs
+++ b/benches/happy_path_overhead.rs
@@ -98,7 +98,10 @@ fn bench_bulkhead(c: &mut Criterion) {
 
     c.bench_function("bulkhead_permits_available", |b| {
         b.to_async(&runtime).iter(|| async {
-            let config = BulkheadLayer::builder().max_concurrent_calls(100).build();
+            let config = BulkheadLayer::builder()
+                .max_concurrent_calls(100)
+                .build()
+                .unwrap();
             let mut service = ServiceBuilder::new().layer(config).service(BaselineService);
 
             let response = service
@@ -115,7 +118,8 @@ fn bench_bulkhead(c: &mut Criterion) {
         let layer = BulkheadLayer::builder()
             .max_concurrent_calls(100)
             .backpressure()
-            .build();
+            .build()
+            .unwrap();
 
         b.to_async(&runtime).iter_batched(
             || layer.layer(BaselineService),
@@ -251,7 +255,8 @@ fn bench_adaptive_limiter(c: &mut Criterion) {
                 Aimd::builder()
                     .initial_limit(100)
                     .latency_threshold(Duration::from_secs(1))
-                    .build(),
+                    .build()
+                    .unwrap(),
             );
             let mut service = ServiceBuilder::new().layer(layer).service(BaselineService);
 
@@ -359,7 +364,10 @@ fn bench_composition_simple(c: &mut Criterion) {
                 .failure_rate_threshold(0.5)
                 .build()
                 .unwrap();
-            let bh_config = BulkheadLayer::builder().max_concurrent_calls(100).build();
+            let bh_config = BulkheadLayer::builder()
+                .max_concurrent_calls(100)
+                .build()
+                .unwrap();
 
             let mut service = cb_layer.layer(
                 ServiceBuilder::new()

--- a/crates/tower-resilience-adaptive/Cargo.toml
+++ b/crates/tower-resilience-adaptive/Cargo.toml
@@ -19,6 +19,7 @@ tower-service = { workspace = true }
 tokio = { workspace = true, features = ["sync", "time"] }
 tokio-util.workspace = true
 pin-project-lite = { workspace = true }
+thiserror = { workspace = true }
 
 # Optional dependencies
 tracing = { workspace = true, optional = true }

--- a/crates/tower-resilience-adaptive/src/algorithm.rs
+++ b/crates/tower-resilience-adaptive/src/algorithm.rs
@@ -5,7 +5,7 @@
 
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::time::Duration;
-use tower_resilience_core::aimd::{AimdConfig, AimdController};
+use tower_resilience_core::aimd::{AimdConfig, AimdConfigError, AimdController};
 
 /// Trait for adaptive concurrency control algorithms.
 pub trait ConcurrencyAlgorithm: Send + Sync {
@@ -43,11 +43,16 @@ pub struct Aimd {
 
 impl Aimd {
     /// Create a new AIMD algorithm with the given configuration.
-    pub fn new(config: AimdConfig, latency_threshold: Duration) -> Self {
-        Self {
-            controller: AimdController::new(config).expect("invalid AIMD algorithm configuration"),
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AimdConfigError`] if `config` is invalid (see
+    /// [`AimdConfig::validate`](tower_resilience_core::aimd::AimdConfig::validate)).
+    pub fn new(config: AimdConfig, latency_threshold: Duration) -> Result<Self, AimdConfigError> {
+        Ok(Self {
+            controller: AimdController::new(config)?,
             latency_threshold,
-        }
+        })
     }
 
     /// Create a builder for configuring AIMD.
@@ -151,7 +156,13 @@ impl AimdBuilder {
     }
 
     /// Build the AIMD algorithm.
-    pub fn build(self) -> Aimd {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AimdConfigError`] if the configuration is invalid:
+    /// `min_limit` exceeds `max_limit`, `increase_by` is zero, or
+    /// `decrease_factor` is not finite or not in `[0.0, 1.0)`.
+    pub fn build(self) -> Result<Aimd, AimdConfigError> {
         let config = AimdConfig::new()
             .with_initial_limit(self.initial_limit)
             .with_min_limit(self.min_limit)
@@ -195,14 +206,26 @@ pub struct Vegas {
 
 impl Vegas {
     /// Create a new Vegas algorithm.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VegasConfigError::MinExceedsMax`] if `min_limit` is greater
+    /// than `max_limit`.
     pub fn new(
         initial_limit: usize,
         min_limit: usize,
         max_limit: usize,
         alpha: usize,
         beta: usize,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, VegasConfigError> {
+        if min_limit > max_limit {
+            return Err(VegasConfigError::MinExceedsMax {
+                min_limit,
+                max_limit,
+            });
+        }
+
+        Ok(Self {
             limit: AtomicUsize::new(initial_limit.clamp(min_limit, max_limit)),
             min_limit,
             max_limit,
@@ -213,7 +236,7 @@ impl Vegas {
             smoothed_rtt_nanos: AtomicU64::new(0),
             sample_count: AtomicUsize::new(0),
             min_samples: 10,
-        }
+        })
     }
 
     /// Create a builder for Vegas.
@@ -378,7 +401,12 @@ impl VegasBuilder {
     }
 
     /// Build the Vegas algorithm.
-    pub fn build(self) -> Vegas {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VegasConfigError::MinExceedsMax`] if `min_limit` is greater
+    /// than `max_limit`.
+    pub fn build(self) -> Result<Vegas, VegasConfigError> {
         Vegas::new(
             self.initial_limit,
             self.min_limit,
@@ -387,6 +415,21 @@ impl VegasBuilder {
             self.beta,
         )
     }
+}
+
+/// Errors that can occur when validating a [`Vegas`] configuration at
+/// construction time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum VegasConfigError {
+    /// `min_limit` is greater than `max_limit`.
+    #[error("min_limit ({min_limit}) must not exceed max_limit ({max_limit})")]
+    MinExceedsMax {
+        /// Configured minimum limit.
+        min_limit: usize,
+        /// Configured maximum limit.
+        max_limit: usize,
+    },
 }
 
 /// Algorithm selection enum for the adaptive limiter.
@@ -454,7 +497,8 @@ mod tests {
             .increase_by(2)
             .decrease_factor(0.75)
             .latency_threshold(Duration::from_millis(50))
-            .build();
+            .build()
+            .unwrap();
 
         assert_eq!(aimd.limit(), 20);
         assert_eq!(aimd.min_limit(), 5);
@@ -467,7 +511,8 @@ mod tests {
             .initial_limit(10)
             .increase_by(1)
             .latency_threshold(Duration::from_millis(100))
-            .build();
+            .build()
+            .unwrap();
 
         // Fast request - should increase
         aimd.record_success(Duration::from_millis(50));
@@ -480,7 +525,8 @@ mod tests {
             .initial_limit(10)
             .decrease_factor(0.5)
             .latency_threshold(Duration::from_millis(100))
-            .build();
+            .build()
+            .unwrap();
 
         // Slow request - should decrease
         aimd.record_success(Duration::from_millis(150));
@@ -492,7 +538,8 @@ mod tests {
         let aimd = Aimd::builder()
             .initial_limit(10)
             .decrease_factor(0.5)
-            .build();
+            .build()
+            .unwrap();
 
         aimd.record_failure();
         assert_eq!(aimd.limit(), 5);
@@ -506,7 +553,8 @@ mod tests {
             .max_limit(200)
             .alpha(2)
             .beta(8)
-            .build();
+            .build()
+            .unwrap();
 
         assert_eq!(vegas.limit(), 20);
         assert_eq!(vegas.min_limit(), 5);
@@ -515,7 +563,11 @@ mod tests {
 
     #[test]
     fn test_vegas_failure_decreases() {
-        let vegas = Vegas::builder().initial_limit(20).min_limit(1).build();
+        let vegas = Vegas::builder()
+            .initial_limit(20)
+            .min_limit(1)
+            .build()
+            .unwrap();
 
         vegas.record_failure();
         assert_eq!(vegas.limit(), 10);
@@ -523,7 +575,7 @@ mod tests {
 
     #[test]
     fn test_vegas_min_rtt_tracking() {
-        let vegas = Vegas::builder().initial_limit(10).build();
+        let vegas = Vegas::builder().initial_limit(10).build().unwrap();
 
         vegas.record_success(Duration::from_millis(100));
         vegas.record_success(Duration::from_millis(50));
@@ -536,10 +588,126 @@ mod tests {
 
     #[test]
     fn test_algorithm_enum() {
-        let aimd = Algorithm::Aimd(Aimd::builder().initial_limit(10).build());
+        let aimd = Algorithm::Aimd(Aimd::builder().initial_limit(10).build().unwrap());
         assert_eq!(aimd.limit(), 10);
 
-        let vegas = Algorithm::Vegas(Vegas::builder().initial_limit(20).build());
+        let vegas = Algorithm::Vegas(Vegas::builder().initial_limit(20).build().unwrap());
         assert_eq!(vegas.limit(), 20);
+    }
+}
+
+#[cfg(test)]
+mod config_error_tests {
+    use super::*;
+
+    #[test]
+    fn aimd_min_exceeds_max_is_rejected() {
+        let result = Aimd::builder().min_limit(100).max_limit(10).build();
+        assert_eq!(
+            result.err().unwrap(),
+            AimdConfigError::MinExceedsMax {
+                min_limit: 100,
+                max_limit: 10
+            }
+        );
+    }
+
+    #[test]
+    fn aimd_zero_increase_by_is_rejected() {
+        let result = Aimd::builder().increase_by(0).build();
+        assert_eq!(result.err().unwrap(), AimdConfigError::ZeroIncrease);
+    }
+
+    /// Table-driven: every non-finite or out-of-range decrease factor must be
+    /// rejected with the same typed error.
+    #[test]
+    fn aimd_invalid_decrease_factor_is_rejected() {
+        for factor in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY, -1.0, 1.0, 2.0] {
+            let result = Aimd::builder().decrease_factor(factor).build();
+            assert!(
+                matches!(result, Err(AimdConfigError::InvalidDecreaseFactor(_))),
+                "decrease_factor {factor} should be rejected"
+            );
+        }
+    }
+
+    /// Table-driven: valid decrease factors (including the boundary at 0.0)
+    /// must be accepted.
+    #[test]
+    fn aimd_valid_decrease_factor_is_accepted() {
+        for factor in [0.0, 0.1, 0.5, 0.999] {
+            let result = Aimd::builder().decrease_factor(factor).build();
+            assert!(
+                result.is_ok(),
+                "decrease_factor {factor} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn aimd_valid_config_builds_successfully() {
+        let result = Aimd::builder()
+            .initial_limit(10)
+            .min_limit(1)
+            .max_limit(100)
+            .increase_by(1)
+            .decrease_factor(0.5)
+            .build();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn vegas_min_exceeds_max_is_rejected() {
+        let result = Vegas::builder().min_limit(100).max_limit(10).build();
+        assert_eq!(
+            result.err().unwrap(),
+            VegasConfigError::MinExceedsMax {
+                min_limit: 100,
+                max_limit: 10
+            }
+        );
+    }
+
+    #[test]
+    fn vegas_min_equals_max_is_accepted() {
+        let result = Vegas::builder().min_limit(10).max_limit(10).build();
+        assert!(result.is_ok());
+    }
+
+    /// Table-driven: `min_limit` values at or below `max_limit` must all be
+    /// accepted.
+    #[test]
+    fn vegas_valid_bounds_are_accepted() {
+        for (min, max) in [(1, 100), (10, 10), (0, 1)] {
+            let result = Vegas::builder().min_limit(min).max_limit(max).build();
+            assert!(
+                result.is_ok(),
+                "min_limit {min}, max_limit {max} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn vegas_valid_config_builds_successfully() {
+        let result = Vegas::builder()
+            .initial_limit(10)
+            .min_limit(1)
+            .max_limit(100)
+            .alpha(3)
+            .beta(6)
+            .build();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn vegas_new_rejects_min_exceeds_max_directly() {
+        let result = Vegas::new(10, 100, 10, 3, 6);
+        assert_eq!(
+            result.err().unwrap(),
+            VegasConfigError::MinExceedsMax {
+                min_limit: 100,
+                max_limit: 10
+            }
+        );
     }
 }

--- a/crates/tower-resilience-adaptive/src/layer.rs
+++ b/crates/tower-resilience-adaptive/src/layer.rs
@@ -20,6 +20,7 @@ use tower_layer::Layer;
 ///         .initial_limit(10)
 ///         .latency_threshold(Duration::from_millis(100))
 ///         .build()
+///         .unwrap()
 /// );
 /// ```
 pub struct AdaptiveLimiterLayer<A> {
@@ -127,14 +128,19 @@ mod tests {
         let algorithm = Aimd::builder()
             .initial_limit(10)
             .latency_threshold(Duration::from_millis(100))
-            .build();
+            .build()
+            .unwrap();
         let layer = AdaptiveLimiterLayer::new(algorithm);
         let _ = layer.clone();
     }
 
     #[test]
     fn test_into_layer() {
-        let layer = Aimd::builder().initial_limit(10).build().into_layer();
+        let layer = Aimd::builder()
+            .initial_limit(10)
+            .build()
+            .unwrap()
+            .into_layer();
         let _ = layer.clone();
     }
 }

--- a/crates/tower-resilience-adaptive/src/lib.rs
+++ b/crates/tower-resilience-adaptive/src/lib.rs
@@ -46,7 +46,7 @@
 //!             .min_limit(1)
 //!             .max_limit(100)
 //!             .latency_threshold(Duration::from_millis(100))
-//!             .build()
+//!             .build()?
 //!     ))
 //!     .service(service);
 //!
@@ -68,6 +68,7 @@
 //!         .alpha(3)  // Increase when queue < 3
 //!         .beta(6)   // Decrease when queue > 6
 //!         .build()
+//!         .unwrap()
 //! );
 //! ```
 //!
@@ -102,9 +103,12 @@ mod algorithm;
 mod layer;
 mod service;
 
-pub use algorithm::{Aimd, AimdBuilder, Algorithm, ConcurrencyAlgorithm, Vegas, VegasBuilder};
+pub use algorithm::{
+    Aimd, AimdBuilder, Algorithm, ConcurrencyAlgorithm, Vegas, VegasBuilder, VegasConfigError,
+};
 pub use layer::{AdaptiveLimiterLayer, AdaptiveLimiterLayerBuilder, IntoLayer};
 pub use service::{AdaptiveError, AdaptiveFuture, AdaptiveService};
+pub use tower_resilience_core::aimd::AimdConfigError;
 
 #[cfg(test)]
 mod tests {
@@ -123,7 +127,8 @@ mod tests {
                 Aimd::builder()
                     .initial_limit(10)
                     .latency_threshold(Duration::from_secs(1))
-                    .build(),
+                    .build()
+                    .unwrap(),
             ))
             .service(service);
 
@@ -142,7 +147,8 @@ mod tests {
             .initial_limit(10)
             .increase_by(1)
             .latency_threshold(Duration::from_secs(1))
-            .build();
+            .build()
+            .unwrap();
 
         let initial_limit = algorithm.limit();
         let algorithm = Arc::new(algorithm);
@@ -178,7 +184,8 @@ mod tests {
             .initial_limit(20)
             .decrease_factor(0.5)
             .latency_threshold(Duration::from_secs(1))
-            .build();
+            .build()
+            .unwrap();
 
         let algorithm = Arc::new(algorithm);
         let mut service = AdaptiveService::new(service, Arc::clone(&algorithm));
@@ -203,7 +210,7 @@ mod tests {
 
         let mut service = ServiceBuilder::new()
             .layer(AdaptiveLimiterLayer::new(
-                Vegas::builder().initial_limit(10).build(),
+                Vegas::builder().initial_limit(10).build().unwrap(),
             ))
             .service(service);
 
@@ -223,7 +230,8 @@ mod tests {
                 Aimd::builder()
                     .initial_limit(5)
                     .latency_threshold(Duration::from_secs(1))
-                    .build(),
+                    .build()
+                    .unwrap(),
             ))
             .service(service);
 
@@ -247,7 +255,7 @@ mod tests {
         let service = tower::service_fn(|req: i32| async move { Ok::<_, &str>(req) });
 
         // Test with Algorithm enum
-        let algorithm = Algorithm::Aimd(Aimd::builder().initial_limit(10).build());
+        let algorithm = Algorithm::Aimd(Aimd::builder().initial_limit(10).build().unwrap());
 
         let mut service = ServiceBuilder::new()
             .layer(AdaptiveLimiterLayer::new(algorithm))

--- a/crates/tower-resilience-adaptive/src/service.rs
+++ b/crates/tower-resilience-adaptive/src/service.rs
@@ -318,7 +318,7 @@ mod tests {
     #[test]
     fn accessors_expose_the_inner_service() {
         let service = tower::service_fn(|req: i32| async move { Ok::<_, &str>(req * 2) });
-        let algorithm = Aimd::builder().initial_limit(10).build();
+        let algorithm = Aimd::builder().initial_limit(10).build().unwrap();
         let mut service = AdaptiveService::new(service, Arc::new(algorithm));
 
         // No `into_inner`: see the comment on the accessor impl block.
@@ -333,7 +333,8 @@ mod tests {
         let algorithm = Aimd::builder()
             .initial_limit(10)
             .latency_threshold(Duration::from_secs(1))
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = AdaptiveService::new(service, Arc::new(algorithm));
 
@@ -349,7 +350,7 @@ mod tests {
             Ok::<_, &str>(())
         });
 
-        let algorithm = Aimd::builder().initial_limit(10).build();
+        let algorithm = Aimd::builder().initial_limit(10).build().unwrap();
         let service = AdaptiveService::new(service, Arc::new(algorithm));
 
         assert_eq!(service.in_flight(), 0);

--- a/crates/tower-resilience-adaptive/tests/contract.rs
+++ b/crates/tower-resilience-adaptive/tests/contract.rs
@@ -75,7 +75,8 @@ async fn adaptive_drives_readied_instance() {
         Aimd::builder()
             .initial_limit(8)
             .latency_threshold(Duration::from_secs(1))
-            .build(),
+            .build()
+            .unwrap(),
     );
     let mut svc = tower::ServiceBuilder::new()
         .layer(layer)
@@ -93,7 +94,8 @@ async fn adaptive_composes_with_concurrency_limit() {
         Aimd::builder()
             .initial_limit(8)
             .latency_threshold(Duration::from_secs(1))
-            .build(),
+            .build()
+            .unwrap(),
     );
     let mut svc = tower::ServiceBuilder::new().layer(layer).service(inner);
 
@@ -111,7 +113,8 @@ async fn adaptive_reserves_capacity_across_clones() {
         .initial_limit(2)
         .min_limit(2)
         .max_limit(2)
-        .build();
+        .build()
+        .unwrap();
     let service = AdaptiveService::new(inner, Arc::new(algorithm));
 
     let mut tasks = Vec::new();

--- a/crates/tower-resilience-bulkhead/examples/bulkhead_advanced.rs
+++ b/crates/tower-resilience-bulkhead/examples/bulkhead_advanced.rs
@@ -55,7 +55,8 @@ async fn main() {
             fail.fetch_add(1, Ordering::SeqCst);
             println!("  ⚠ Call failed ({:?})", duration);
         })
-        .build();
+        .build()
+        .unwrap();
 
     // Create a service that simulates work
     let service = tower::service_fn(|req: (usize, Duration, bool)| async move {

--- a/crates/tower-resilience-bulkhead/examples/bulkhead_basic.rs
+++ b/crates/tower-resilience-bulkhead/examples/bulkhead_basic.rs
@@ -16,7 +16,8 @@ async fn main() {
     let config = BulkheadLayer::builder()
         .max_concurrent_calls(5)
         .name("api-bulkhead")
-        .build();
+        .build()
+        .unwrap();
 
     // Create a simple service
     let service = tower::service_fn(|req: String| async move {

--- a/crates/tower-resilience-bulkhead/src/config.rs
+++ b/crates/tower-resilience-bulkhead/src/config.rs
@@ -60,7 +60,8 @@ impl BulkheadConfigBuilder {
     /// let layer = BulkheadLayer::builder()
     ///     .max_concurrent_calls(10)
     ///     .max_wait_duration(Duration::from_secs(5))
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn max_wait_duration(mut self, duration: Duration) -> Self {
         self.max_wait_duration = Some(duration);
@@ -85,7 +86,8 @@ impl BulkheadConfigBuilder {
     /// let layer = BulkheadLayer::builder()
     ///     .max_concurrent_calls(100)
     ///     .reject_when_full()
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     ///
     /// This addresses the use case described in [tower-rs/tower#793](https://github.com/tower-rs/tower/issues/793),
@@ -120,7 +122,8 @@ impl BulkheadConfigBuilder {
     /// let layer = BulkheadLayer::builder()
     ///     .max_concurrent_calls(10)
     ///     .backpressure()
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn backpressure(mut self) -> Self {
         self.backpressure = true;
@@ -157,7 +160,8 @@ impl BulkheadConfigBuilder {
     ///             println!("Warning: approaching capacity!");
     ///         }
     ///     })
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn on_call_permitted<F>(mut self, f: F) -> Self
     where
@@ -200,7 +204,8 @@ impl BulkheadConfigBuilder {
     ///         println!("Call rejected - bulkhead at capacity ({} max), total rejections: {}",
     ///                  max_capacity, count + 1);
     ///     })
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn on_call_rejected<F>(mut self, f: F) -> Self
     where
@@ -241,7 +246,8 @@ impl BulkheadConfigBuilder {
     ///             println!("Warning: slow call detected");
     ///         }
     ///     })
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn on_call_finished<F>(mut self, f: F) -> Self
     where
@@ -281,7 +287,8 @@ impl BulkheadConfigBuilder {
     ///         let count = counter.fetch_add(1, Ordering::SeqCst);
     ///         println!("Call failed after {:?} (total failures: {})", duration, count + 1);
     ///     })
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn on_call_failed<F>(mut self, f: F) -> Self
     where
@@ -296,15 +303,26 @@ impl BulkheadConfigBuilder {
     }
 
     /// Builds the configuration and returns a BulkheadLayer.
-    pub fn build(self) -> crate::layer::BulkheadLayer {
-        let config = self.into_config();
-        crate::layer::BulkheadLayer::new(config)
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BulkheadConfigError::ZeroMaxConcurrentCalls`] if
+    /// `max_concurrent_calls` is zero -- a semaphore with zero permits could
+    /// never admit a call.
+    pub fn build(self) -> Result<crate::layer::BulkheadLayer, BulkheadConfigError> {
+        let config = self.into_config()?;
+        Ok(crate::layer::BulkheadLayer::new(config))
     }
 
     /// Builds the configuration, returning both a layer and an observable handle.
     ///
     /// All services produced by the returned layer share the same semaphore,
     /// and the handle can observe concurrency state from outside the service.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BulkheadConfigError`] under the same conditions as
+    /// [`build`](Self::build).
     ///
     /// # Example
     ///
@@ -313,13 +331,17 @@ impl BulkheadConfigBuilder {
     ///
     /// let (layer, handle) = BulkheadLayer::builder()
     ///     .max_concurrent_calls(10)
-    ///     .build_with_handle();
+    ///     .build_with_handle()
+    ///     .unwrap();
     ///
     /// assert_eq!(handle.max_concurrent(), 10);
     /// assert_eq!(handle.active_calls(), 0);
     /// ```
-    pub fn build_with_handle(self) -> (crate::layer::BulkheadLayer, crate::handle::BulkheadHandle) {
-        let config = self.into_config();
+    pub fn build_with_handle(
+        self,
+    ) -> Result<(crate::layer::BulkheadLayer, crate::handle::BulkheadHandle), BulkheadConfigError>
+    {
+        let config = self.into_config()?;
         let config = std::sync::Arc::new(config);
         let semaphore =
             std::sync::Arc::new(tokio::sync::Semaphore::new(config.max_concurrent_calls));
@@ -334,22 +356,85 @@ impl BulkheadConfigBuilder {
             shared: Some((semaphore, config)),
         };
 
-        (layer, handle)
+        Ok((layer, handle))
     }
 
-    fn into_config(self) -> BulkheadConfig {
-        BulkheadConfig {
+    fn into_config(self) -> Result<BulkheadConfig, BulkheadConfigError> {
+        if self.max_concurrent_calls == 0 {
+            return Err(BulkheadConfigError::ZeroMaxConcurrentCalls);
+        }
+
+        Ok(BulkheadConfig {
             max_concurrent_calls: self.max_concurrent_calls,
             max_wait_duration: self.max_wait_duration,
             backpressure: self.backpressure,
             name: self.name,
             event_listeners: self.event_listeners,
-        }
+        })
     }
 }
 
 impl Default for BulkheadConfigBuilder {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Errors that can occur when validating a [`BulkheadConfig`] at
+/// construction time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum BulkheadConfigError {
+    /// `max_concurrent_calls` is zero, which would create a semaphore with
+    /// no permits that could never admit any call.
+    #[error("max_concurrent_calls must be greater than zero")]
+    ZeroMaxConcurrentCalls,
+}
+
+#[cfg(test)]
+mod config_error_tests {
+    use super::*;
+    use crate::layer::BulkheadLayer;
+
+    #[test]
+    fn zero_max_concurrent_calls_is_rejected() {
+        let result = BulkheadLayer::builder().max_concurrent_calls(0).build();
+        assert_eq!(
+            result.err().unwrap(),
+            BulkheadConfigError::ZeroMaxConcurrentCalls
+        );
+    }
+
+    /// Table-driven: the smallest valid value and a handful of larger ones
+    /// must all be accepted.
+    #[test]
+    fn nonzero_max_concurrent_calls_is_accepted() {
+        for max in [1, 2, 10, 1000] {
+            let result = BulkheadLayer::builder().max_concurrent_calls(max).build();
+            assert!(
+                result.is_ok(),
+                "max_concurrent_calls {max} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn zero_max_concurrent_calls_is_rejected_with_handle() {
+        let result = BulkheadLayer::builder()
+            .max_concurrent_calls(0)
+            .build_with_handle();
+        assert_eq!(
+            result.err().unwrap(),
+            BulkheadConfigError::ZeroMaxConcurrentCalls
+        );
+    }
+
+    #[test]
+    fn valid_config_builds_successfully() {
+        let result = BulkheadLayer::builder()
+            .max_concurrent_calls(25)
+            .name("test-bulkhead")
+            .build();
+        assert!(result.is_ok());
     }
 }

--- a/crates/tower-resilience-bulkhead/src/handle.rs
+++ b/crates/tower-resilience-bulkhead/src/handle.rs
@@ -18,7 +18,8 @@ use tokio::sync::Semaphore;
 ///
 /// let (layer, handle) = BulkheadLayer::builder()
 ///     .max_concurrent_calls(10)
-///     .build_with_handle();
+///     .build_with_handle()
+///     .unwrap();
 ///
 /// // Apply the layer to a service...
 ///
@@ -97,7 +98,8 @@ mod tests {
     async fn test_handle_initial_state() {
         let (_layer, handle) = BulkheadLayer::builder()
             .max_concurrent_calls(10)
-            .build_with_handle();
+            .build_with_handle()
+            .unwrap();
 
         assert_eq!(handle.active_calls(), 0);
         assert_eq!(handle.max_concurrent(), 10);
@@ -109,7 +111,8 @@ mod tests {
     async fn test_handle_observes_active_calls() {
         let (layer, handle) = BulkheadLayer::builder()
             .max_concurrent_calls(5)
-            .build_with_handle();
+            .build_with_handle()
+            .unwrap();
 
         let mut svc = layer.layer(SlowService);
 
@@ -130,7 +133,8 @@ mod tests {
     async fn test_handle_shared_across_services() {
         let (layer, handle) = BulkheadLayer::builder()
             .max_concurrent_calls(10)
-            .build_with_handle();
+            .build_with_handle()
+            .unwrap();
 
         let mut svc1 = layer.layer(SlowService);
         let mut svc2 = layer.layer(SlowService);
@@ -151,7 +155,8 @@ mod tests {
     async fn test_handle_clone() {
         let (_layer, handle) = BulkheadLayer::builder()
             .max_concurrent_calls(10)
-            .build_with_handle();
+            .build_with_handle()
+            .unwrap();
 
         let handle2 = handle.clone();
         assert_eq!(handle.active_calls(), handle2.active_calls());

--- a/crates/tower-resilience-bulkhead/src/layer.rs
+++ b/crates/tower-resilience-bulkhead/src/layer.rs
@@ -42,7 +42,8 @@ impl BulkheadLayer {
     /// let layer = BulkheadLayer::builder()
     ///     .max_concurrent_calls(10)
     ///     .max_wait_duration(Duration::from_secs(5))
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn builder() -> crate::BulkheadConfigBuilder {
         #[cfg(feature = "metrics")]
@@ -99,12 +100,13 @@ impl BulkheadLayer {
     /// ```
     /// use tower_resilience_bulkhead::BulkheadLayer;
     ///
-    /// let layer = BulkheadLayer::small().build();
+    /// let layer = BulkheadLayer::small().build().unwrap();
     ///
     /// // Or customize further
     /// let layer = BulkheadLayer::small()
     ///     .max_wait_duration(std::time::Duration::from_secs(5))
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn small() -> crate::BulkheadConfigBuilder {
         Self::builder().max_concurrent_calls(10).reject_when_full()
@@ -123,7 +125,7 @@ impl BulkheadLayer {
     /// ```
     /// use tower_resilience_bulkhead::BulkheadLayer;
     ///
-    /// let layer = BulkheadLayer::medium().build();
+    /// let layer = BulkheadLayer::medium().build().unwrap();
     /// ```
     pub fn medium() -> crate::BulkheadConfigBuilder {
         Self::builder().max_concurrent_calls(50).reject_when_full()
@@ -143,7 +145,7 @@ impl BulkheadLayer {
     /// ```
     /// use tower_resilience_bulkhead::BulkheadLayer;
     ///
-    /// let layer = BulkheadLayer::large().build();
+    /// let layer = BulkheadLayer::large().build().unwrap();
     /// ```
     pub fn large() -> crate::BulkheadConfigBuilder {
         Self::builder().max_concurrent_calls(200).reject_when_full()

--- a/crates/tower-resilience-bulkhead/src/lib.rs
+++ b/crates/tower-resilience-bulkhead/src/lib.rs
@@ -16,7 +16,7 @@
 //! let layer = BulkheadLayer::builder()
 //!     .max_concurrent_calls(10)
 //!     .name("my-bulkhead")
-//!     .build();
+//!     .build().unwrap();
 //!
 //! let service = ServiceBuilder::new()
 //!     .layer(layer)
@@ -46,7 +46,7 @@
 //!         BulkheadLayer::builder()
 //!             .max_concurrent_calls(10)
 //!             .backpressure()
-//!             .build(),
+//!             .build().unwrap(),
 //!     )
 //!     .service_fn(|request: String| async move { Ok::<_, ()>(request) });
 //! ```
@@ -68,7 +68,7 @@
 //! let layer = BulkheadLayer::builder()
 //!     .max_concurrent_calls(100)
 //!     .reject_when_full()
-//!     .build();
+//!     .build().unwrap();
 //!
 //! let service = ServiceBuilder::new()
 //!     .layer(layer)
@@ -92,7 +92,7 @@
 //!     .max_concurrent_calls(5)
 //!     .max_wait_duration(Duration::from_secs(2))
 //!     .name("timeout-bulkhead")
-//!     .build();
+//!     .build().unwrap();
 //!
 //! let service = ServiceBuilder::new()
 //!     .layer(layer)
@@ -127,7 +127,7 @@
 //!     .on_call_finished(|duration| {
 //!         println!("Call finished in {:?}", duration);
 //!     })
-//!     .build();
+//!     .build().unwrap();
 //! # }
 //! ```
 //!
@@ -147,7 +147,7 @@
 //! let layer = BulkheadLayer::builder()
 //!     .max_concurrent_calls(5)
 //!     .max_wait_duration(Duration::from_millis(100))
-//!     .build();
+//!     .build()?;
 //!
 //! let service = ServiceBuilder::new()
 //!     .layer(layer)
@@ -189,7 +189,7 @@
 //! let layer = BulkheadLayer::builder()
 //!     .max_concurrent_calls(10)
 //!     .max_wait_duration(Duration::from_millis(50))
-//!     .build();
+//!     .build()?;
 //!
 //! let service = ServiceBuilder::new()
 //!     .layer(layer)
@@ -227,7 +227,7 @@
 //! let layer = BulkheadLayer::builder()
 //!     .max_concurrent_calls(5)
 //!     .max_wait_duration(Duration::from_millis(10))
-//!     .build();
+//!     .build()?;
 //!
 //! let service = ServiceBuilder::new()
 //!     .layer(layer)
@@ -264,7 +264,7 @@
 //!     .on_call_rejected(move |_| {
 //!         r.fetch_add(1, Ordering::SeqCst);
 //!     })
-//!     .build();
+//!     .build().unwrap();
 //!
 //! let service = ServiceBuilder::new()
 //!     .layer(layer)
@@ -289,7 +289,7 @@ pub mod layer;
 /// Tower `Service` implementation for the bulkhead.
 pub mod service;
 
-pub use config::{BulkheadConfig, BulkheadConfigBuilder};
+pub use config::{BulkheadConfig, BulkheadConfigBuilder, BulkheadConfigError};
 pub use error::{BulkheadError, BulkheadServiceError, Result};
 pub use events::BulkheadEvent;
 pub use handle::BulkheadHandle;
@@ -306,7 +306,7 @@ mod tests {
 
     #[test]
     fn test_config_builder_defaults() {
-        let _config = BulkheadLayer::builder().build();
+        let _config = BulkheadLayer::builder().build().unwrap();
         // Layer is built, so we can't inspect config directly
         // This test just ensures the builder works
     }
@@ -323,7 +323,8 @@ mod tests {
             .on_call_permitted(move |_| {
                 c.fetch_add(1, Ordering::SeqCst);
             })
-            .build();
+            .build()
+            .unwrap();
 
         // Builder accepts all parameters without panic
     }
@@ -382,17 +383,17 @@ mod tests {
 
     #[test]
     fn test_preset_small() {
-        let _layer = BulkheadLayer::small().build();
+        let _layer = BulkheadLayer::small().build().unwrap();
     }
 
     #[test]
     fn test_preset_medium() {
-        let _layer = BulkheadLayer::medium().build();
+        let _layer = BulkheadLayer::medium().build().unwrap();
     }
 
     #[test]
     fn test_preset_large() {
-        let _layer = BulkheadLayer::large().build();
+        let _layer = BulkheadLayer::large().build().unwrap();
     }
 
     #[test]
@@ -401,7 +402,8 @@ mod tests {
         let _layer = BulkheadLayer::small()
             .max_wait_duration(Duration::from_secs(5))
             .name("custom")
-            .build();
+            .build()
+            .unwrap();
     }
 
     #[tokio::test]
@@ -420,7 +422,8 @@ mod tests {
         let layer = BulkheadLayer::builder()
             .max_concurrent_calls(5)
             .backpressure()
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = tower::ServiceBuilder::new().layer(layer).service(service);
 
@@ -447,7 +450,8 @@ mod tests {
         let layer = BulkheadLayer::builder()
             .max_concurrent_calls(1)
             .backpressure()
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = tower::ServiceBuilder::new().layer(layer).service(service);
 
@@ -480,7 +484,8 @@ mod tests {
         let layer = BulkheadLayer::builder()
             .max_concurrent_calls(1)
             .backpressure()
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = tower::ServiceBuilder::new().layer(layer).service(service);
 
@@ -513,7 +518,8 @@ mod tests {
             .on_call_rejected(move |_| {
                 rc.fetch_add(1, Ordering::SeqCst);
             })
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = tower::ServiceBuilder::new().layer(layer).service(service);
 

--- a/crates/tower-resilience-bulkhead/src/service.rs
+++ b/crates/tower-resilience-bulkhead/src/service.rs
@@ -385,7 +385,10 @@ mod tests {
 
     #[test]
     fn accessors_expose_the_inner_service() {
-        let layer = BulkheadLayer::builder().max_concurrent_calls(1).build();
+        let layer = BulkheadLayer::builder()
+            .max_concurrent_calls(1)
+            .build()
+            .unwrap();
         let mut bulkhead = layer.layer(service_fn(|()| async { Ok::<_, Infallible>(()) }));
 
         let _: &_ = bulkhead.get_ref();
@@ -400,7 +403,8 @@ mod tests {
         let layer = BulkheadLayer::builder()
             .max_concurrent_calls(1)
             .backpressure()
-            .build();
+            .build()
+            .unwrap();
         let mut service = layer.layer(service_fn(move |()| {
             observed.fetch_add(1, Ordering::SeqCst);
             async { Ok::<_, Infallible>(()) }
@@ -419,7 +423,8 @@ mod tests {
         let (layer, handle) = BulkheadLayer::builder()
             .max_concurrent_calls(1)
             .backpressure()
-            .build_with_handle();
+            .build_with_handle()
+            .unwrap();
         let mut service = layer.layer(service_fn(|()| async { Ok::<_, Infallible>(()) }));
         handle.semaphore.close();
 
@@ -438,7 +443,8 @@ mod tests {
         let (layer, handle) = BulkheadLayer::builder()
             .max_concurrent_calls(1)
             .backpressure()
-            .build_with_handle();
+            .build_with_handle()
+            .unwrap();
         let mut service = layer.layer(ReadinessError);
 
         let error = match service.ready().await {
@@ -457,7 +463,8 @@ mod tests {
         let (layer, handle) = BulkheadLayer::builder()
             .max_concurrent_calls(1)
             .backpressure()
-            .build_with_handle();
+            .build_with_handle()
+            .unwrap();
         let service = layer.layer(service_fn(|()| async { Ok::<_, Infallible>(()) }));
         let mut reserved = service.clone();
         let mut waiter = service.clone();
@@ -485,7 +492,8 @@ mod tests {
         let layer = BulkheadLayer::builder()
             .max_concurrent_calls(1)
             .backpressure()
-            .build();
+            .build()
+            .unwrap();
         let service = layer.layer(service_fn(|()| async { Ok::<_, Infallible>(()) }));
         let mut reserved = service.clone();
         let mut next = service.clone();
@@ -509,7 +517,8 @@ mod tests {
         let (layer, handle) = BulkheadLayer::builder()
             .max_concurrent_calls(1)
             .backpressure()
-            .build_with_handle();
+            .build_with_handle()
+            .unwrap();
         let service = layer.layer(service_fn(|()| pending::<Result<(), Infallible>>()));
         let mut first = service.clone();
         let mut second = service.clone();

--- a/crates/tower-resilience-bulkhead/tests/contract.rs
+++ b/crates/tower-resilience-bulkhead/tests/contract.rs
@@ -19,7 +19,8 @@ async fn bulkhead_rejection_drives_readied_instance() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(4)
         .reject_when_full()
-        .build();
+        .build()
+        .unwrap();
     let mut svc = tower::ServiceBuilder::new()
         .layer(layer)
         .service(StatefulInner::new());
@@ -34,7 +35,8 @@ async fn bulkhead_backpressure_drives_readied_instance() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(4)
         .backpressure()
-        .build();
+        .build()
+        .unwrap();
     let mut svc = tower::ServiceBuilder::new()
         .layer(layer)
         .service(StatefulInner::new());
@@ -55,7 +57,8 @@ async fn bulkhead_rejection_composes_with_concurrency_limit() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(4)
         .reject_when_full()
-        .build();
+        .build()
+        .unwrap();
     let mut svc = tower::ServiceBuilder::new().layer(layer).service(inner);
 
     for _ in 0..3 {
@@ -69,7 +72,8 @@ async fn bulkhead_backpressure_composes_with_concurrency_limit() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(4)
         .backpressure()
-        .build();
+        .build()
+        .unwrap();
     let mut svc = tower::ServiceBuilder::new().layer(layer).service(inner);
 
     for _ in 0..3 {

--- a/crates/tower-resilience-outlier/src/config.rs
+++ b/crates/tower-resilience-outlier/src/config.rs
@@ -59,7 +59,8 @@ impl OutlierDetectionConfigBuilder<DefaultClassifier> {
     ///             Err(e) => e.kind() == std::io::ErrorKind::ConnectionRefused,
     ///         }
     ///     })
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn failure_classifier<F>(self, f: F) -> OutlierDetectionConfigBuilder<FnClassifier<F>> {
         OutlierDetectionConfigBuilder {
@@ -165,7 +166,8 @@ impl<C> OutlierDetectionConfigBuilder<C> {
     ///     .detector(detector)
     ///     .instance_name("backend-1")
     ///     .failure_classifier_type(RedisFailureClassifier)
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn failure_classifier_type<C2>(self, classifier: C2) -> OutlierDetectionConfigBuilder<C2> {
         OutlierDetectionConfigBuilder {
@@ -178,25 +180,63 @@ impl<C> OutlierDetectionConfigBuilder<C> {
 
     /// Builds the `OutlierDetectionLayer`.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if no detector was provided.
-    pub fn build(self) -> OutlierDetectionLayer<C> {
+    /// Returns [`OutlierDetectionConfigError::MissingDetector`] if no
+    /// detector was provided.
+    pub fn build(self) -> Result<OutlierDetectionLayer<C>, OutlierDetectionConfigError> {
         let detector = self
             .detector
-            .expect("OutlierDetectionConfigBuilder requires a detector");
+            .ok_or(OutlierDetectionConfigError::MissingDetector)?;
         let config = OutlierDetectionConfig {
             detector,
             instance_name: self.instance_name,
             classifier: self.classifier,
             backpressure: self.backpressure,
         };
-        OutlierDetectionLayer::new(config)
+        Ok(OutlierDetectionLayer::new(config))
     }
 }
 
 impl Default for OutlierDetectionConfigBuilder<DefaultClassifier> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Errors that can occur when validating an [`OutlierDetectionConfig`] at
+/// construction time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum OutlierDetectionConfigError {
+    /// No [`OutlierDetector`] was provided via
+    /// [`OutlierDetectionConfigBuilder::detector`].
+    #[error("OutlierDetectionConfigBuilder requires a detector")]
+    MissingDetector,
+}
+
+#[cfg(test)]
+mod config_error_tests {
+    use super::*;
+
+    #[test]
+    fn missing_detector_is_rejected() {
+        let result = OutlierDetectionLayer::builder().build();
+        assert_eq!(
+            result.err().unwrap(),
+            OutlierDetectionConfigError::MissingDetector
+        );
+    }
+
+    #[test]
+    fn detector_present_builds_successfully() {
+        let detector = OutlierDetector::new();
+        detector.register("backend-1", 5);
+
+        let result = OutlierDetectionLayer::builder()
+            .detector(detector)
+            .instance_name("backend-1")
+            .build();
+        assert!(result.is_ok());
     }
 }

--- a/crates/tower-resilience-outlier/src/layer.rs
+++ b/crates/tower-resilience-outlier/src/layer.rs
@@ -25,7 +25,8 @@ use tower_resilience_core::classifier::DefaultClassifier;
 /// let layer = OutlierDetectionLayer::builder()
 ///     .detector(detector)
 ///     .instance_name("backend-1")
-///     .build();
+///     .build()
+///     .unwrap();
 ///
 /// let service = ServiceBuilder::new()
 ///     .layer(layer)

--- a/crates/tower-resilience-outlier/src/lib.rs
+++ b/crates/tower-resilience-outlier/src/lib.rs
@@ -30,12 +30,14 @@
 //! let layer1 = OutlierDetectionLayer::builder()
 //!     .detector(detector.clone())
 //!     .instance_name("backend-1")
-//!     .build();
+//!     .build()
+//!     .unwrap();
 //!
 //! let layer2 = OutlierDetectionLayer::builder()
 //!     .detector(detector.clone())
 //!     .instance_name("backend-2")
-//!     .build();
+//!     .build()
+//!     .unwrap();
 //!
 //! // Apply to services
 //! let svc1 = ServiceBuilder::new()
@@ -57,7 +59,8 @@
 //!     .detector(detector)
 //!     .instance_name("backend-1")
 //!     .error_on_ejection()
-//!     .build();
+//!     .build()
+//!     .unwrap();
 //! ```
 
 /// Configuration types for outlier detection.
@@ -75,7 +78,9 @@ pub mod service;
 /// Ejection strategies (e.g., consecutive errors).
 pub mod strategy;
 
-pub use config::{OutlierDetectionConfig, OutlierDetectionConfigBuilder};
+pub use config::{
+    OutlierDetectionConfig, OutlierDetectionConfigBuilder, OutlierDetectionConfigError,
+};
 pub use detector::OutlierDetector;
 pub use error::{OutlierDetectionError, OutlierDetectionServiceError};
 pub use events::OutlierDetectionEvent;

--- a/crates/tower-resilience-outlier/src/service.rs
+++ b/crates/tower-resilience-outlier/src/service.rs
@@ -154,7 +154,7 @@ mod tests {
         if !backpressure {
             builder = builder.error_on_ejection();
         }
-        let layer = builder.build();
+        let layer = builder.build().unwrap();
         tower::Layer::layer(&layer, boxed)
     }
 
@@ -197,7 +197,8 @@ mod tests {
             .detector(detector.clone())
             .instance_name("backend-1")
             .error_on_ejection()
-            .build();
+            .build()
+            .unwrap();
         let mut svc = tower::Layer::layer(&layer, boxed);
 
         // First call fails (inner error) and triggers ejection
@@ -250,7 +251,8 @@ mod tests {
             .instance_name("backend-1")
             .error_on_ejection()
             .failure_classifier_type(RedisFailureClassifier)
-            .build();
+            .build()
+            .unwrap();
         let mut svc = tower::Layer::layer(&layer, boxed);
 
         // First call fails (inner error) and triggers ejection.

--- a/crates/tower-resilience-outlier/tests/contract.rs
+++ b/crates/tower-resilience-outlier/tests/contract.rs
@@ -15,7 +15,8 @@ async fn outlier_drives_readied_instance() {
     let layer = OutlierDetectionLayer::builder()
         .detector(detector)
         .instance_name("inner")
-        .build();
+        .build()
+        .unwrap();
     let mut svc = tower::ServiceBuilder::new()
         .layer(layer)
         .service(StatefulInner::new());
@@ -34,7 +35,8 @@ async fn outlier_composes_with_concurrency_limit() {
     let layer = OutlierDetectionLayer::builder()
         .detector(detector)
         .instance_name("inner")
-        .build();
+        .build()
+        .unwrap();
     let mut svc = tower::ServiceBuilder::new().layer(layer).service(inner);
 
     for _ in 0..3 {

--- a/crates/tower-resilience/examples/combined.rs
+++ b/crates/tower-resilience/examples/combined.rs
@@ -80,7 +80,8 @@ async fn main() {
         .on_call_rejected(move |_| {
             bulkhead_clone.fetch_add(1, Ordering::SeqCst);
         })
-        .build();
+        .build()
+        .expect("valid bulkhead config");
 
     let service = bulkhead_layer.layer(service);
 

--- a/crates/tower-resilience/src/lib.rs
+++ b/crates/tower-resilience/src/lib.rs
@@ -27,7 +27,8 @@
 //!     .layer(circuit_breaker)
 //!     .layer(BulkheadLayer::builder()
 //!         .max_concurrent_calls(10)
-//!         .build())
+//!         .build()
+//!         .unwrap())
 //!     .service(my_service);
 //! # }
 //! ```

--- a/crates/tower-resilience/src/patterns.rs
+++ b/crates/tower-resilience/src/patterns.rs
@@ -131,6 +131,7 @@ pub mod adaptive {
     //!         .decrease_factor(0.5)
     //!         .latency_threshold(Duration::from_millis(100))
     //!         .build()
+    //!         .unwrap()
     //! );
     //!
     //! let service = ServiceBuilder::new()
@@ -158,6 +159,7 @@ pub mod adaptive {
     //!         .alpha(3)   // Increase when queue < 3
     //!         .beta(6)    // Decrease when queue > 6
     //!         .build()
+    //!         .unwrap()
     //! );
     //!
     //! let service = ServiceBuilder::new()
@@ -246,7 +248,8 @@ pub mod bulkhead {
     //!     .on_call_rejected(|max| {
     //!         eprintln!("Bulkhead exhausted (max: {})", max);
     //!     })
-    //!     .build();
+    //!     .build()
+    //!     .unwrap();
     //!
     //! let service = tower::ServiceBuilder::new()
     //!     .layer(bulkhead)
@@ -1406,7 +1409,8 @@ pub mod outlier_detection {
     //! let layer = OutlierDetectionLayer::builder()
     //!     .detector(detector.clone())
     //!     .instance_name("backend-1")
-    //!     .build();
+    //!     .build()
+    //!     .unwrap();
     //!
     //! let service = ServiceBuilder::new()
     //!     .layer(layer)

--- a/examples/adaptive.rs
+++ b/examples/adaptive.rs
@@ -65,7 +65,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .increase_by(1)
             .decrease_factor(0.5)
             .latency_threshold(Duration::from_millis(50))
-            .build(),
+            .build()
+            .unwrap(),
     );
 
     let mut aimd_service = ServiceBuilder::new()
@@ -105,7 +106,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .max_limit(50)
             .alpha(2) // Increase when queue < 2
             .beta(4) // Decrease when queue > 4
-            .build(),
+            .build()
+            .unwrap(),
     );
 
     let mut vegas_service = ServiceBuilder::new()
@@ -143,7 +145,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .min_limit(1)
             .max_limit(20)
             .latency_threshold(Duration::from_millis(100))
-            .build(),
+            .build()
+            .unwrap(),
     );
 
     let service = ServiceBuilder::new()

--- a/examples/observability_metrics.rs
+++ b/examples/observability_metrics.rs
@@ -253,6 +253,7 @@ async fn demo_bulkhead() {
         .max_concurrent_calls(2)
         .max_wait_duration(Duration::from_millis(100))
         .build()
+        .unwrap()
         .layer(base_service);
 
     // Make concurrent calls

--- a/examples/outlier.rs
+++ b/examples/outlier.rs
@@ -46,7 +46,8 @@ async fn main() {
         .detector(detector.clone())
         .instance_name("backend-1")
         .error_on_ejection()
-        .build();
+        .build()
+        .unwrap();
 
     let ok_svc = tower::util::BoxCloneService::new(tower::service_fn(|req: String| async move {
         Ok::<_, std::io::Error>(format!("OK: {}", req))
@@ -64,7 +65,8 @@ async fn main() {
         .detector(detector.clone())
         .instance_name("backend-2")
         .error_on_ejection()
-        .build();
+        .build()
+        .unwrap();
 
     let fail_svc =
         tower::util::BoxCloneService::new(tower::service_fn(|_req: String| async move {

--- a/examples/server_api.rs
+++ b/examples/server_api.rs
@@ -195,7 +195,8 @@ async fn scenario_bulkhead() {
                 max
             );
         })
-        .build();
+        .build()
+        .unwrap();
 
     let service = bulkhead.layer(base_service);
 
@@ -258,7 +259,8 @@ async fn scenario_full_server_stack() {
                 .on_call_rejected(|max| {
                     println!("[Bulkhead] Call rejected (max: {})", max);
                 })
-                .build(),
+                .build()
+                .unwrap(),
         )
         .service_fn(move |req: Request| {
             let count = request_count.fetch_add(1, Ordering::SeqCst) + 1;

--- a/examples/tonic-resilient-greeter/src/server.rs
+++ b/examples/tonic-resilient-greeter/src/server.rs
@@ -68,7 +68,8 @@ fn build_pipeline() -> GreetPipeline {
                 active
             )
         })
-        .build();
+        .build()
+        .expect("valid bulkhead config");
 
     let ratelimiter_layer = RateLimiterLayer::builder()
         .name("greeter-ratelimiter")

--- a/tests/adaptive/algorithms.rs
+++ b/tests/adaptive/algorithms.rs
@@ -19,7 +19,8 @@ async fn test_aimd_limit_increases_on_fast_responses() {
         .initial_limit(10)
         .increase_by(1)
         .latency_threshold(Duration::from_secs(1))
-        .build();
+        .build()
+        .unwrap();
 
     let _initial_limit = algorithm.limit();
 
@@ -57,7 +58,8 @@ async fn test_aimd_limit_decreases_on_errors() {
                 .initial_limit(20)
                 .decrease_factor(0.5)
                 .latency_threshold(Duration::from_secs(1))
-                .build(),
+                .build()
+                .unwrap(),
         ))
         .service(service);
 
@@ -92,7 +94,8 @@ async fn test_aimd_respects_min_limit() {
                 .min_limit(2)
                 .decrease_factor(0.5)
                 .latency_threshold(Duration::from_secs(1))
-                .build(),
+                .build()
+                .unwrap(),
         ))
         .service(service);
 
@@ -119,7 +122,8 @@ async fn test_aimd_respects_max_limit() {
                 .max_limit(10)
                 .increase_by(5)
                 .latency_threshold(Duration::from_secs(10))
-                .build(),
+                .build()
+                .unwrap(),
         ))
         .service(service);
 
@@ -143,7 +147,12 @@ async fn test_vegas_basic_operation() {
 
     let mut service = ServiceBuilder::new()
         .layer(AdaptiveLimiterLayer::new(
-            Vegas::builder().initial_limit(10).alpha(3).beta(6).build(),
+            Vegas::builder()
+                .initial_limit(10)
+                .alpha(3)
+                .beta(6)
+                .build()
+                .unwrap(),
         ))
         .service(service);
 
@@ -170,7 +179,8 @@ async fn test_vegas_with_custom_parameters() {
                 .max_limit(20)
                 .alpha(2)
                 .beta(4)
-                .build(),
+                .build()
+                .unwrap(),
         ))
         .service(service);
 
@@ -187,7 +197,8 @@ async fn test_algorithm_enum_aimd() {
         Aimd::builder()
             .initial_limit(10)
             .latency_threshold(Duration::from_secs(1))
-            .build(),
+            .build()
+            .unwrap(),
     );
 
     let mut service = ServiceBuilder::new()
@@ -202,7 +213,7 @@ async fn test_algorithm_enum_aimd() {
 async fn test_algorithm_enum_vegas() {
     let service = tower::service_fn(|req: i32| async move { Ok::<_, &str>(req) });
 
-    let algorithm = Algorithm::Vegas(Vegas::builder().initial_limit(10).build());
+    let algorithm = Algorithm::Vegas(Vegas::builder().initial_limit(10).build().unwrap());
 
     let mut service = ServiceBuilder::new()
         .layer(AdaptiveLimiterLayer::new(algorithm))
@@ -226,7 +237,8 @@ async fn test_aimd_slow_response_decreases_limit() {
                 .initial_limit(10)
                 .latency_threshold(Duration::from_millis(50))
                 .decrease_factor(0.9)
-                .build(),
+                .build()
+                .unwrap(),
         ))
         .service(service);
 

--- a/tests/adaptive/concurrency.rs
+++ b/tests/adaptive/concurrency.rs
@@ -25,7 +25,8 @@ async fn test_concurrent_requests_within_limit() {
             Aimd::builder()
                 .initial_limit(20)
                 .latency_threshold(Duration::from_secs(1))
-                .build(),
+                .build()
+                .unwrap(),
         ))
         .service(service);
 
@@ -65,7 +66,8 @@ async fn test_concurrent_requests_exceeding_limit() {
             Aimd::builder()
                 .initial_limit(5)
                 .latency_threshold(Duration::from_secs(1))
-                .build(),
+                .build()
+                .unwrap(),
         ))
         .service(service);
 
@@ -106,7 +108,7 @@ async fn test_vegas_concurrent_requests() {
 
     let service = ServiceBuilder::new()
         .layer(AdaptiveLimiterLayer::new(
-            Vegas::builder().initial_limit(10).build(),
+            Vegas::builder().initial_limit(10).build().unwrap(),
         ))
         .service(service);
 
@@ -149,7 +151,8 @@ async fn test_concurrent_mixed_success_and_failure() {
             Aimd::builder()
                 .initial_limit(10)
                 .latency_threshold(Duration::from_secs(1))
-                .build(),
+                .build()
+                .unwrap(),
         ))
         .service(service);
 
@@ -196,7 +199,8 @@ async fn test_high_concurrency_stress() {
                 .initial_limit(50)
                 .max_limit(100)
                 .latency_threshold(Duration::from_secs(1))
-                .build(),
+                .build()
+                .unwrap(),
         ))
         .service(service);
 
@@ -237,7 +241,8 @@ async fn test_limit_adapts_under_varying_load() {
             Aimd::builder()
                 .initial_limit(10)
                 .latency_threshold(Duration::from_millis(50))
-                .build(),
+                .build()
+                .unwrap(),
         ))
         .service(service);
 

--- a/tests/adaptive/integration.rs
+++ b/tests/adaptive/integration.rs
@@ -24,7 +24,8 @@ async fn test_basic_request_passes_through() {
             Aimd::builder()
                 .initial_limit(10)
                 .latency_threshold(Duration::from_secs(1))
-                .build(),
+                .build()
+                .unwrap(),
         ))
         .service(service);
 
@@ -58,7 +59,8 @@ async fn test_multiple_sequential_requests() {
             Aimd::builder()
                 .initial_limit(10)
                 .latency_threshold(Duration::from_secs(1))
-                .build(),
+                .build()
+                .unwrap(),
         ))
         .service(service);
 
@@ -79,7 +81,8 @@ async fn test_error_propagates() {
             Aimd::builder()
                 .initial_limit(10)
                 .latency_threshold(Duration::from_secs(1))
-                .build(),
+                .build()
+                .unwrap(),
         ))
         .service(service);
 
@@ -106,7 +109,8 @@ async fn test_service_clone() {
             Aimd::builder()
                 .initial_limit(10)
                 .latency_threshold(Duration::from_secs(1))
-                .build(),
+                .build()
+                .unwrap(),
         ))
         .service(service);
 
@@ -139,7 +143,7 @@ async fn test_with_vegas_algorithm() {
 
     let mut service = ServiceBuilder::new()
         .layer(AdaptiveLimiterLayer::new(
-            Vegas::builder().initial_limit(10).build(),
+            Vegas::builder().initial_limit(10).build().unwrap(),
         ))
         .service(service);
 
@@ -159,7 +163,8 @@ async fn test_layer_builder() {
             .increase_by(2)
             .decrease_factor(0.75)
             .latency_threshold(Duration::from_millis(500))
-            .build(),
+            .build()
+            .unwrap(),
     );
 
     let mut service = layer.layer(service);

--- a/tests/auto_traits.rs
+++ b/tests/auto_traits.rs
@@ -45,6 +45,7 @@ fn bulkhead_is_send_sync() {
     let svc = BulkheadLayer::builder()
         .max_concurrent_calls(2)
         .build()
+        .unwrap()
         .layer(SyncInner);
     assert_send_sync_static(&svc);
 }
@@ -56,6 +57,7 @@ fn bulkhead_backpressure_is_send_sync() {
         .max_concurrent_calls(2)
         .backpressure()
         .build()
+        .unwrap()
         .layer(SyncInner);
     assert_send_sync_static(&svc);
 }
@@ -117,7 +119,8 @@ fn adaptive_is_send_sync() {
         Aimd::builder()
             .initial_limit(8)
             .latency_threshold(Duration::from_secs(1))
-            .build(),
+            .build()
+            .unwrap(),
     )
     .layer(SyncInner);
     assert_send_sync_static(&svc);
@@ -201,6 +204,7 @@ fn outlier_is_send_sync() {
         .detector(detector)
         .instance_name("inner")
         .build()
+        .unwrap()
         .layer(SyncInner);
     assert_send_sync_static(&svc);
 }
@@ -253,6 +257,7 @@ async fn bulkhead_composes_under_arc_like_tonic() {
         .max_concurrent_calls(2)
         .backpressure()
         .build()
+        .unwrap()
         .layer(SyncInner);
 
     // The shape tonic generates: Arc<MyService>, where MyService holds the

--- a/tests/bulkhead/concurrency.rs
+++ b/tests/bulkhead/concurrency.rs
@@ -23,7 +23,8 @@ async fn high_concurrency_stress_test() {
         .layer(
             BulkheadLayer::builder()
                 .max_concurrent_calls(max_allowed)
-                .build(),
+                .build()
+                .unwrap(),
         )
         .service_fn(move |_req: ()| {
             let counter = Arc::clone(&counter_clone);
@@ -72,7 +73,8 @@ async fn concurrent_requests_respect_limit() {
         .layer(
             BulkheadLayer::builder()
                 .max_concurrent_calls(max_allowed)
-                .build(),
+                .build()
+                .unwrap(),
         )
         .service_fn(move |_req: ()| {
             let counter = Arc::clone(&counter_clone);
@@ -114,7 +116,8 @@ async fn rejection_under_load_with_timeout() {
             BulkheadLayer::builder()
                 .max_concurrent_calls(2)
                 .max_wait_duration(Duration::from_millis(10))
-                .build(),
+                .build()
+                .unwrap(),
         )
         .service_fn(|_req: ()| async {
             sleep(Duration::from_millis(200)).await;
@@ -155,7 +158,12 @@ async fn single_permit_bulkhead_serializes_requests() {
     let max_clone = Arc::clone(&max_concurrent);
 
     let service = ServiceBuilder::new()
-        .layer(BulkheadLayer::builder().max_concurrent_calls(1).build())
+        .layer(
+            BulkheadLayer::builder()
+                .max_concurrent_calls(1)
+                .build()
+                .unwrap(),
+        )
         .service_fn(move |_req: ()| {
             let counter = Arc::clone(&counter_clone);
             let max = Arc::clone(&max_clone);
@@ -193,7 +201,12 @@ async fn mixed_fast_and_slow_requests() {
     let slow_clone = Arc::clone(&slow_count);
 
     let service = ServiceBuilder::new()
-        .layer(BulkheadLayer::builder().max_concurrent_calls(5).build())
+        .layer(
+            BulkheadLayer::builder()
+                .max_concurrent_calls(5)
+                .build()
+                .unwrap(),
+        )
         .service_fn(move |req: bool| {
             let fast = Arc::clone(&fast_clone);
             let slow = Arc::clone(&slow_clone);
@@ -244,7 +257,12 @@ async fn burst_traffic_pattern() {
     let conc_clone = Arc::clone(&concurrent);
 
     let service = ServiceBuilder::new()
-        .layer(BulkheadLayer::builder().max_concurrent_calls(5).build())
+        .layer(
+            BulkheadLayer::builder()
+                .max_concurrent_calls(5)
+                .build()
+                .unwrap(),
+        )
         .service_fn(move |_req: ()| {
             let proc = Arc::clone(&proc_clone);
             let max = Arc::clone(&max_clone);
@@ -283,7 +301,12 @@ async fn burst_traffic_pattern() {
 #[tokio::test]
 async fn concurrent_with_varied_delays() {
     let service = ServiceBuilder::new()
-        .layer(BulkheadLayer::builder().max_concurrent_calls(10).build())
+        .layer(
+            BulkheadLayer::builder()
+                .max_concurrent_calls(10)
+                .build()
+                .unwrap(),
+        )
         .service_fn(|delay_ms: u64| async move {
             sleep(Duration::from_millis(delay_ms)).await;
             Ok::<_, TestError>(delay_ms)
@@ -310,22 +333,18 @@ async fn concurrent_with_varied_delays() {
     }
 }
 
+/// `max_concurrent_calls(0)` used to silently build a permit-less semaphore
+/// that could never admit a call (an eternal-timeout footgun). It's now
+/// rejected at construction time with a typed error instead.
 #[tokio::test]
-async fn zero_concurrent_immediately_rejects() {
-    let service = ServiceBuilder::new()
-        .layer(
-            BulkheadLayer::builder()
-                .max_concurrent_calls(0)
-                .max_wait_duration(Duration::from_millis(10))
-                .build(),
-        )
-        .service_fn(|_req: ()| async { Ok::<_, TestError>(()) });
+async fn zero_concurrent_calls_is_rejected_at_construction() {
+    let result = BulkheadLayer::builder()
+        .max_concurrent_calls(0)
+        .max_wait_duration(Duration::from_millis(10))
+        .build();
 
-    let mut svc = service.clone();
-    let result = svc.ready().await.unwrap().call(()).await;
-
-    assert!(matches!(
-        result,
-        Err(BulkheadServiceError::Bulkhead(BulkheadError::Timeout))
-    ));
+    assert_eq!(
+        result.err().unwrap(),
+        tower_resilience_bulkhead::BulkheadConfigError::ZeroMaxConcurrentCalls
+    );
 }

--- a/tests/bulkhead/config.rs
+++ b/tests/bulkhead/config.rs
@@ -13,7 +13,8 @@ async fn test_max_concurrent_calls_one() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(1)
         .name("single-call-bulkhead")
-        .build();
+        .build()
+        .unwrap();
 
     let service = ServiceBuilder::new()
         .layer(layer)
@@ -63,7 +64,8 @@ async fn test_max_concurrent_calls_large_value() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(large_limit)
         .name("large-bulkhead")
-        .build();
+        .build()
+        .unwrap();
 
     let service = ServiceBuilder::new()
         .layer(layer)
@@ -93,36 +95,27 @@ async fn test_max_concurrent_calls_large_value() {
     }
 }
 
+/// `max_concurrent_calls(0)` used to build a bulkhead whose every call timed
+/// out immediately (a permit-less semaphore). It's now rejected at
+/// construction time with a typed error instead.
 #[tokio::test]
-async fn test_max_concurrent_calls_zero() {
-    // Zero concurrent calls means all calls should be rejected immediately
-    let layer = BulkheadLayer::builder()
+async fn test_max_concurrent_calls_zero_is_rejected_at_construction() {
+    let result = BulkheadLayer::builder()
         .max_concurrent_calls(0)
         .max_wait_duration(Duration::from_millis(10))
         .name("zero-capacity-bulkhead")
         .build();
 
-    let mut service = ServiceBuilder::new()
-        .layer(layer)
-        .service_fn(|_req: String| async move { Ok::<_, TestError>("ok".to_string()) });
-
-    // Any call should timeout immediately
-    let result = service
-        .ready()
-        .await
-        .unwrap()
-        .call("request".to_string())
-        .await;
-    assert!(matches!(
-        result,
-        Err(BulkheadServiceError::Bulkhead(BulkheadError::Timeout))
-    ));
+    assert_eq!(
+        result.err().unwrap(),
+        tower_resilience_bulkhead::BulkheadConfigError::ZeroMaxConcurrentCalls
+    );
 }
 
 #[tokio::test]
 async fn test_default_config() {
     // Test that default config works
-    let layer = BulkheadLayer::builder().build();
+    let layer = BulkheadLayer::builder().build().unwrap();
 
     let mut service = ServiceBuilder::new()
         .layer(layer)
@@ -154,7 +147,8 @@ async fn test_config_with_event_listeners() {
         .on_call_finished(move |_| {
             f.fetch_add(1, Ordering::SeqCst);
         })
-        .build();
+        .build()
+        .unwrap();
 
     let service = ServiceBuilder::new()
         .layer(layer)
@@ -196,7 +190,8 @@ async fn test_config_with_multiple_event_listeners() {
         .on_call_permitted(move |_| {
             c2.fetch_add(10, Ordering::SeqCst);
         })
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = ServiceBuilder::new()
         .layer(layer)
@@ -221,13 +216,15 @@ async fn test_config_timeout_some_vs_none() {
         .max_concurrent_calls(1)
         .max_wait_duration(Duration::from_millis(50))
         .name("timeout-some")
-        .build();
+        .build()
+        .unwrap();
 
     // Config with no timeout (default: wait indefinitely)
     let layer_none = BulkheadLayer::builder()
         .max_concurrent_calls(1)
         .name("timeout-none")
-        .build();
+        .build()
+        .unwrap();
 
     let service_some =
         ServiceBuilder::new()
@@ -286,7 +283,8 @@ async fn test_builder_pattern_chaining() {
         .on_call_rejected(|_| {})
         .on_call_finished(|_| {})
         .on_call_failed(|_| {})
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = ServiceBuilder::new()
         .layer(layer)
@@ -308,12 +306,14 @@ async fn test_config_independent_instances() {
     let layer1 = BulkheadLayer::builder()
         .max_concurrent_calls(1)
         .name("bulkhead-1")
-        .build();
+        .build()
+        .unwrap();
 
     let layer2 = BulkheadLayer::builder()
         .max_concurrent_calls(1)
         .name("bulkhead-2")
-        .build();
+        .build()
+        .unwrap();
 
     let service1 = ServiceBuilder::new()
         .layer(layer1)
@@ -360,7 +360,8 @@ async fn test_config_name_normal() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(5)
         .name("my-service-bulkhead")
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = ServiceBuilder::new()
         .layer(layer)
@@ -380,7 +381,8 @@ async fn test_config_name_empty() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(5)
         .name("")
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = ServiceBuilder::new()
         .layer(layer)
@@ -401,7 +403,8 @@ async fn test_config_name_very_long() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(5)
         .name(long_name)
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = ServiceBuilder::new()
         .layer(layer)
@@ -444,7 +447,8 @@ async fn test_config_with_all_options() {
         .on_call_failed(move |_| {
             fail.fetch_add(1, Ordering::SeqCst);
         })
-        .build();
+        .build()
+        .unwrap();
 
     let service = ServiceBuilder::new()
         .layer(layer)
@@ -496,7 +500,8 @@ async fn test_config_different_timeouts() {
             .max_concurrent_calls(5)
             .max_wait_duration(*timeout)
             .name(format!("bulkhead-{}", idx))
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = ServiceBuilder::new()
             .layer(layer)

--- a/tests/bulkhead/integration.rs
+++ b/tests/bulkhead/integration.rs
@@ -22,7 +22,12 @@ async fn test_bulkhead_limits_concurrency() {
     let max_clone = Arc::clone(&max_concurrent);
 
     let service = ServiceBuilder::new()
-        .layer(BulkheadLayer::builder().max_concurrent_calls(5).build())
+        .layer(
+            BulkheadLayer::builder()
+                .max_concurrent_calls(5)
+                .build()
+                .unwrap(),
+        )
         .service_fn(move |_req: ()| {
             let counter = Arc::clone(&counter_clone);
             let max = Arc::clone(&max_clone);
@@ -59,7 +64,8 @@ async fn test_bulkhead_rejects_when_full_with_timeout() {
             BulkheadLayer::builder()
                 .max_concurrent_calls(2)
                 .max_wait_duration(Duration::from_millis(10))
-                .build(),
+                .build()
+                .unwrap(),
         )
         .service_fn(|_req: ()| async {
             sleep(Duration::from_millis(100)).await;
@@ -106,7 +112,8 @@ async fn test_bulkhead_event_listeners() {
                 .on_call_finished(move |_| {
                     f_clone.fetch_add(1, Ordering::SeqCst);
                 })
-                .build(),
+                .build()
+                .unwrap(),
         )
         .service_fn(|_req: ()| async { Ok::<_, TestError>(()) });
 
@@ -132,7 +139,12 @@ async fn test_bulkhead_releases_on_error() {
     let counter_clone = Arc::clone(&concurrent_counter);
 
     let service = ServiceBuilder::new()
-        .layer(BulkheadLayer::builder().max_concurrent_calls(2).build())
+        .layer(
+            BulkheadLayer::builder()
+                .max_concurrent_calls(2)
+                .build()
+                .unwrap(),
+        )
         .service_fn(move |_req: ()| {
             let counter = Arc::clone(&counter_clone);
             async move {
@@ -171,7 +183,8 @@ async fn test_bulkhead_without_timeout_waits() {
             BulkheadLayer::builder()
                 .max_concurrent_calls(1)
                 // Default: wait indefinitely
-                .build(),
+                .build()
+                .unwrap(),
         )
         .service_fn(|_req: ()| async {
             sleep(Duration::from_millis(50)).await;

--- a/tests/bulkhead/permits.rs
+++ b/tests/bulkhead/permits.rs
@@ -21,7 +21,8 @@ async fn test_permits_released_after_success() {
         .on_call_permitted(move |_| {
             p.fetch_add(1, Ordering::SeqCst);
         })
-        .build();
+        .build()
+        .unwrap();
 
     let service = ServiceBuilder::new()
         .layer(layer)
@@ -69,7 +70,8 @@ async fn test_permits_released_after_error() {
         .on_call_failed(move |_| {
             f.fetch_add(1, Ordering::SeqCst);
         })
-        .build();
+        .build()
+        .unwrap();
 
     let call_count = Arc::new(AtomicUsize::new(0));
     let c = call_count.clone();
@@ -110,7 +112,8 @@ async fn test_permits_released_after_panic() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(1)
         .name("permit-panic-bulkhead")
-        .build();
+        .build()
+        .unwrap();
 
     let panic_count = Arc::new(AtomicUsize::new(0));
     let c = panic_count.clone();
@@ -157,7 +160,8 @@ async fn test_permit_reuse() {
         .on_call_permitted(move |_| {
             p.fetch_add(1, Ordering::SeqCst);
         })
-        .build();
+        .build()
+        .unwrap();
 
     let service = ServiceBuilder::new()
         .layer(layer)
@@ -199,7 +203,8 @@ async fn test_permits_not_leaked_on_timeout() {
         .on_call_rejected(move |_| {
             r.fetch_add(1, Ordering::SeqCst);
         })
-        .build();
+        .build()
+        .unwrap();
 
     let service = ServiceBuilder::new()
         .layer(layer)
@@ -246,7 +251,8 @@ async fn test_rapid_permit_acquisition_release() {
         .on_call_permitted(move |_| {
             p.fetch_add(1, Ordering::SeqCst);
         })
-        .build();
+        .build()
+        .unwrap();
 
     let service = ServiceBuilder::new()
         .layer(layer)
@@ -281,7 +287,8 @@ async fn test_permit_fifo_fairness() {
         .on_call_permitted(move |_| {
             // This doesn't help us track order, so we'll track in the service
         })
-        .build();
+        .build()
+        .unwrap();
 
     let order_for_service = order.clone();
     let service = ServiceBuilder::new()
@@ -343,7 +350,8 @@ async fn test_concurrent_permit_requests() {
         .on_call_finished(move |_| {
             f.fetch_add(1, Ordering::SeqCst);
         })
-        .build();
+        .build()
+        .unwrap();
 
     let service = ServiceBuilder::new()
         .layer(layer)
@@ -397,7 +405,8 @@ async fn test_permits_with_mixed_outcomes() {
         .on_call_failed(move |_| {
             fail.fetch_add(1, Ordering::SeqCst);
         })
-        .build();
+        .build()
+        .unwrap();
 
     let call_count = Arc::new(AtomicUsize::new(0));
     let c = call_count.clone();
@@ -438,7 +447,8 @@ async fn test_starvation_prevention() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(2)
         .name("starvation-prevention-bulkhead")
-        .build();
+        .build()
+        .unwrap();
 
     let service = ServiceBuilder::new()
         .layer(layer)

--- a/tests/bulkhead/timeout.rs
+++ b/tests/bulkhead/timeout.rs
@@ -14,7 +14,8 @@ async fn test_zero_timeout() {
         .max_concurrent_calls(1)
         .max_wait_duration(Duration::ZERO)
         .name("zero-timeout-bulkhead")
-        .build();
+        .build()
+        .unwrap();
 
     let service = ServiceBuilder::new()
         .layer(layer)
@@ -64,7 +65,8 @@ async fn test_very_short_timeout() {
         .max_concurrent_calls(1)
         .max_wait_duration(Duration::from_millis(1))
         .name("short-timeout-bulkhead")
-        .build();
+        .build()
+        .unwrap();
 
     let service = ServiceBuilder::new()
         .layer(layer)
@@ -121,7 +123,8 @@ async fn test_long_timeout() {
         .max_concurrent_calls(1)
         .max_wait_duration(Duration::from_secs(5))
         .name("long-timeout-bulkhead")
-        .build();
+        .build()
+        .unwrap();
 
     let service = ServiceBuilder::new()
         .layer(layer)
@@ -171,7 +174,8 @@ async fn test_no_timeout_none() {
         .max_concurrent_calls(1)
         // Default: wait indefinitely (no timeout)
         .name("no-timeout-bulkhead")
-        .build();
+        .build()
+        .unwrap();
 
     let service = ServiceBuilder::new()
         .layer(layer)
@@ -218,7 +222,8 @@ async fn test_timeout_precision() {
         .max_concurrent_calls(1)
         .max_wait_duration(timeout_duration)
         .name("precision-timeout-bulkhead")
-        .build();
+        .build()
+        .unwrap();
 
     let service = ServiceBuilder::new()
         .layer(layer)
@@ -277,7 +282,8 @@ async fn test_multiple_timeouts() {
         .on_call_rejected(move |_| {
             r.fetch_add(1, Ordering::SeqCst);
         })
-        .build();
+        .build()
+        .unwrap();
 
     let service = ServiceBuilder::new()
         .layer(layer)
@@ -330,7 +336,8 @@ async fn test_timeout_then_success() {
         .max_concurrent_calls(1)
         .max_wait_duration(Duration::from_millis(50))
         .name("timeout-success-bulkhead")
-        .build();
+        .build()
+        .unwrap();
 
     let service = ServiceBuilder::new()
         .layer(layer)
@@ -391,7 +398,8 @@ async fn test_concurrent_timeouts() {
         .max_concurrent_calls(2)
         .max_wait_duration(Duration::from_millis(50))
         .name("concurrent-timeout-bulkhead")
-        .build();
+        .build()
+        .unwrap();
 
     let service = ServiceBuilder::new()
         .layer(layer)
@@ -444,7 +452,8 @@ async fn test_timeout_boundary_conditions() {
         .max_concurrent_calls(1)
         .max_wait_duration(Duration::from_secs(120))
         .name("boundary-timeout-bulkhead")
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = ServiceBuilder::new()
         .layer(layer)
@@ -470,13 +479,15 @@ async fn test_changing_timeout_behavior() {
         .max_concurrent_calls(1)
         .max_wait_duration(Duration::from_millis(10))
         .name("short-timeout")
-        .build();
+        .build()
+        .unwrap();
 
     let long_timeout = BulkheadLayer::builder()
         .max_concurrent_calls(1)
         .max_wait_duration(Duration::from_millis(200))
         .name("long-timeout")
-        .build();
+        .build()
+        .unwrap();
 
     let service_short =
         ServiceBuilder::new()

--- a/tests/clone_in_call_contract.rs
+++ b/tests/clone_in_call_contract.rs
@@ -35,7 +35,8 @@ async fn bulkhead_rejection_drives_readied_instance() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(4)
         .reject_when_full()
-        .build();
+        .build()
+        .unwrap();
     let mut svc = tower::ServiceBuilder::new()
         .layer(layer)
         .service(StatefulInner::new());
@@ -52,7 +53,8 @@ async fn bulkhead_backpressure_drives_readied_instance() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(4)
         .backpressure()
-        .build();
+        .build()
+        .unwrap();
     let mut svc = tower::ServiceBuilder::new()
         .layer(layer)
         .service(StatefulInner::new());
@@ -203,7 +205,8 @@ async fn outlier_drives_readied_instance() {
     let layer = OutlierDetectionLayer::builder()
         .detector(detector)
         .instance_name("inner")
-        .build();
+        .build()
+        .unwrap();
     let mut svc = tower::ServiceBuilder::new()
         .layer(layer)
         .service(StatefulInner::new());
@@ -221,7 +224,8 @@ async fn adaptive_drives_readied_instance() {
         Aimd::builder()
             .initial_limit(8)
             .latency_threshold(Duration::from_secs(1))
-            .build(),
+            .build()
+            .unwrap(),
     );
     let mut svc = tower::ServiceBuilder::new()
         .layer(layer)

--- a/tests/composition_stacks/database.rs
+++ b/tests/composition_stacks/database.rs
@@ -68,7 +68,8 @@ fn mock_db_client() -> impl Service<Query, Response = QueryResult, Error = DbErr
 async fn standard_database_stack_compiles() {
     let bulkhead = BulkheadLayer::builder()
         .max_concurrent_calls(20) // Match connection pool size
-        .build();
+        .build()
+        .unwrap();
 
     let retry = RetryLayer::<Query, QueryResult, DbError>::builder()
         .max_attempts(2)
@@ -90,7 +91,10 @@ async fn standard_database_stack_compiles() {
 /// Database stack with circuit breaker (for replicas)
 #[tokio::test]
 async fn database_with_circuit_breaker_compiles() {
-    let bulkhead = BulkheadLayer::builder().max_concurrent_calls(20).build();
+    let bulkhead = BulkheadLayer::builder()
+        .max_concurrent_calls(20)
+        .build()
+        .unwrap();
 
     let circuit_breaker = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)

--- a/tests/composition_stacks/message_queues.rs
+++ b/tests/composition_stacks/message_queues.rs
@@ -105,7 +105,10 @@ async fn consumer_stack_compiles() {
 /// Producer stack: Timeout + Retry + Bulkhead
 #[tokio::test]
 async fn producer_stack_compiles() {
-    let bulkhead = BulkheadLayer::builder().max_concurrent_calls(50).build();
+    let bulkhead = BulkheadLayer::builder()
+        .max_concurrent_calls(50)
+        .build()
+        .unwrap();
 
     let retry = RetryLayer::<PublishRequest, PublishResult, MessageError>::builder()
         .max_attempts(3)

--- a/tests/composition_stacks/microservices.rs
+++ b/tests/composition_stacks/microservices.rs
@@ -82,7 +82,7 @@ async fn microservices_with_adaptive_concurrency_compiles() {
         .max_attempts(2)
         .build();
 
-    let adaptive = AdaptiveLimiterLayer::new(Vegas::builder().build());
+    let adaptive = AdaptiveLimiterLayer::new(Vegas::builder().build().unwrap());
 
     let timeout = TimeLimiterLayer::builder()
         .timeout_duration(Duration::from_secs(5))

--- a/tests/composition_stacks/server_side.rs
+++ b/tests/composition_stacks/server_side.rs
@@ -56,7 +56,8 @@ async fn server_side_stack_compiles() {
     let bulkhead = BulkheadLayer::builder()
         .max_concurrent_calls(100)
         .max_wait_duration(Duration::from_secs(1))
-        .build();
+        .build()
+        .unwrap();
 
     let rate_limiter = RateLimiterLayer::builder()
         .limit_for_period(1000)
@@ -94,7 +95,8 @@ async fn bulkhead_tenant_isolation_compiles() {
     let bulkhead = BulkheadLayer::builder()
         .max_concurrent_calls(10) // Per-tenant limit
         .max_wait_duration(Duration::from_secs(5))
-        .build();
+        .build()
+        .unwrap();
 
     let timeout = TimeLimiterLayer::builder()
         .timeout_duration(Duration::from_secs(30))

--- a/tests/outlier/concurrency.rs
+++ b/tests/outlier/concurrency.rs
@@ -15,7 +15,8 @@ async fn concurrent_failures_eject_correctly() {
         .detector(detector.clone())
         .instance_name("backend-1")
         .error_on_ejection()
-        .build();
+        .build()
+        .unwrap();
 
     let fail_svc =
         tower::util::BoxCloneService::new(tower::service_fn(|_req: String| async move {
@@ -65,7 +66,8 @@ async fn concurrent_successes_prevent_ejection() {
         .detector(detector.clone())
         .instance_name("backend-1")
         .error_on_ejection()
-        .build();
+        .build()
+        .unwrap();
 
     let ok_svc = tower::util::BoxCloneService::new(tower::service_fn(move |req: String| {
         let c = Arc::clone(&sc);

--- a/tests/outlier/fleet.rs
+++ b/tests/outlier/fleet.rs
@@ -72,13 +72,15 @@ async fn shared_detector_across_multiple_services() {
         .detector(detector.clone())
         .instance_name("backend-1")
         .error_on_ejection()
-        .build();
+        .build()
+        .unwrap();
 
     let layer2 = OutlierDetectionLayer::builder()
         .detector(detector.clone())
         .instance_name("backend-2")
         .error_on_ejection()
-        .build();
+        .build()
+        .unwrap();
 
     let mut svc1 = layer1.layer(make_fail_svc());
     let mut svc2 = layer2.layer(make_fail_svc());

--- a/tests/outlier/integration.rs
+++ b/tests/outlier/integration.rs
@@ -30,7 +30,8 @@ async fn healthy_instance_passes_through() {
         .detector(detector)
         .instance_name("backend-1")
         .error_on_ejection()
-        .build();
+        .build()
+        .unwrap();
 
     let mut svc = layer.layer(make_ok_svc());
 
@@ -48,7 +49,8 @@ async fn consecutive_errors_trigger_ejection() {
         .detector(detector.clone())
         .instance_name("backend-1")
         .error_on_ejection()
-        .build();
+        .build()
+        .unwrap();
 
     let mut svc = layer.layer(make_fail_svc());
 
@@ -177,7 +179,8 @@ async fn error_on_ejection_returns_outlier_error() {
         .detector(detector.clone())
         .instance_name("backend-1")
         .error_on_ejection()
-        .build();
+        .build()
+        .unwrap();
 
     let mut svc = layer.layer(make_fail_svc());
 

--- a/tests/property/bulkhead.rs
+++ b/tests/property/bulkhead.rs
@@ -150,7 +150,7 @@ proptest! {
             let layer = BulkheadLayer::builder()
                 .max_concurrent_calls(max_concurrent)
                 .max_wait_duration(Duration::from_secs(10))
-                .build();
+                .build().unwrap();
 
             let service = layer.layer(tracker);
 
@@ -196,7 +196,7 @@ proptest! {
             let layer = BulkheadLayer::builder()
                 .max_concurrent_calls(max_concurrent)
                 .max_wait_duration(Duration::from_secs(30))
-                .build();
+                .build().unwrap();
 
             let service = layer.layer(counting_svc);
 

--- a/tests/router/composition.rs
+++ b/tests/router/composition.rs
@@ -137,7 +137,10 @@ async fn router_with_bulkhead_per_backend() {
     let count = Arc::new(AtomicUsize::new(0));
     let c = Arc::clone(&count);
 
-    let bh = BulkheadLayer::builder().max_concurrent_calls(10).build();
+    let bh = BulkheadLayer::builder()
+        .max_concurrent_calls(10)
+        .build()
+        .unwrap();
 
     let svc = tower::service_fn(move |req: String| {
         let c = Arc::clone(&c);

--- a/tests/stress/adaptive.rs
+++ b/tests/stress/adaptive.rs
@@ -29,7 +29,8 @@ async fn stress_sequential_high_volume() {
             Aimd::builder()
                 .initial_limit(100)
                 .latency_threshold(Duration::from_secs(1))
-                .build(),
+                .build()
+                .unwrap(),
         ))
         .service(svc);
 
@@ -80,7 +81,8 @@ async fn stress_high_concurrency_aimd() {
                 .initial_limit(50)
                 .max_limit(100)
                 .latency_threshold(Duration::from_millis(500))
-                .build(),
+                .build()
+                .unwrap(),
         ))
         .service(svc);
 
@@ -135,7 +137,11 @@ async fn stress_high_concurrency_vegas() {
 
     let service = ServiceBuilder::new()
         .layer(AdaptiveLimiterLayer::new(
-            Vegas::builder().initial_limit(50).max_limit(100).build(),
+            Vegas::builder()
+                .initial_limit(50)
+                .max_limit(100)
+                .build()
+                .unwrap(),
         ))
         .service(svc);
 
@@ -194,7 +200,8 @@ async fn stress_latency_adaptation() {
                 .latency_threshold(Duration::from_millis(50))
                 .increase_by(2)
                 .decrease_factor(0.8)
-                .build(),
+                .build()
+                .unwrap(),
         ))
         .service(svc);
 
@@ -278,7 +285,8 @@ async fn stress_error_adaptation() {
                 .min_limit(2)
                 .decrease_factor(0.5)
                 .latency_threshold(Duration::from_secs(1))
-                .build(),
+                .build()
+                .unwrap(),
         ))
         .service(svc);
 
@@ -334,7 +342,8 @@ async fn stress_sustained_load() {
             Aimd::builder()
                 .initial_limit(50)
                 .latency_threshold(Duration::from_millis(10))
-                .build(),
+                .build()
+                .unwrap(),
         ))
         .service(svc);
 
@@ -388,7 +397,8 @@ async fn stress_memory_stability() {
             Aimd::builder()
                 .initial_limit(100)
                 .latency_threshold(Duration::from_secs(1))
-                .build(),
+                .build()
+                .unwrap(),
         ))
         .service(svc);
 
@@ -465,7 +475,8 @@ async fn stress_algorithm_comparison() {
                 Aimd::builder()
                     .initial_limit(20)
                     .latency_threshold(Duration::from_millis(50))
-                    .build(),
+                    .build()
+                    .unwrap(),
             ))
             .service(svc);
 
@@ -515,7 +526,7 @@ async fn stress_algorithm_comparison() {
 
         let service = ServiceBuilder::new()
             .layer(AdaptiveLimiterLayer::new(
-                Vegas::builder().initial_limit(20).build(),
+                Vegas::builder().initial_limit(20).build().unwrap(),
             ))
             .service(svc);
 

--- a/tests/stress/bulkhead.rs
+++ b/tests/stress/bulkhead.rs
@@ -45,7 +45,8 @@ async fn stress_large_queue() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(10)
         .max_wait_duration(Duration::from_secs(30))
-        .build();
+        .build()
+        .unwrap();
 
     let service = layer.layer(svc);
 
@@ -96,7 +97,8 @@ async fn stress_permit_churn() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(50)
         // Default: wait indefinitely (no timeout)
-        .build();
+        .build()
+        .unwrap();
 
     let service = layer.layer(svc);
 
@@ -153,7 +155,8 @@ async fn stress_long_running_operations() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(5)
         .max_wait_duration(Duration::from_secs(10))
-        .build();
+        .build()
+        .unwrap();
 
     let service = layer.layer(svc);
 
@@ -208,7 +211,8 @@ async fn stress_timeout_under_load() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(10)
         .max_wait_duration(Duration::from_millis(100))
-        .build();
+        .build()
+        .unwrap();
 
     let service = layer.layer(svc);
 
@@ -260,7 +264,8 @@ async fn stress_memory_with_queue() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(10)
         .max_wait_duration(Duration::from_secs(60))
-        .build();
+        .build()
+        .unwrap();
 
     let service = layer.layer(svc);
 
@@ -318,7 +323,8 @@ async fn stress_burst_pattern() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(20)
         .max_wait_duration(Duration::from_secs(5))
-        .build();
+        .build()
+        .unwrap();
 
     let service = layer.layer(svc);
 
@@ -385,7 +391,8 @@ async fn stress_mixed_operation_speeds() {
     let layer = BulkheadLayer::builder()
         .max_concurrent_calls(50)
         .max_wait_duration(Duration::from_secs(10))
-        .build();
+        .build()
+        .unwrap();
 
     let service = layer.layer(svc);
 

--- a/tests/stress/composition.rs
+++ b/tests/stress/composition.rs
@@ -45,7 +45,10 @@ async fn stress_circuit_breaker_plus_bulkhead() {
         }
     });
 
-    let bulkhead = BulkheadLayer::builder().max_concurrent_calls(20).build();
+    let bulkhead = BulkheadLayer::builder()
+        .max_concurrent_calls(20)
+        .build()
+        .unwrap();
 
     // CircuitBreaker now wraps BulkheadServiceError<InnerError>
     let circuit_breaker = CircuitBreakerLayer::builder()
@@ -109,12 +112,14 @@ async fn stress_nested_bulkheads() {
     let bulkhead1 = BulkheadLayer::builder()
         .name("outer")
         .max_concurrent_calls(50)
-        .build();
+        .build()
+        .unwrap();
 
     let bulkhead2 = BulkheadLayer::builder()
         .name("inner")
         .max_concurrent_calls(20)
-        .build();
+        .build()
+        .unwrap();
 
     let service = bulkhead1.layer(bulkhead2.layer(svc));
 
@@ -160,7 +165,10 @@ async fn stress_two_layer_high_concurrency() {
         }
     });
 
-    let bulkhead = BulkheadLayer::builder().max_concurrent_calls(100).build();
+    let bulkhead = BulkheadLayer::builder()
+        .max_concurrent_calls(100)
+        .build()
+        .unwrap();
 
     let circuit_breaker = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.9)
@@ -203,7 +211,10 @@ async fn stress_composed_memory() {
 
     let svc = tower::service_fn(|_req: u32| async move { Ok::<_, TestError>(()) });
 
-    let bulkhead = BulkheadLayer::builder().max_concurrent_calls(100).build();
+    let bulkhead = BulkheadLayer::builder()
+        .max_concurrent_calls(100)
+        .build()
+        .unwrap();
 
     let circuit_breaker = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)
@@ -248,7 +259,10 @@ async fn stress_composed_burst_traffic() {
         }
     });
 
-    let bulkhead = BulkheadLayer::builder().max_concurrent_calls(50).build();
+    let bulkhead = BulkheadLayer::builder()
+        .max_concurrent_calls(50)
+        .build()
+        .unwrap();
 
     let circuit_breaker = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.9)
@@ -306,7 +320,10 @@ async fn stress_composed_stability() {
         }
     });
 
-    let bulkhead = BulkheadLayer::builder().max_concurrent_calls(20).build();
+    let bulkhead = BulkheadLayer::builder()
+        .max_concurrent_calls(20)
+        .build()
+        .unwrap();
 
     let circuit_breaker = CircuitBreakerLayer::builder()
         .failure_rate_threshold(0.5)

--- a/tests/stress/outlier.rs
+++ b/tests/stress/outlier.rs
@@ -42,7 +42,8 @@ fn make_instance(detector: OutlierDetector, name: &str, healthy: Arc<AtomicBool>
         .detector(detector)
         .instance_name(name)
         .error_on_ejection()
-        .build();
+        .build()
+        .unwrap();
 
     BoxCloneService::new(layer.layer(inner))
 }

--- a/tests/tower_differential_contract.rs
+++ b/tests/tower_differential_contract.rs
@@ -69,7 +69,8 @@ async fn bulkhead_backpressure_matches_tower_single_permit_admission() {
             BulkheadLayer::builder()
                 .max_concurrent_calls(1)
                 .backpressure()
-                .build(),
+                .build()
+                .unwrap(),
         )
         .service(bulkhead_probe);
 

--- a/tests/unified_errors.rs
+++ b/tests/unified_errors.rs
@@ -26,7 +26,10 @@ impl std::error::Error for AppError {}
 async fn test_single_layer_unified() {
     let svc = tower::service_fn(|req: String| async move { Ok::<_, AppError>(req.to_uppercase()) });
 
-    let bulkhead = BulkheadLayer::builder().max_concurrent_calls(10).build();
+    let bulkhead = BulkheadLayer::builder()
+        .max_concurrent_calls(10)
+        .build()
+        .unwrap();
     let layer = ResilienceErrorLayer::<_, AppError>::new(bulkhead);
 
     let mut svc = ServiceBuilder::new().layer(layer).service(svc);
@@ -45,7 +48,8 @@ async fn test_bulkhead_error_converts() {
     let bulkhead = BulkheadLayer::builder()
         .max_concurrent_calls(1)
         .max_wait_duration(Duration::from_millis(1))
-        .build();
+        .build()
+        .unwrap();
     let layer = ResilienceErrorLayer::<_, AppError>::new(bulkhead);
 
     let mut svc = ServiceBuilder::new().layer(layer).service(svc);
@@ -117,7 +121,10 @@ async fn test_two_layers_stacked() {
     let svc = tower::service_fn(|req: String| async move { Ok::<_, AppError>(req.to_uppercase()) });
 
     let bulkhead = ResilienceErrorLayer::<_, AppError>::new(
-        BulkheadLayer::builder().max_concurrent_calls(50).build(),
+        BulkheadLayer::builder()
+            .max_concurrent_calls(50)
+            .build()
+            .unwrap(),
     );
     let cb = ResilienceErrorLayer::<_, AppError>::new(
         CircuitBreakerLayer::builder()
@@ -144,7 +151,10 @@ async fn test_three_layers_stacked() {
             .build(),
     );
     let bulkhead = ResilienceErrorLayer::<_, AppError>::new(
-        BulkheadLayer::builder().max_concurrent_calls(50).build(),
+        BulkheadLayer::builder()
+            .max_concurrent_calls(50)
+            .build()
+            .unwrap(),
     );
     let timeout = ResilienceErrorLayer::<_, AppError>::new(
         TimeLimiterLayer::builder()
@@ -173,6 +183,7 @@ async fn test_unified_extension_trait() {
             BulkheadLayer::builder()
                 .max_concurrent_calls(50)
                 .build()
+                .unwrap()
                 .unified::<AppError>(),
         )
         .service(svc);
@@ -188,7 +199,10 @@ async fn test_application_error_preserved() {
     });
 
     let bulkhead = ResilienceErrorLayer::<_, AppError>::new(
-        BulkheadLayer::builder().max_concurrent_calls(10).build(),
+        BulkheadLayer::builder()
+            .max_concurrent_calls(10)
+            .build()
+            .unwrap(),
     );
 
     let mut svc = ServiceBuilder::new().layer(bulkhead).service(svc);


### PR DESCRIPTION
## Context

Follow-up to #372 / PR #417, tracked in #422. PR #417 established the
pattern for `tower-resilience-circuitbreaker`: a `#[non_exhaustive]`
`thiserror::Error` enum, `build()` / `build_with_handle()` returning
`Result<_, XConfigError>`, rustdoc `# Errors` sections, and table-driven
boundary tests colocated with the enum.

Issue #422 asks for this pattern to be applied to five more crates. This PR
scopes to the three crates that don't collide with other concurrently
dispatched work and don't need a larger, separate redesign:

- **`tower-resilience-bulkhead`**: `max_concurrent_calls == 0` is currently
  unchecked and silently builds a permit-less semaphore that can never admit
  a call -- no panic, no error, just a bulkhead that hangs every caller
  forever. This is the highest-risk case in the issue since it fails silently
  rather than loudly.
- **`tower-resilience-adaptive`**: `AimdBuilder::build()` panics via
  `.expect("invalid AIMD algorithm configuration")`; converted to return
  `Result<Aimd, tower_resilience_core::aimd::AimdConfigError>`, reusing the
  existing core error type. `VegasBuilder::build()` has no check for the
  inverted-bound case (`min_limit > max_limit`), which currently panics
  inside `usize::clamp` with a confusing, unattributed message; added a new
  `VegasConfigError`.
- **`tower-resilience-outlier`**: `build()` panics via
  `.expect("OutlierDetectionConfigBuilder requires a detector")`; added
  `OutlierDetectionConfigError::MissingDetector`.

### Deferred out of this PR

- **`tower-resilience-ratelimiter`**: in scope per #422, but issue #430
  (ratelimiter sliding-window parity tests) is concurrently modifying the
  same test files this crate's call-site sweep would touch
  (`tests/ratelimiter/*.rs`, `crates/tower-resilience-ratelimiter/tests/contract.rs`,
  etc). Deferring to a follow-up issue to avoid a large, contested diff
  surface while that work is in flight.
- **`tower-resilience-retry`**: the issue itself scopes this out --
  the multiplier validation needs the interval-function setters to return
  `Result`, which is a larger, separate change than a `build()` signature
  change.

A follow-up issue will be filed for the ratelimiter conversion and retry
backoff work, mirroring how #372 was originally broader and got narrowed to
circuitbreaker with #422 filed for the rest.

## Plan

1. `tower-resilience-bulkhead`: add `BulkheadConfigError` (`ZeroMaxConcurrentCalls`),
   validate in `into_config`, `build()`/`build_with_handle()` return `Result`.
2. `tower-resilience-adaptive`:
   - `Aimd::new`/`AimdBuilder::build()` return
     `Result<_, tower_resilience_core::aimd::AimdConfigError>`.
   - Add `VegasConfigError` (`MinExceedsMax`), validate in `Vegas::new`,
     `VegasBuilder::build()` returns `Result`.
3. `tower-resilience-outlier`: add `OutlierDetectionConfigError::MissingDetector`,
   `build()` returns `Result`.
4. Compiler-guided workspace call-site sweep: `cargo check --workspace --all-targets`
   plus `cargo test --doc` to find every `.build()`/`.build_with_handle()` call
   site across examples, tests, benches, and the `tower-resilience` facade
   crate; fix each with `.unwrap()` or `?` as appropriate to the surrounding
   function's return type.
5. Table-driven boundary tests colocated with each new error enum (mirroring
   `config_error_tests` in circuitbreaker's `config.rs`).
6. `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`,
   `cargo test`.
7. File a follow-up issue for ratelimiter + retry backoff.

Closes #422 for the scoped subset; follow-up issue tracks the remainder.