### PR TITLE
feat(observability): implement metrics/tracing for adaptive, executor, hedge, outlier, reconnect (closes #428)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,6 +2627,7 @@ name = "tower-resilience-adaptive"
 version = "0.12.0"
 dependencies = [
  "metrics",
+ "metrics-util",
  "pin-project-lite",
  "tokio",
  "tokio-util",
@@ -2732,6 +2733,7 @@ name = "tower-resilience-executor"
 version = "0.12.0"
 dependencies = [
  "metrics",
+ "metrics-util",
  "pin-project-lite",
  "tokio",
  "tower",
@@ -2775,6 +2777,7 @@ version = "0.12.0"
 dependencies = [
  "futures",
  "metrics",
+ "metrics-util",
  "pin-project-lite",
  "tokio",
  "tower",
@@ -2790,6 +2793,7 @@ version = "0.12.0"
 dependencies = [
  "futures",
  "metrics",
+ "metrics-util",
  "thiserror 2.0.17",
  "tokio",
  "tower",
@@ -2817,6 +2821,7 @@ version = "0.12.0"
 dependencies = [
  "futures",
  "metrics",
+ "metrics-util",
  "thiserror 2.0.17",
  "tokio",
  "tokio-test",

--- a/README.md
+++ b/README.md
@@ -100,15 +100,14 @@ tower-resilience = { version = "0.12", features = ["full"] }
 
 `metrics` and `tracing` use weak feature activation, so they only turn on
 observability for the patterns you've already enabled - they never pull in a
-pattern on their own. Not every pattern emits metrics or tracing yet:
-`bulkhead`, `cache`, `chaos`, `circuitbreaker`, `coalesce`, `fallback`,
-`ratelimiter`, `retry`, `router`, and `timelimiter` emit metrics today (see
-the [metrics guide](https://docs.rs/tower-resilience/latest/tower_resilience/observability/metrics/)
-for the full list of metric names per pattern); all of those except
-`bulkhead` also emit `tracing` spans/events. `adaptive`, `executor`, `hedge`,
-`outlier`, and `reconnect` accept the `metrics`/`tracing` Cargo features
-(they compile cleanly) but do not yet instrument any calls; see
-[#428](https://github.com/joshrotenberg/tower-resilience/issues/428).
+pattern on their own. Every pattern that declares a `metrics`/`tracing`
+Cargo feature emits real metrics/tracing through it (see the
+[metrics guide](https://docs.rs/tower-resilience/latest/tower_resilience/observability/metrics/)
+for the full list of metric names per pattern). `adaptive`, `executor`, and
+`reconnect` don't yet have a per-instance naming concept, so their metrics
+aren't labeled by instance name the way the other patterns are. The one
+remaining exception is `healthcheck`'s `tracing` feature, which is a
+documented placeholder for future implementation (see its `Cargo.toml`).
 
 To get all patterns with observability:
 

--- a/crates/tower-resilience-adaptive/CHANGELOG.md
+++ b/crates/tower-resilience-adaptive/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   release a reserved semaphore permit), and Rust's partial-move rules
   forbid moving a field out of a type with a manual `Drop` impl without
   `unsafe` code -- see `docs/tower-api-surface-audit.md`.
+- Real `metrics`/`tracing` instrumentation: `adaptive_limit_changes_total`,
+  `adaptive_limit`, and `adaptive_rtt_seconds`, plus `tracing::debug!` on
+  limit changes. Metrics are not yet labeled by instance name -- `adaptive`
+  has no per-instance naming concept ([#428](https://github.com/joshrotenberg/tower-resilience/issues/428)).
 
 ## [0.12.0](https://github.com/joshrotenberg/tower-resilience/compare/tower-resilience-adaptive-v0.11.0...tower-resilience-adaptive-v0.12.0) - 2026-08-17
 

--- a/crates/tower-resilience-adaptive/Cargo.toml
+++ b/crates/tower-resilience-adaptive/Cargo.toml
@@ -28,6 +28,7 @@ metrics = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time"] }
 tower-resilience-core = { workspace = true, features = ["testing"] }
 tower = { workspace = true, features = ["util", "limit"] }
+metrics-util = { version = "0.20", default-features = false, features = ["debugging"] }
 
 [features]
 default = []

--- a/crates/tower-resilience-adaptive/src/service.rs
+++ b/crates/tower-resilience-adaptive/src/service.rs
@@ -11,6 +11,9 @@ use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio_util::sync::PollSemaphore;
 use tower_service::Service;
 
+#[cfg(feature = "tracing")]
+use tracing::debug;
+
 #[derive(Debug)]
 struct CapacityState {
     desired_limit: usize,
@@ -130,14 +133,50 @@ where
     let limit = algorithm.limit();
 
     if limit > state.desired_limit {
+        #[cfg(feature = "tracing")]
+        let old_limit = state.desired_limit;
+
         let increase = limit - state.desired_limit;
         let cancelled_debt = increase.min(state.shrink_debt);
         state.shrink_debt -= cancelled_debt;
         semaphore.add_permits(increase - cancelled_debt);
+
+        #[cfg(feature = "tracing")]
+        debug!(
+            old_limit,
+            new_limit = limit,
+            direction = "increase",
+            "Adaptive concurrency limit changed"
+        );
+
+        #[cfg(feature = "metrics")]
+        {
+            metrics::counter!("adaptive_limit_changes_total", "direction" => "increase")
+                .increment(1);
+            metrics::gauge!("adaptive_limit").set(limit as f64);
+        }
     } else if limit < state.desired_limit {
+        #[cfg(feature = "tracing")]
+        let old_limit = state.desired_limit;
+
         let decrease = state.desired_limit - limit;
         let removed = semaphore.forget_permits(decrease);
         state.shrink_debt += decrease - removed;
+
+        #[cfg(feature = "tracing")]
+        debug!(
+            old_limit,
+            new_limit = limit,
+            direction = "decrease",
+            "Adaptive concurrency limit changed"
+        );
+
+        #[cfg(feature = "metrics")]
+        {
+            metrics::counter!("adaptive_limit_changes_total", "direction" => "decrease")
+                .increment(1);
+            metrics::gauge!("adaptive_limit").set(limit as f64);
+        }
     }
 
     state.desired_limit = limit;
@@ -255,6 +294,9 @@ where
                 let result = future.await;
                 let latency = start.elapsed();
 
+                #[cfg(feature = "metrics")]
+                metrics::histogram!("adaptive_rtt_seconds").record(latency.as_secs_f64());
+
                 match &result {
                     Ok(_) => algorithm.record_success(latency),
                     Err(_) => algorithm.record_failure(),
@@ -340,6 +382,56 @@ mod tests {
         use tower::ServiceExt;
         let response = service.ready().await.unwrap().call(21).await.unwrap();
         assert_eq!(response, 42);
+    }
+
+    #[cfg(feature = "metrics")]
+    #[tokio::test]
+    async fn successful_calls_emit_metrics() {
+        use metrics::set_global_recorder;
+        use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+        use std::sync::LazyLock;
+
+        static RECORDER: LazyLock<DebuggingRecorder> = LazyLock::new(DebuggingRecorder::default);
+        let _ = set_global_recorder(&*RECORDER);
+
+        let service = tower::service_fn(|req: i32| async move { Ok::<_, &str>(req * 2) });
+
+        // A fast, well-under-threshold success grows the AIMD limit by
+        // `increase_by` (1 by default), guaranteeing a limit-change event.
+        let algorithm = Aimd::builder()
+            .initial_limit(10)
+            .increase_by(1)
+            .latency_threshold(Duration::from_secs(1))
+            .build();
+        let mut service = AdaptiveService::new(service, Arc::new(algorithm));
+
+        use tower::ServiceExt;
+        let response = service.ready().await.unwrap().call(21).await.unwrap();
+        assert_eq!(response, 42);
+        assert_eq!(service.limit(), 11);
+
+        let snapshot = RECORDER.snapshotter().snapshot().into_vec();
+
+        let increase_recorded = snapshot.iter().any(|(key, _, _, value)| {
+            key.key().name() == "adaptive_limit_changes_total"
+                && matches!(value, DebugValue::Counter(v) if *v >= 1)
+                && key
+                    .key()
+                    .labels()
+                    .any(|label| label.key() == "direction" && label.value() == "increase")
+        });
+        let rtt_recorded = snapshot
+            .iter()
+            .any(|(key, _, _, _)| key.key().name() == "adaptive_rtt_seconds");
+
+        assert!(
+            increase_recorded,
+            "expected adaptive_limit_changes_total{{direction=\"increase\"}} > 0"
+        );
+        assert!(
+            rtt_recorded,
+            "expected an adaptive_rtt_seconds histogram entry"
+        );
     }
 
     #[tokio::test]

--- a/crates/tower-resilience-bulkhead/CHANGELOG.md
+++ b/crates/tower-resilience-bulkhead/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Bulkhead::get_ref()`, `get_mut()`, and `into_inner()` accessors for the
   wrapped service, matching Tower's own middleware convention.
+- Real `tracing` instrumentation alongside the existing metrics: `debug!`
+  on permitted/finished/failed calls, `warn!` on rejected calls
+  ([#428](https://github.com/joshrotenberg/tower-resilience/issues/428)).
 
 ### Changed
 

--- a/crates/tower-resilience-bulkhead/src/service.rs
+++ b/crates/tower-resilience-bulkhead/src/service.rs
@@ -14,6 +14,9 @@ use tower::Service;
 #[cfg(feature = "metrics")]
 use metrics::{counter, gauge, histogram};
 
+#[cfg(feature = "tracing")]
+use tracing::{debug, warn};
+
 /// Bulkhead service that limits concurrent calls.
 pub struct Bulkhead<S> {
     inner: S,
@@ -144,6 +147,9 @@ where
             };
             config.event_listeners.emit(&event);
 
+            #[cfg(feature = "tracing")]
+            debug!(bulkhead = %config.name, concurrent_calls, "Call permitted");
+
             #[cfg(feature = "metrics")]
             {
                 counter!("bulkhead_calls_permitted_total", "bulkhead" => config.name.clone())
@@ -168,6 +174,9 @@ where
                         };
                         config.event_listeners.emit(&event);
 
+                        #[cfg(feature = "tracing")]
+                        debug!(bulkhead = %config.name, duration_ms = duration.as_millis() as u64, "Call finished");
+
                         #[cfg(feature = "metrics")]
                         {
                             counter!("bulkhead_calls_finished_total", "bulkhead" => config.name.clone())
@@ -183,6 +192,9 @@ where
                             duration,
                         };
                         config.event_listeners.emit(&event);
+
+                        #[cfg(feature = "tracing")]
+                        debug!(bulkhead = %config.name, duration_ms = duration.as_millis() as u64, "Call failed");
 
                         #[cfg(feature = "metrics")]
                         {
@@ -232,6 +244,9 @@ where
                             };
                             config.event_listeners.emit(&event);
 
+                            #[cfg(feature = "tracing")]
+                            warn!(bulkhead = %config.name, max_concurrent_calls = config.max_concurrent_calls, "Call rejected");
+
                             #[cfg(feature = "metrics")]
                             counter!("bulkhead_calls_rejected_total", "bulkhead" => config.name.clone())
                                 .increment(1);
@@ -246,6 +261,9 @@ where
                                 max_concurrent_calls: config.max_concurrent_calls,
                             };
                             config.event_listeners.emit(&event);
+
+                            #[cfg(feature = "tracing")]
+                            warn!(bulkhead = %config.name, max_concurrent_calls = config.max_concurrent_calls, "Call rejected");
 
                             #[cfg(feature = "metrics")]
                             counter!("bulkhead_calls_rejected_total", "bulkhead" => config.name.clone())
@@ -268,6 +286,9 @@ where
                             };
                             config.event_listeners.emit(&event);
 
+                            #[cfg(feature = "tracing")]
+                            warn!(bulkhead = %config.name, max_concurrent_calls = config.max_concurrent_calls, "Call rejected");
+
                             #[cfg(feature = "metrics")]
                             counter!("bulkhead_calls_rejected_total", "bulkhead" => config.name.clone())
                                 .increment(1);
@@ -287,6 +308,9 @@ where
                 concurrent_calls,
             };
             config.event_listeners.emit(&event);
+
+            #[cfg(feature = "tracing")]
+            debug!(bulkhead = %config.name, concurrent_calls, "Call permitted");
 
             #[cfg(feature = "metrics")]
             {
@@ -317,6 +341,9 @@ where
                     };
                     config.event_listeners.emit(&event);
 
+                    #[cfg(feature = "tracing")]
+                    debug!(bulkhead = %config.name, duration_ms = duration.as_millis() as u64, "Call finished");
+
                     #[cfg(feature = "metrics")]
                     {
                         counter!("bulkhead_calls_finished_total", "bulkhead" => config.name.clone())
@@ -332,6 +359,9 @@ where
                         duration,
                     };
                     config.event_listeners.emit(&event);
+
+                    #[cfg(feature = "tracing")]
+                    debug!(bulkhead = %config.name, duration_ms = duration.as_millis() as u64, "Call failed");
 
                     #[cfg(feature = "metrics")]
                     {
@@ -524,5 +554,70 @@ mod tests {
             .await
             .expect("dropping the response future must release its permit")
             .unwrap();
+    }
+
+    #[cfg(feature = "tracing")]
+    #[tokio::test]
+    async fn call_rejected_emits_tracing_event() {
+        use std::sync::Mutex;
+        use tracing::field::{Field, Visit};
+        use tracing::span::{Attributes, Id, Record};
+        use tracing::{Event, Metadata, Subscriber};
+
+        #[derive(Default)]
+        struct Captured {
+            messages: Vec<String>,
+        }
+
+        struct CaptureSubscriber(Arc<Mutex<Captured>>);
+
+        struct MessageVisitor(String);
+        impl Visit for MessageVisitor {
+            fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+                if field.name() == "message" {
+                    self.0 = format!("{value:?}");
+                }
+            }
+        }
+
+        impl Subscriber for CaptureSubscriber {
+            fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+                true
+            }
+            fn new_span(&self, _span: &Attributes<'_>) -> Id {
+                Id::from_u64(1)
+            }
+            fn record(&self, _span: &Id, _values: &Record<'_>) {}
+            fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+            fn event(&self, event: &Event<'_>) {
+                let mut visitor = MessageVisitor(String::new());
+                event.record(&mut visitor);
+                self.0.lock().unwrap().messages.push(visitor.0);
+            }
+            fn enter(&self, _span: &Id) {}
+            fn exit(&self, _span: &Id) {}
+        }
+
+        let captured = Arc::new(Mutex::new(Captured::default()));
+        let subscriber = CaptureSubscriber(Arc::clone(&captured));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        // Default (non-backpressure/rejection) mode: poll_ready forwards to
+        // the inner service, so readiness always succeeds. Closing the
+        // semaphore forces `call()` down the immediate-rejection branch.
+        let (layer, handle) = BulkheadLayer::builder()
+            .max_concurrent_calls(1)
+            .build_with_handle();
+        let mut service = layer.layer(service_fn(|()| async { Ok::<_, Infallible>(()) }));
+        handle.semaphore.close();
+
+        let result = service.ready().await.unwrap().call(()).await;
+        assert!(result.is_err(), "closed semaphore must reject the call");
+
+        let messages = captured.lock().unwrap().messages.clone();
+        assert!(
+            messages.iter().any(|m| m.to_lowercase().contains("reject")),
+            "expected a tracing event mentioning rejection, got: {messages:?}"
+        );
     }
 }

--- a/crates/tower-resilience-executor/CHANGELOG.md
+++ b/crates/tower-resilience-executor/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Real `metrics`/`tracing` instrumentation: `executor_tasks_spawned_total`,
+  `executor_task_duration_seconds`, and `executor_tasks_cancelled_total`,
+  plus `tracing::debug!`/`warn!` at spawn and cancellation. Metrics are not
+  yet labeled by instance name -- `executor` has no per-instance naming
+  concept ([#428](https://github.com/joshrotenberg/tower-resilience/issues/428)).
+
 ## [0.12.0](https://github.com/joshrotenberg/tower-resilience/compare/tower-resilience-executor-v0.11.0...tower-resilience-executor-v0.12.0) - 2026-08-17
 
 ### Fixed

--- a/crates/tower-resilience-executor/Cargo.toml
+++ b/crates/tower-resilience-executor/Cargo.toml
@@ -25,6 +25,7 @@ metrics = { workspace = true, optional = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time"] }
 tower-resilience-core = { workspace = true, features = ["testing"] }
+metrics-util = { version = "0.20", default-features = false, features = ["debugging"] }
 
 [features]
 default = []

--- a/crates/tower-resilience-executor/src/service.rs
+++ b/crates/tower-resilience-executor/src/service.rs
@@ -8,6 +8,9 @@ use std::task::{Context, Poll};
 use tokio::sync::oneshot;
 use tower_service::Service;
 
+#[cfg(feature = "tracing")]
+use tracing::{debug, warn};
+
 /// A service that delegates request processing to an executor.
 ///
 /// Each request is spawned as a new task on the executor, allowing
@@ -80,10 +83,23 @@ where
         let mut service = std::mem::replace(&mut self.inner, clone);
         let (tx, rx) = oneshot::channel();
 
+        #[cfg(feature = "metrics")]
+        let spawn_start = std::time::Instant::now();
+
+        #[cfg(feature = "tracing")]
+        debug!("Task spawned");
+
+        #[cfg(feature = "metrics")]
+        metrics::counter!("executor_tasks_spawned_total").increment(1);
+
         // Spawn the request processing on the executor
         let _handle = self.executor.spawn(async move {
             // Call the service
             let result = service.call(req).await;
+
+            #[cfg(feature = "metrics")]
+            metrics::histogram!("executor_task_duration_seconds")
+                .record(spawn_start.elapsed().as_secs_f64());
 
             // Send the result back
             // The send may fail if the receiver is dropped (caller cancelled)
@@ -137,7 +153,15 @@ impl<T, E> Future for ExecutorFuture<T, E> {
         let this = self.project();
         match this.rx.poll(cx) {
             Poll::Ready(Ok(result)) => Poll::Ready(result),
-            Poll::Ready(Err(_)) => Poll::Ready(Err(ExecutorError::TaskCancelled)),
+            Poll::Ready(Err(_)) => {
+                #[cfg(feature = "tracing")]
+                warn!("Executor task cancelled (spawned task dropped its sender)");
+
+                #[cfg(feature = "metrics")]
+                metrics::counter!("executor_tasks_cancelled_total").increment(1);
+
+                Poll::Ready(Err(ExecutorError::TaskCancelled))
+            }
             Poll::Pending => Poll::Pending,
         }
     }
@@ -162,5 +186,43 @@ mod tests {
         let err3: ExecutorError<&str> = ExecutorError::Service("test");
         let err4: ExecutorError<&str> = ExecutorError::Service("test");
         assert_eq!(err3, err4);
+    }
+
+    #[cfg(feature = "metrics")]
+    #[tokio::test]
+    async fn spawning_a_task_emits_metrics() {
+        use crate::ExecutorLayer;
+        use metrics::set_global_recorder;
+        use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+        use std::convert::Infallible;
+        use std::sync::LazyLock;
+        use tower::{Layer, ServiceExt};
+
+        static RECORDER: LazyLock<DebuggingRecorder> = LazyLock::new(DebuggingRecorder::default);
+        let _ = set_global_recorder(&*RECORDER);
+
+        let layer = ExecutorLayer::current();
+        let mut service = layer.layer(tower::service_fn(|req: i32| async move {
+            Ok::<_, Infallible>(req * 2)
+        }));
+
+        let response = service.ready().await.unwrap().call(21).await.unwrap();
+        assert_eq!(response, 42);
+
+        let snapshot = RECORDER.snapshotter().snapshot().into_vec();
+
+        let spawned = snapshot.iter().any(|(key, _, _, value)| {
+            key.key().name() == "executor_tasks_spawned_total"
+                && matches!(value, DebugValue::Counter(v) if *v >= 1)
+        });
+        let duration_recorded = snapshot
+            .iter()
+            .any(|(key, _, _, _)| key.key().name() == "executor_task_duration_seconds");
+
+        assert!(spawned, "expected executor_tasks_spawned_total > 0");
+        assert!(
+            duration_recorded,
+            "expected an executor_task_duration_seconds histogram entry"
+        );
     }
 }

--- a/crates/tower-resilience-hedge/CHANGELOG.md
+++ b/crates/tower-resilience-hedge/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Hedge::get_ref()`, `get_mut()`, and `into_inner()` accessors for the
   wrapped service, matching Tower's own middleware convention.
+- Real `metrics`/`tracing` instrumentation: `hedge_attempts_total`,
+  `hedge_calls_total{result}`, and `hedge_call_duration_seconds`, plus
+  `tracing::debug!`/`warn!` at hedge starts and terminal outcomes
+  ([#428](https://github.com/joshrotenberg/tower-resilience/issues/428)).
 
 ## [0.12.0](https://github.com/joshrotenberg/tower-resilience/compare/tower-resilience-hedge-v0.11.0...tower-resilience-hedge-v0.12.0) - 2026-08-17
 

--- a/crates/tower-resilience-hedge/Cargo.toml
+++ b/crates/tower-resilience-hedge/Cargo.toml
@@ -32,3 +32,4 @@ tracing = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time"] }
 tower-resilience-core = { workspace = true, features = ["testing"] }
 tower = { workspace = true, features = ["util", "limit"] }
+metrics-util = { version = "0.20", default-features = false, features = ["debugging"] }

--- a/crates/tower-resilience-hedge/src/lib.rs
+++ b/crates/tower-resilience-hedge/src/lib.rs
@@ -161,6 +161,12 @@ use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 use tower::{Service, ServiceExt};
 
+#[cfg(feature = "tracing")]
+use tracing::{debug, warn};
+
+#[cfg(feature = "metrics")]
+use metrics::{counter, histogram};
+
 /// Hedging service that wraps an inner service.
 ///
 /// This service executes parallel redundant requests to reduce tail latency.
@@ -300,6 +306,11 @@ where
     };
     let start = Instant::now();
 
+    // Label shared by every metrics/tracing call site below; mirrors the
+    // fallback `HedgeEvent::pattern_name()` already uses in `events.rs`.
+    #[cfg(any(feature = "metrics", feature = "tracing"))]
+    let label = config.name.as_deref().unwrap_or("hedge");
+
     // Emit primary started event
     config.listeners.emit(&HedgeEvent::PrimaryStarted {
         name: config.name.clone(),
@@ -348,6 +359,13 @@ where
                 delay: Duration::ZERO,
                 timestamp: Instant::now(),
             });
+
+            #[cfg(feature = "tracing")]
+            debug!(hedge = %label, attempt, delay_ms = 0u64, "Hedge attempt started");
+
+            #[cfg(feature = "metrics")]
+            counter!("hedge_attempts_total", "hedge" => label.to_string()).increment(1);
+
             attempts.push(attempt_future(
                 hedge_template
                     .as_ref()
@@ -404,6 +422,13 @@ where
                     delay: elapsed_delay,
                     timestamp: Instant::now(),
                 });
+
+                #[cfg(feature = "tracing")]
+                debug!(hedge = %label, attempt, delay_ms = elapsed_delay.as_millis() as u64, "Hedge attempt started");
+
+                #[cfg(feature = "metrics")]
+                counter!("hedge_attempts_total", "hedge" => label.to_string()).increment(1);
+
                 attempts.push(attempt_future(
                     hedge_template
                         .as_ref()
@@ -462,6 +487,17 @@ where
                         hedges_cancelled,
                         timestamp: Instant::now(),
                     });
+
+                    #[cfg(feature = "tracing")]
+                    debug!(hedge = %label, duration_ms = duration.as_millis() as u64, hedges_cancelled, "Primary succeeded");
+
+                    #[cfg(feature = "metrics")]
+                    {
+                        counter!("hedge_calls_total", "hedge" => label.to_string(), "result" => "primary")
+                            .increment(1);
+                        histogram!("hedge_call_duration_seconds", "hedge" => label.to_string())
+                            .record(duration.as_secs_f64());
+                    }
                 } else {
                     config.listeners.emit(&HedgeEvent::HedgeSucceeded {
                         name: config.name.clone(),
@@ -470,6 +506,17 @@ where
                         primary_cancelled,
                         timestamp: Instant::now(),
                     });
+
+                    #[cfg(feature = "tracing")]
+                    debug!(hedge = %label, attempt, duration_ms = duration.as_millis() as u64, primary_cancelled, "Hedge attempt won");
+
+                    #[cfg(feature = "metrics")]
+                    {
+                        counter!("hedge_calls_total", "hedge" => label.to_string(), "result" => "hedge")
+                            .increment(1);
+                        histogram!("hedge_call_duration_seconds", "hedge" => label.to_string())
+                            .record(duration.as_secs_f64());
+                    }
                 }
                 return Ok(response);
             }
@@ -482,6 +529,18 @@ where
         attempts: max_attempts,
         timestamp: Instant::now(),
     });
+
+    #[cfg(feature = "tracing")]
+    warn!(hedge = %label, attempts = max_attempts, "All hedge attempts failed");
+
+    #[cfg(feature = "metrics")]
+    {
+        let duration = start.elapsed();
+        counter!("hedge_calls_total", "hedge" => label.to_string(), "result" => "failed")
+            .increment(1);
+        histogram!("hedge_call_duration_seconds", "hedge" => label.to_string())
+            .record(duration.as_secs_f64());
+    }
 
     Err(HedgeError::AllAttemptsFailed(
         primary_error
@@ -621,6 +680,71 @@ mod tests {
 
         // Both were called; the slow primary was dropped before return.
         assert_eq!(call_count.load(Ordering::SeqCst), 2);
+    }
+
+    #[cfg(feature = "metrics")]
+    #[tokio::test]
+    async fn hedging_emits_metrics() {
+        use metrics::set_global_recorder;
+        use metrics_util::debugging::DebugValue;
+        use metrics_util::debugging::DebuggingRecorder;
+        use std::sync::LazyLock;
+
+        static RECORDER: LazyLock<DebuggingRecorder> = LazyLock::new(DebuggingRecorder::default);
+        let _ = set_global_recorder(&*RECORDER);
+
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let cc = Arc::clone(&call_count);
+
+        let service = tower::service_fn(move |_req: String| {
+            let cc = Arc::clone(&cc);
+            async move {
+                let count = cc.fetch_add(1, Ordering::SeqCst);
+                if count == 0 {
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                }
+                Ok::<_, TestError>("success".to_string())
+            }
+        });
+
+        let layer = HedgeLayer::builder()
+            .name("metrics-test")
+            .delay(Duration::from_millis(20))
+            .max_hedged_attempts(2)
+            .build();
+
+        let mut service = layer.layer(service);
+        let result = service
+            .ready()
+            .await
+            .unwrap()
+            .call("test".to_string())
+            .await;
+        assert!(result.is_ok());
+
+        let snapshot = RECORDER.snapshotter().snapshot().into_vec();
+
+        let has_metric_with_label = |name: &str, label_key: &str, label_value: &str| {
+            snapshot.iter().any(|(key, _, _, value)| {
+                key.key().name() == name
+                    && matches!(value, DebugValue::Counter(v) if *v >= 1)
+                    && key
+                        .key()
+                        .labels()
+                        .any(|label| label.key() == label_key && label.value() == label_value)
+            })
+        };
+
+        assert!(has_metric_with_label(
+            "hedge_attempts_total",
+            "hedge",
+            "metrics-test"
+        ));
+        assert!(has_metric_with_label(
+            "hedge_calls_total",
+            "hedge",
+            "metrics-test"
+        ));
     }
 
     #[tokio::test]

--- a/crates/tower-resilience-outlier/CHANGELOG.md
+++ b/crates/tower-resilience-outlier/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `OutlierDetectionService::get_ref()`, `get_mut()`, and `into_inner()`
   accessors for the wrapped service, matching Tower's own middleware
   convention.
+- Real `metrics`/`tracing` instrumentation: `outlier_ejections_total`,
+  `outlier_recoveries_total`, `outlier_ejection_skipped_total`, and
+  `outlier_ejected_instances`, plus `tracing::warn!`/`info!`/`debug!` at
+  ejection, recovery, and skipped-ejection
+  ([#428](https://github.com/joshrotenberg/tower-resilience/issues/428)).
 
 ### Removed
 

--- a/crates/tower-resilience-outlier/Cargo.toml
+++ b/crates/tower-resilience-outlier/Cargo.toml
@@ -26,6 +26,7 @@ metrics = { workspace = true, optional = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros", "rt-multi-thread", "time"] }
 tower-resilience-core = { workspace = true, features = ["testing"] }
+metrics-util = { version = "0.20", default-features = false, features = ["debugging"] }
 
 [features]
 default = []

--- a/crates/tower-resilience-outlier/src/detector.rs
+++ b/crates/tower-resilience-outlier/src/detector.rs
@@ -11,6 +11,12 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tower_resilience_core::events::EventListeners;
 
+#[cfg(feature = "tracing")]
+use tracing::{debug, info, warn};
+
+#[cfg(feature = "metrics")]
+use metrics::{counter, gauge};
+
 /// State for a single instance tracked by the detector.
 struct InstanceState {
     /// Whether this instance is currently ejected.
@@ -235,6 +241,18 @@ impl OutlierDetector {
                 current_ejection_percent: (currently_ejected as f64 / total as f64) * 100.0,
             };
             inner.event_listeners.emit(&event);
+
+            #[cfg(feature = "tracing")]
+            debug!(
+                outlier = %inner.pattern_name,
+                instance_name = %name,
+                "Ejection skipped: max_ejection_percent would be exceeded"
+            );
+
+            #[cfg(feature = "metrics")]
+            counter!("outlier_ejection_skipped_total", "outlier" => inner.pattern_name.clone())
+                .increment(1);
+
             return false;
         }
 
@@ -253,13 +271,29 @@ impl OutlierDetector {
         instance.ejection_duration = ejection_duration;
 
         let event = OutlierDetectionEvent::Ejected {
-            pattern_name,
+            pattern_name: pattern_name.clone(),
             timestamp: Instant::now(),
             instance_name: name.to_string(),
             consecutive_errors: failure_count,
             ejection_duration,
         };
         inner.event_listeners.emit(&event);
+
+        #[cfg(feature = "tracing")]
+        warn!(
+            outlier = %pattern_name,
+            instance_name = %name,
+            consecutive_errors = failure_count,
+            "Instance ejected"
+        );
+
+        #[cfg(feature = "metrics")]
+        {
+            let ejected_instances = inner.instances.values().filter(|i| i.ejected).count();
+            counter!("outlier_ejections_total", "outlier" => pattern_name.clone()).increment(1);
+            gauge!("outlier_ejected_instances", "outlier" => pattern_name)
+                .set(ejected_instances as f64);
+        }
 
         true
     }
@@ -291,13 +325,31 @@ impl OutlierDetector {
             instance.ejected_at = None;
             instance.strategy.reset();
 
+            let pattern_name = inner.pattern_name.clone();
             let event = OutlierDetectionEvent::Recovered {
-                pattern_name: inner.pattern_name.clone(),
+                pattern_name: pattern_name.clone(),
                 timestamp: Instant::now(),
                 instance_name: name.to_string(),
                 ejected_duration,
             };
             inner.event_listeners.emit(&event);
+
+            #[cfg(feature = "tracing")]
+            info!(
+                outlier = %pattern_name,
+                instance_name = %name,
+                ejected_duration_ms = ejected_duration.as_millis() as u64,
+                "Instance recovered"
+            );
+
+            #[cfg(feature = "metrics")]
+            {
+                counter!("outlier_recoveries_total", "outlier" => pattern_name.clone())
+                    .increment(1);
+                let ejected_instances = inner.instances.values().filter(|i| i.ejected).count();
+                gauge!("outlier_ejected_instances", "outlier" => pattern_name)
+                    .set(ejected_instances as f64);
+            }
 
             return false;
         }
@@ -457,5 +509,45 @@ mod tests {
         let detector = OutlierDetector::new();
         assert!(!detector.is_ejected("unknown"));
         assert!(!detector.record_failure("unknown"));
+    }
+
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn ejection_and_recovery_emit_metrics() {
+        use metrics::set_global_recorder;
+        use metrics_util::debugging::DebugValue;
+        use metrics_util::debugging::DebuggingRecorder;
+        use std::sync::LazyLock;
+
+        static RECORDER: LazyLock<DebuggingRecorder> = LazyLock::new(DebuggingRecorder::default);
+        let _ = set_global_recorder(&*RECORDER);
+
+        let detector = OutlierDetector::new()
+            .name("metrics-test")
+            .base_ejection_duration(Duration::from_millis(10))
+            .max_ejection_percent(100);
+        detector.register("backend-1", 1);
+
+        assert!(detector.record_failure("backend-1"));
+        assert!(detector.is_ejected("backend-1"));
+
+        std::thread::sleep(Duration::from_millis(20));
+        assert!(!detector.is_ejected("backend-1"));
+
+        let snapshot = RECORDER.snapshotter().snapshot().into_vec();
+
+        let has_metric = |name: &str| {
+            snapshot.iter().any(|(key, _, _, value)| {
+                key.key().name() == name
+                    && matches!(value, DebugValue::Counter(v) if *v >= 1)
+                    && key
+                        .key()
+                        .labels()
+                        .any(|label| label.key() == "outlier" && label.value() == "metrics-test")
+            })
+        };
+
+        assert!(has_metric("outlier_ejections_total"));
+        assert!(has_metric("outlier_recoveries_total"));
     }
 }

--- a/crates/tower-resilience-reconnect/CHANGELOG.md
+++ b/crates/tower-resilience-reconnect/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Real `metrics`/`tracing` instrumentation: `reconnect_attempts_total`,
+  `reconnect_transitions_total{from, to}`, and `reconnect_state{state}`,
+  plus `tracing::debug!`/`warn!` at state transitions and reconnection
+  attempts. Metrics are not yet labeled by instance name -- `reconnect`
+  has no per-instance naming concept ([#428](https://github.com/joshrotenberg/tower-resilience/issues/428)).
+
 ## [0.12.0](https://github.com/joshrotenberg/tower-resilience/compare/tower-resilience-reconnect-v0.11.0...tower-resilience-reconnect-v0.12.0) - 2026-08-17
 
 ### Fixed

--- a/crates/tower-resilience-reconnect/Cargo.toml
+++ b/crates/tower-resilience-reconnect/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 tokio-test = "0.4"
 tower-resilience-core = { workspace = true, features = ["testing"] }
 tower = { workspace = true, features = ["util", "limit"] }
+metrics-util = { version = "0.20", default-features = false, features = ["debugging"] }
 
 [features]
 default = []

--- a/crates/tower-resilience-reconnect/src/service.rs
+++ b/crates/tower-resilience-reconnect/src/service.rs
@@ -9,6 +9,12 @@ use tower::Service;
 
 use crate::{config::ReconnectConfig, state::ReconnectState};
 
+#[cfg(feature = "tracing")]
+use tracing::{debug, warn};
+
+#[cfg(feature = "metrics")]
+use metrics::{counter, gauge};
+
 /// A Tower service that owns a service factory and replaces failed connections.
 ///
 /// `M` is a `MakeService`-style factory: a `Service<Target>` whose response is
@@ -449,6 +455,15 @@ where
     mark_disconnected(config, state);
     state.increment_attempts();
 
+    #[cfg(feature = "metrics")]
+    counter!("reconnect_attempts_total").increment(1);
+
+    #[cfg(feature = "tracing")]
+    warn!(
+        attempt = shared.factory_attempts,
+        "Reconnection attempt scheduled"
+    );
+
     let Some(delay) = config
         .policy
         .delay_for_attempt(shared.factory_attempts as usize)
@@ -482,6 +497,13 @@ where
 
     mark_disconnected(config, state);
     state.increment_attempts();
+
+    #[cfg(feature = "metrics")]
+    counter!("reconnect_attempts_total").increment(1);
+
+    #[cfg(feature = "tracing")]
+    warn!(attempt, "Reconnection attempt scheduled");
+
     let Some(delay) = config.policy.delay_for_attempt(attempt as usize) else {
         shared.phase = ConnectionPhase::Idle;
         shared.generation = shared.generation.wrapping_add(1);
@@ -559,11 +581,28 @@ fn notify_state_change(
     }
 
     #[cfg(feature = "tracing")]
+    debug!(from = ?previous, to = ?current, "Reconnect state transition");
+
+    #[cfg(feature = "metrics")]
+    {
+        counter!(
+            "reconnect_transitions_total",
+            "from" => format!("{previous:?}"),
+            "to" => format!("{current:?}")
+        )
+        .increment(1);
+        gauge!("reconnect_state", "state" => format!("{current:?}")).set(1.0);
+    }
+
+    #[cfg(feature = "tracing")]
     if let Some(callback) = config.on_state_change.as_ref() {
         callback(previous, current);
     }
 
-    #[cfg(not(feature = "tracing"))]
+    #[cfg(not(any(feature = "tracing", feature = "metrics")))]
+    let _ = config;
+
+    #[cfg(all(feature = "metrics", not(feature = "tracing")))]
     let _ = config;
 }
 
@@ -623,5 +662,92 @@ where
             | Self::ConnectionFailedNoRetry(error)
             | Self::ServiceError(error) => Some(error),
         }
+    }
+}
+
+#[cfg(all(test, feature = "metrics"))]
+mod tests {
+    use crate::{ReconnectConfig, ReconnectLayer, ReconnectPolicy};
+    use metrics::set_global_recorder;
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+    use std::io;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, LazyLock};
+    use std::time::Duration;
+    use tower::{service_fn, Layer, Service, ServiceExt};
+
+    #[derive(Clone)]
+    struct Connection {
+        ready: bool,
+    }
+
+    impl Service<()> for Connection {
+        type Response = ();
+        type Error = io::Error;
+        type Future = std::future::Ready<Result<(), io::Error>>;
+
+        fn poll_ready(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Result<(), Self::Error>> {
+            self.ready = true;
+            std::task::Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, (): ()) -> Self::Future {
+            self.ready = false;
+            std::future::ready(Ok(()))
+        }
+    }
+
+    #[tokio::test]
+    async fn factory_retries_emit_attempt_and_transition_metrics() {
+        static RECORDER: LazyLock<DebuggingRecorder> = LazyLock::new(DebuggingRecorder::default);
+        let _ = set_global_recorder(&*RECORDER);
+
+        let factory_calls = Arc::new(AtomicUsize::new(0));
+        let calls = Arc::clone(&factory_calls);
+        let factory = service_fn(move |(): ()| {
+            let attempt = calls.fetch_add(1, Ordering::SeqCst) + 1;
+            async move {
+                if attempt < 2 {
+                    Err(io::Error::new(
+                        io::ErrorKind::ConnectionRefused,
+                        "factory unavailable",
+                    ))
+                } else {
+                    Ok(Connection { ready: false })
+                }
+            }
+        });
+
+        let config = ReconnectConfig::builder()
+            .policy(ReconnectPolicy::fixed(Duration::from_millis(1)))
+            .max_attempts(3)
+            .build();
+        let mut service = ReconnectLayer::new(config).layer(factory);
+
+        service.ready().await.unwrap().call(()).await.unwrap();
+
+        let snapshot = RECORDER.snapshotter().snapshot().into_vec();
+
+        let attempts_recorded = snapshot.iter().any(|(key, _, _, value)| {
+            key.key().name() == "reconnect_attempts_total"
+                && matches!(value, DebugValue::Counter(v) if *v >= 1)
+        });
+        let transition_recorded = snapshot.iter().any(|(key, _, _, value)| {
+            key.key().name() == "reconnect_transitions_total"
+                && matches!(value, DebugValue::Counter(v) if *v >= 1)
+                && key
+                    .key()
+                    .labels()
+                    .any(|label| label.key() == "to" && label.value() == "Connected")
+        });
+
+        assert!(attempts_recorded, "expected reconnect_attempts_total > 0");
+        assert!(
+            transition_recorded,
+            "expected a reconnect_transitions_total{{to=\"Connected\"}} entry"
+        );
     }
 }

--- a/crates/tower-resilience/src/observability.rs
+++ b/crates/tower-resilience/src/observability.rs
@@ -5,11 +5,12 @@
 pub mod metrics {
     //! # Metrics Guide
     //!
-    //! Most resilience patterns support optional Prometheus-compatible metrics via the
-    //! `metrics` feature; see [Available Metrics by Pattern](#available-metrics-by-pattern)
-    //! below for exactly which patterns currently emit metrics. `adaptive`, `executor`,
-    //! `hedge`, `outlier`, and `reconnect` accept the `metrics` Cargo feature (it compiles
-    //! cleanly) but do not yet emit any metrics of their own.
+    //! Every resilience pattern that declares a `metrics` Cargo feature emits real
+    //! Prometheus-compatible metrics via it; see
+    //! [Available Metrics by Pattern](#available-metrics-by-pattern) below for the full
+    //! list of metric names per pattern. `adaptive`, `executor`, and `reconnect` have no
+    //! per-instance naming concept yet, so their metrics are not labeled by instance name
+    //! the way the other patterns are; see the per-pattern notes below.
     //!
     //! ## Enabling Metrics
     //!
@@ -106,6 +107,49 @@ pub mod metrics {
     //!
     //! - `router_requests_routed_total{router, backend}` - Requests routed, by
     //!   backend index
+    //!
+    //! ### Adaptive
+    //!
+    //! - `adaptive_limit_changes_total{direction}` - Concurrency limit adjustments
+    //!   (`direction` is `increase`/`decrease`)
+    //! - `adaptive_limit` - Current concurrency limit gauge
+    //! - `adaptive_rtt_seconds` - Per-call latency histogram (recorded for both
+    //!   successes and failures, matching how `circuitbreaker_call_duration_seconds`
+    //!   blends outcomes)
+    //!
+    //! Not labeled by instance name: `adaptive` has no per-instance naming concept yet.
+    //!
+    //! ### Executor
+    //!
+    //! - `executor_tasks_spawned_total` - Tasks spawned onto the executor
+    //! - `executor_task_duration_seconds` - Spawn-to-completion duration histogram
+    //! - `executor_tasks_cancelled_total` - Spawned tasks whose result could not be
+    //!   delivered (the spawned task's sender was dropped)
+    //!
+    //! Not labeled by instance name: `executor` has no per-instance naming concept yet.
+    //!
+    //! ### Hedge
+    //!
+    //! - `hedge_attempts_total{hedge}` - Hedge attempts fired
+    //! - `hedge_calls_total{hedge, result}` - Terminal outcomes (`result` is
+    //!   `primary`/`hedge`/`failed`)
+    //! - `hedge_call_duration_seconds{hedge}` - Duration until a terminal outcome
+    //!
+    //! ### Outlier
+    //!
+    //! - `outlier_ejections_total{outlier}` - Instances ejected
+    //! - `outlier_recoveries_total{outlier}` - Instances recovered
+    //! - `outlier_ejection_skipped_total{outlier}` - Ejections skipped because
+    //!   `max_ejection_percent` would have been exceeded
+    //! - `outlier_ejected_instances{outlier}` - Currently-ejected instance count gauge
+    //!
+    //! ### Reconnect
+    //!
+    //! - `reconnect_attempts_total` - Reconnection attempts scheduled
+    //! - `reconnect_transitions_total{from, to}` - Connection state transitions
+    //! - `reconnect_state{state}` - Current connection state gauge
+    //!
+    //! Not labeled by instance name: `reconnect` has no per-instance naming concept yet.
     //!
     //! ## Example Prometheus Queries
     //!


### PR DESCRIPTION
## Setup

cwd: /Users/joshrotenberg/Code/github.com/joshrotenberg/tower-resilience/.claude/worktrees/agent-ab84274e5d8b78b5b

You are on branch `feat/pattern-metrics-tracing-428`, already checked out, already pushed with one
empty commit. Do NOT create a new branch. Do NOT run `git checkout main`. Verify with:

    git branch --show-current

Output must be `feat/pattern-metrics-tracing-428`.

## Context

Issue #428: `adaptive`, `executor`, `hedge`, `outlier`, and `reconnect` each declare a `metrics`
Cargo feature (real optional `metrics` dependency, with a `Cargo.toml` doc comment describing what
it's meant to cover) but implement none of it -- zero `counter!`/`histogram!`/`gauge!` calls
anywhere in `src/`. The same five crates, plus `bulkhead`, declare a `tracing` feature with zero
`tracing::*` calls (`bulkhead` already has real metrics, just no tracing). Enabling either feature
on these crates compiles cleanly and does nothing. This issue closes that gap.

Read `gh issue view 428` yourself for the full text -- it is authoritative over this prompt if
they ever disagree, though they should not: this prompt was written from a fresh read of the issue
plus a full read of every file you will touch.

**Concurrency warning:** another agent is concurrently working issue #422 (construction-time
validation touching `adaptive` and `outlier` config/builder files). To avoid collision:

- Do NOT touch `crates/tower-resilience-adaptive/src/algorithm.rs` or
  `crates/tower-resilience-adaptive/src/layer.rs`.
- Do NOT touch `crates/tower-resilience-outlier/src/config.rs`.
- As a blanket rule across ALL six crates in this task, do not add fields or methods to any
  `config.rs`, `layer.rs`, or builder type anywhere. Every change in this task lives in a
  `service.rs` (or, where the crate has no separate `service.rs`, the service `impl Service<..>`
  block wherever it lives -- `lib.rs` for `hedge`), `detector.rs` (outlier), `Cargo.toml`
  (dev-dependencies only), `CHANGELOG.md`, `README.md`, and
  `crates/tower-resilience/src/observability.rs`.
- If you hit a CHANGELOG.md merge conflict in the `adaptive` or `outlier` crate later (unlikely
  since you're working from a fresh branch), that means #422 already merged into main -- merge
  main into this branch and combine the changelog entries rather than overwriting.

## Naming convention -- read this before writing any metric name

Every crate that already emits metrics (`circuitbreaker`, `bulkhead`, `retry`, `ratelimiter`,
`timelimiter`, `cache`, `coalesce`, `fallback`, `router`) uses the bare pattern name as the metric
prefix, NOT a `tower_resilience_` prefix: `circuitbreaker_calls_total`, `bulkhead_calls_permitted_total`,
`retry_attempts_total`, `cache_requests_total`, etc. `chaos` is the one outlier using dotted names
(`chaos.errors_injected`) -- ignore it, it's legacy and not the pattern to copy. Use the bare
`<pattern>_<noun>[_total|_seconds]` convention (counters end `_total`, duration histograms end
`_seconds`, gauges get a plain noun) for every metric you add here. Do NOT prefix with
`tower_resilience_`.

## Style reference (read for style ONLY -- do not copy structurally, each crate's actual call
sites are specified below)

- `crates/tower-resilience-circuitbreaker/src/circuit.rs` -- the `transition_to` and
  `record_success`/`record_failure` functions show the idiom: emit the existing event first,
  then a `#[cfg(feature = "tracing")]` block with a `tracing::info!`/`debug!`/`warn!` call, then a
  `#[cfg(feature = "metrics")]` block with `counter!`/`histogram!`/`gauge!` calls, using
  `"circuitbreaker" => config.name.clone()` as the label.
- `crates/tower-resilience-retry/src/lib.rs` (around lines 280-475) -- same idiom inline in the
  service future, using `#[cfg(feature = "tracing")] use tracing::{debug, info, warn};` at the top
  of the file and bare `debug!(...)`/`warn!(...)` calls (not `tracing::debug!`) since the names are
  imported.
- `crates/tower-resilience-bulkhead/src/service.rs` -- shows the existing metrics-only idiom you
  are adding tracing next to (bulkhead already has real metrics; you are ONLY adding tracing here,
  not touching the metrics blocks).
- `crates/tower-resilience-core/src/events.rs`, test `listener_panics_increment_metrics_and_keep_processing`
  -- the ONLY existing metrics-snapshot test in the workspace. This is your template for every new
  metrics test below: `metrics_util::debugging::DebuggingRecorder` behind a `std::sync::LazyLock`,
  `metrics::set_global_recorder(&*RECORDER)` (ignore the `Result`, `let _ =`), then
  `RECORDER.snapshotter().snapshot().into_vec()` and search for your metric name + label values.
  **Only one such test per crate** -- `set_global_recorder` only succeeds once per test-binary
  process; a second `#[test]` calling it again silently no-ops and shares state with the first,
  which will make your assertions flaky/wrong. If you want to exercise more than one code path,
  do it within the one test function before taking the snapshot.

## Per-crate work

### 1. `bulkhead` -- tracing only (metrics already implemented, do not touch metrics blocks)

File: `crates/tower-resilience-bulkhead/src/service.rs`.

Add `#[cfg(feature = "tracing")] use tracing::{debug, warn};` near the top (next to the existing
`#[cfg(feature = "metrics")] use metrics::{counter, gauge, histogram};`).

At each of the existing `config.event_listeners.emit(&BulkheadEvent::...)` call sites (there are
several, in both backpressure and rejection mode), add a `#[cfg(feature = "tracing")]` block right
next to the existing `#[cfg(feature = "metrics")]` block for that same event:

- `CallPermitted` sites: `debug!(bulkhead = %config.name, concurrent_calls, "Call permitted")`
- `CallRejected` sites (closed-while-waiting, timeout, closed-immediate -- three call sites in
  rejection mode): `warn!(bulkhead = %config.name, max_concurrent_calls = config.max_concurrent_calls, "Call rejected")`
- `CallFinished` sites: `debug!(bulkhead = %config.name, duration_ms = duration.as_millis() as u64, "Call finished")`
- `CallFailed` sites: `debug!(bulkhead = %config.name, duration_ms = duration.as_millis() as u64, "Call failed")`

Test (add to the existing `#[cfg(test)] mod tests` block in `service.rs`): a
`#[cfg(feature = "tracing")]` test proving a tracing event actually fires on rejection. Use a
minimal custom `tracing::Subscriber` scoped with `tracing::subscriber::set_default` (NOT a global
recorder -- this is thread-scoped and safe to use more than once per crate). Template:

```rust
#[cfg(feature = "tracing")]
#[tokio::test]
async fn call_rejected_emits_tracing_event() {
    use std::sync::{Arc, Mutex};
    use tracing::field::{Field, Visit};
    use tracing::span::{Attributes, Id, Record};
    use tracing::{Event, Metadata, Subscriber};

    #[derive(Default)]
    struct Captured {
        messages: Vec<String>,
    }

    struct CaptureSubscriber(Arc<Mutex<Captured>>);

    struct MessageVisitor(String);
    impl Visit for MessageVisitor {
        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
            if field.name() == "message" {
                self.0 = format!("{value:?}");
            }
        }
    }

    impl Subscriber for CaptureSubscriber {
        fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
            true
        }
        fn new_span(&self, _span: &Attributes<'_>) -> Id {
            Id::from_u64(1)
        }
        fn record(&self, _span: &Id, _values: &Record<'_>) {}
        fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
        fn event(&self, event: &Event<'_>) {
            let mut visitor = MessageVisitor(String::new());
            event.record(&mut visitor);
            self.0.lock().unwrap().messages.push(visitor.0);
        }
        fn enter(&self, _span: &Id) {}
        fn exit(&self, _span: &Id) {}
    }

    let captured = Arc::new(Mutex::new(Captured::default()));
    let subscriber = CaptureSubscriber(Arc::clone(&captured));
    let _guard = tracing::subscriber::set_default(subscriber);

    let (layer, handle) = BulkheadLayer::builder()
        .max_concurrent_calls(1)
        .build_with_handle();
    let mut service = layer.layer(service_fn(|()| async { Ok::<_, Infallible>(()) }));
    handle.semaphore.close();

    let _ = service.ready().await; // closed semaphore -> rejection path

    let messages = captured.lock().unwrap().messages.clone();
    assert!(
        messages.iter().any(|m| m.to_lowercase().contains("reject")),
        "expected a tracing event mentioning rejection, got: {messages:?}"
    );
}
```

Adjust to whatever call path actually reaches a `CallRejected`/warn! site in this crate's real
code (check whether it's `poll_ready` or `call` that hits the closed-semaphore path in
non-backpressure/rejection mode -- follow the existing `closed_backpressure_semaphore_is_a_readiness_error`
test in this same file for the exact mechanics of forcing a closed-semaphore rejection).

No Cargo.toml changes needed for bulkhead (the `tracing` optional dependency it already has is
sufficient for both the src code and this test, since the test is itself
`#[cfg(feature = "tracing")]`-gated).

### 2. `hedge` -- metrics + tracing

Files: `crates/tower-resilience-hedge/src/lib.rs` (the service logic lives here, in
`execute_with_hedging`, around lines 280-491), plus a new dev-dependency in
`crates/tower-resilience-hedge/Cargo.toml`.

`HedgeConfig` already has `name: Option<String>` (`pub(crate) name`, doc comment: "used in
metrics/tracing") -- use `config.name.as_deref().unwrap_or("hedge")` as the label value,
matching `HedgeEvent::pattern_name()`'s existing fallback in `events.rs`. Do NOT touch
`config.rs` or `layer.rs`.

At the existing `config.listeners.emit(&HedgeEvent::...)` call sites in `lib.rs`, add
`#[cfg(feature = "tracing")]`/`#[cfg(feature = "metrics")]` blocks:

- `HedgeStarted` (two call sites -- the parallel-fanout loop and the `RaceResult::StartHedge`
  branch): counter `hedge_attempts_total{hedge}`, `debug!(hedge = %label, attempt, delay_ms = delay.as_millis() as u64, "Hedge attempt started")`.
- `PrimarySucceeded`: counter `hedge_calls_total{hedge, result="primary"}`, histogram
  `hedge_call_duration_seconds{hedge}` recording `duration.as_secs_f64()`,
  `debug!(hedge = %label, duration_ms = duration.as_millis() as u64, hedges_cancelled, "Primary succeeded")`.
- `HedgeSucceeded`: counter `hedge_calls_total{hedge, result="hedge"}`, histogram
  `hedge_call_duration_seconds{hedge}` recording `duration.as_secs_f64()`,
  `debug!(hedge = %label, attempt, duration_ms = duration.as_millis() as u64, primary_cancelled, "Hedge attempt won")`.
- `AllFailed`: counter `hedge_calls_total{hedge, result="failed"}`. Compute `let duration = start.elapsed();`
  right before this event (it isn't currently computed on this path) and record it into the same
  `hedge_call_duration_seconds{hedge}` histogram. `warn!(hedge = %label, attempts, "All hedge attempts failed")`.

Add near the top of `lib.rs` (inside the existing `#[cfg(feature = "metrics")]`/`tracing` gates,
following the retry.rs style of importing bare names):
```rust
#[cfg(feature = "tracing")]
use tracing::{debug, warn};
#[cfg(feature = "metrics")]
use metrics::{counter, histogram};
```

Cargo.toml: add to `[dev-dependencies]`:
```toml
metrics-util = { version = "0.20", default-features = false, features = ["debugging"] }
```

Test: one `#[cfg(feature = "metrics")]` test in `lib.rs`'s existing `#[cfg(test)] mod tests` (or a
new one if none exists in this file) proving `hedge_calls_total` and `hedge_attempts_total` are
recorded, following the `DebuggingRecorder` template from `core/events.rs`. Drive a real hedge
call through a `tower::service_fn` inner (there are existing hedge tests in this same file to copy
the harness shape from) so at least one hedge attempt fires and one terminal outcome is recorded.

### 3. `outlier` -- metrics + tracing

Files: `crates/tower-resilience-outlier/src/detector.rs` (this is where
`OutlierDetectionEvent::Ejected`/`Recovered`/`EjectionSkipped` are actually emitted -- NOT
`config.rs`, do not touch that file), plus a new dev-dependency in
`crates/tower-resilience-outlier/Cargo.toml`.

`DetectorInner` already has `pattern_name: String` -- use it as the label (`inner.pattern_name`
or the already-extracted local `pattern_name` variable at each site).

At the three existing `inner.event_listeners.emit(&OutlierDetectionEvent::...)` call sites in
`detector.rs`:

- `Ejected` (in `record_failure`): counter `outlier_ejections_total{outlier}`, gauge
  `outlier_ejected_instances{outlier}` set to the post-ejection ejected count (you already compute
  `currently_ejected` above this branch -- use `currently_ejected + 1`),
  `warn!(outlier = %pattern_name, instance_name = %name, consecutive_errors = failure_count, "Instance ejected")`.
- `Recovered` (in `is_ejected`): counter `outlier_recoveries_total{outlier}`,
  `info!(outlier = %pattern_name, instance_name = %name, ejected_duration_ms = ejected_duration.as_millis() as u64, "Instance recovered")`.
- `EjectionSkipped` (in `record_failure`): counter `outlier_ejection_skipped_total{outlier}`,
  `debug!(outlier = %pattern_name, instance_name = %name, "Ejection skipped: max_ejection_percent would be exceeded")`.

Add near the top of `detector.rs`:
```rust
#[cfg(feature = "tracing")]
use tracing::{debug, info, warn};
#[cfg(feature = "metrics")]
use metrics::{counter, gauge};
```

Cargo.toml: same `metrics-util` dev-dependency addition as hedge above.

Test: one `#[cfg(feature = "metrics")]` test in `detector.rs`'s existing `#[cfg(test)] mod tests`
proving `outlier_ejections_total` (and ideally `outlier_recoveries_total`) are recorded, using the
`DebuggingRecorder` template. The existing `test_register_and_eject` and `test_auto_recovery` tests
in this file show how to drive an ejection and a recovery deterministically -- reuse that shape.

### 4. `reconnect` -- metrics + tracing

File: `crates/tower-resilience-reconnect/src/service.rs` (the `mark_disconnected`,
`mark_reconnecting`, `mark_connected`, `notify_state_change`, and `schedule_factory_retry`/
`invalidate` functions are the actual state-transition/event code path here -- this crate's
`lib.rs` doc comment claims an "event system" but there is no `EventListeners` here; these
functions ARE the event system). Do not touch `config.rs` or `state.rs`.

This crate has no per-instance `name` concept anywhere (confirmed: no `name` field on
`ReconnectConfig`). Per the blanket "don't touch config/builders" rule above, do not add one.
Emit these metrics unlabeled (no per-instance label) -- note this as a known limitation in the
CHANGELOG entry (a future issue can add instance naming to this crate if needed).

- In `notify_state_change` (called from `mark_disconnected`/`mark_reconnecting`/`mark_connected`,
  already receives `previous` and `current` `ConnectionState`, already guards `if previous ==
  current { return; }`): add, right after that guard,
  ```rust
  #[cfg(feature = "tracing")]
  tracing::debug!(from = ?previous, to = ?current, "Reconnect state transition");

  #[cfg(feature = "metrics")]
  {
      metrics::counter!(
          "reconnect_transitions_total",
          "from" => format!("{previous:?}"),
          "to" => format!("{current:?}")
      )
      .increment(1);
      metrics::gauge!("reconnect_state", "state" => format!("{current:?}")).set(1.0);
  }
  ```
  (mirrors `circuitbreaker`'s `transition_to`/`circuitbreaker_state` idiom exactly -- gauge is set
  per-state-label to 1.0, old-state labels are not reset to 0, that's the existing accepted idiom
  in this codebase, copy it don't improve on it here.)
- In `schedule_factory_retry` AND `invalidate` (both already call `state.increment_attempts()`):
  add right after that call,
  ```rust
  #[cfg(feature = "metrics")]
  metrics::counter!("reconnect_attempts_total").increment(1);

  #[cfg(feature = "tracing")]
  tracing::warn!(attempt = shared.factory_attempts, "Reconnection attempt scheduled"); // schedule_factory_retry
  // or, in invalidate:
  #[cfg(feature = "tracing")]
  tracing::warn!(attempt, "Reconnection attempt scheduled");
  ```
  (use whichever local variable holds the attempt count at each call site -- `shared.factory_attempts`
  in `schedule_factory_retry`, the `attempt: u32` parameter in `invalidate`.)

Cargo.toml: same `metrics-util` dev-dependency addition as hedge/outlier above.

Test: one `#[cfg(feature = "metrics")]` test proving `reconnect_transitions_total` and
`reconnect_attempts_total` are recorded, using the `DebuggingRecorder` template. There is no
existing test file that drives a full `ReconnectService` through a failing-then-succeeding
factory in `service.rs` -- check `tests/` in this crate for a harness to reuse, or build a minimal
one with a `tower::service_fn`-based factory that fails once then succeeds (see `ReconnectConfig`'s
own doctest examples for the shape of constructing a factory-backed reconnect service).

### 5. `executor` -- metrics + tracing

File: `crates/tower-resilience-executor/src/service.rs` (`ExecutorService::call` and
`ExecutorFuture::poll`). No name/config concept exists in this crate at all -- emit unlabeled
metrics, same as reconnect.

In `call()`, right where `self.executor.spawn(...)` happens:
```rust
#[cfg(feature = "metrics")]
let spawn_start = std::time::Instant::now();

#[cfg(feature = "tracing")]
tracing::debug!("Task spawned");

#[cfg(feature = "metrics")]
metrics::counter!("executor_tasks_spawned_total").increment(1);
```
Then inside the spawned async block, right before `let _ = tx.send(...)`:
```rust
#[cfg(feature = "metrics")]
metrics::histogram!("executor_task_duration_seconds").record(spawn_start.elapsed().as_secs_f64());
```
(You'll need to move the `Instant::now()` capture before the closure and move it into the closure
along with `tx`/`service`/`req` -- same capture pattern already used for `tx`/`service`.)

In `ExecutorFuture::poll`, the `Poll::Ready(Err(_))` arm (oneshot recv error -> `TaskCancelled`):
```rust
#[cfg(feature = "metrics")]
metrics::counter!("executor_tasks_cancelled_total").increment(1);

#[cfg(feature = "tracing")]
tracing::warn!("Executor task cancelled (spawned task dropped its sender)");
```

Cargo.toml: same `metrics-util` dev-dependency addition as the others above.

Test: one `#[cfg(feature = "metrics")]` test proving `executor_tasks_spawned_total` and
`executor_task_duration_seconds` are recorded, using the `DebuggingRecorder` template, driving one
call through an `ExecutorLayer::current()`-built service with a `tower::service_fn` inner.

### 6. `adaptive` -- metrics + tracing (service.rs ONLY -- see concurrency warning above)

File: `crates/tower-resilience-adaptive/src/service.rs` ONLY. Do not touch `algorithm.rs` or
`layer.rs`. No name/algorithm-type label -- emit unlabeled metrics (this crate has no instance
identity or algorithm-name accessor reachable without touching the files you're avoiding).

In the free function `sync_limit<A>`, inside the two branches that already exist
(`if limit > state.desired_limit { ... } else if limit < state.desired_limit { ... }`), add at the
end of each branch (after the existing semaphore adjustment logic, still inside the branch so you
have the right direction):
```rust
#[cfg(feature = "metrics")]
{
    metrics::counter!("adaptive_limit_changes_total", "direction" => "increase").increment(1);
    metrics::gauge!("adaptive_limit").set(limit as f64);
}
#[cfg(feature = "tracing")]
tracing::debug!(old_limit = state.desired_limit, new_limit = limit, direction = "increase", "Adaptive concurrency limit changed");
```
(swap `"increase"`/`increase` for `"decrease"`/`decrease` in the second branch; capture
`state.desired_limit` into a local before you overwrite `state.desired_limit = limit;` at the end
of the function, since the tracing/metrics blocks need the OLD value and must run before that
final assignment -- or just read `state.desired_limit` before it's mutated, whichever is easiest
given the existing code order).

In `Service::call`'s returned future, where `let latency = start.elapsed();` is computed
(unconditionally, before the `match &result { Ok(_) => ..., Err(_) => ... }` branch) add right
after that line:
```rust
#[cfg(feature = "metrics")]
metrics::histogram!("adaptive_rtt_seconds").record(latency.as_secs_f64());
```
(unlabeled, recorded for both success and failure outcomes, matching how `circuitbreaker`'s
`circuitbreaker_call_duration_seconds` histogram blends both outcomes into one series -- do not
add an outcome label here, keep it consistent with that existing precedent.)

Cargo.toml: same `metrics-util` dev-dependency addition as the others above.

Test: one `#[cfg(feature = "metrics")]` test in `service.rs`'s existing `#[cfg(test)] mod tests`
proving `adaptive_limit_changes_total` and `adaptive_rtt_seconds` are recorded, using the
`DebuggingRecorder` template. The existing `test_service_basic`/`test_in_flight_tracking` tests in
this file show the harness shape (an `Aimd` algorithm + a `tower::service_fn` inner) -- drive
enough successful calls that the AIMD algorithm actually increases the limit at least once (check
`Aimd`'s `record_success`/latency_threshold semantics in `algorithm.rs`, read-only, to pick
parameters that guarantee a limit change without needing to edit that file).

## Docs to update

- `crates/tower-resilience/src/observability.rs`: in the `metrics` module doc, remove the sentence
  "`adaptive`, `executor`, `hedge`, `outlier`, and `reconnect` accept the `metrics` Cargo feature
  (it compiles cleanly) but do not yet emit any metrics of their own." and instead add each of
  the six crates' new metric names to the "Available Metrics by Pattern" list (one new `###`
  subsection per crate, alphabetically placed, matching the existing format exactly -- see the
  `### Circuit Breaker` section for the template). In the `tracing_guide` module doc, similarly
  update if it currently implies these six patterns have no tracing (check current wording before
  editing).
- `README.md` around line 101-111: update the sentence listing which patterns emit metrics/tracing
  today. After this PR, ALL patterns with a `metrics`/`tracing` feature actually emit
  metrics/tracing (only `healthcheck`'s `tracing` feature remains a documented placeholder per its
  own Cargo.toml comment -- verify that's still true and leave it as the one exception). Rewrite
  the paragraph to reflect that, and drop the "(they compile cleanly) but do not yet instrument
  any calls; see #428" clause since #428 is what closes that gap.
- Each of the six crates' `CHANGELOG.md` (`crates/tower-resilience-{adaptive,executor,hedge,outlier,
  reconnect,bulkhead}/CHANGELOG.md`): add one line under `## [Unreleased]` / `### Added`
  (create that heading if the `[Unreleased]` section doesn't have an `### Added` subsection yet)
  describing the new metrics/tracing instrumentation for that specific crate, referencing #428.

## Tool-call discipline

Setup steps (already done for you -- branch exists, do not redo them) aside, do not batch
independent multi-file edits into one giant parallel tool-call burst per crate; work crate by
crate, verify each crate compiles (`cargo check -p tower-resilience-<crate> --all-features`)
before moving to the next. If a tool call returns `<tool_use_error>Cancelled: parallel tool call
Bash(...) errored</tool_use_error>`, do not retry blindly or issue "flush" echo commands -- read
the actual failing call and fix or continue past it.

If a write (Edit/Write tool) is blocked by a permission/approval gate, STOP immediately and report
the exact gate message. Do NOT attempt mechanical bypasses.

## Steps

1. Work through the six crates in this order: `bulkhead`, `outlier`, `hedge`, `reconnect`,
   `executor`, `adaptive` (simplest/lowest-risk first). After each crate, run
   `cargo test -p tower-resilience-<crate> --all-features` and `cargo clippy -p
   tower-resilience-<crate> --all-targets --all-features -- -D warnings` and fix anything before
   moving on.
2. Update `crates/tower-resilience/src/observability.rs` and `README.md` as described above.
3. Update all six `CHANGELOG.md` files as described above.
4. Run, in order, and fix anything before proceeding:
   - `cargo fmt --all -- --check`
   - `cargo clippy --workspace --all-targets --all-features -- -D warnings`
   - `cargo test --lib --workspace --all-features`
   - `cargo test --doc --workspace --all-features`
5. If all green: `git add` the files you touched (do not `git add -A`) and commit. Conventional
   commit message:
   ```
   feat(observability): implement metrics/tracing for adaptive, executor, hedge, outlier, reconnect, bulkhead

   Closes #428
   ```
   You may split into more than one commit per crate if that reads more clearly in `git log`; all
   commits on this branch will be squashed at merge, so the exact commit boundaries don't matter,
   but each individual commit should leave the workspace compiling (don't leave a broken
   intermediate commit as the last one).
6. Print `git log --oneline` (full branch history since `main`), `git diff main --stat`, and the
   branch name.

## Scope-reduction fallback

If mid-session you judge the full six-crate scope will not fit in one reviewable, working PR:
STOP after completing a coherent subset (`bulkhead` + `outlier` + `hedge` is the natural first
cut -- they already have event systems and/or name fields; `reconnect` + `executor` + `adaptive`
is the natural second cut). Leave the workspace compiling and all tests green for whatever subset
you completed. In your final summary, state clearly which crates you completed and which remain,
so the runner can file a follow-up issue for the rest with `gh issue create` (do not create that
issue yourself -- report back and let the runner handle it).

## Constraints

- Do NOT push (the runner pushes after you finish).
- Do NOT amend existing commits.
- Do NOT create a new branch or touch `main`.
- Do NOT run `gh pr create`, `gh pr ready`, or `gh pr merge` (the runner owns the PR lifecycle).
- Do NOT touch `crates/tower-resilience-adaptive/src/algorithm.rs`,
  `crates/tower-resilience-adaptive/src/layer.rs`, or `crates/tower-resilience-outlier/src/config.rs`.
- Do NOT add fields or methods to any `config.rs`, `layer.rs`, or builder type in any of the six
  crates.
- Do NOT modify the existing metrics blocks already present in `bulkhead/src/service.rs` -- only
  add tracing next to them.
- Do NOT rename or remove any existing metric name in any already-instrumented crate.
