### PR TITLE
fix: update #428's tests for #431's fallible builder API

### DIFF
--- a/crates/tower-resilience-adaptive/src/service.rs
+++ b/crates/tower-resilience-adaptive/src/service.rs
@@ -403,7 +403,8 @@ mod tests {
             .initial_limit(10)
             .increase_by(1)
             .latency_threshold(Duration::from_secs(1))
-            .build();
+            .build()
+            .unwrap();
         let mut service = AdaptiveService::new(service, Arc::new(algorithm));
 
         use tower::ServiceExt;

--- a/crates/tower-resilience-bulkhead/src/service.rs
+++ b/crates/tower-resilience-bulkhead/src/service.rs
@@ -616,7 +616,8 @@ mod tests {
         // semaphore forces `call()` down the immediate-rejection branch.
         let (layer, handle) = BulkheadLayer::builder()
             .max_concurrent_calls(1)
-            .build_with_handle();
+            .build_with_handle()
+            .unwrap();
         let mut service = layer.layer(service_fn(|()| async { Ok::<_, Infallible>(()) }));
         handle.semaphore.close();
 


### PR DESCRIPTION
## Context

Main is currently broken. #428 (metrics/tracing instrumentation for adaptive,
executor, hedge, outlier, reconnect, bulkhead) and #431 (construction-time
validation for adaptive/bulkhead/outlier) were developed concurrently on
separate branches. #431 merged to main first; #428's CI had already run
(and passed) against a slightly earlier `main` before #431 landed. #428's
squash-merge then landed cleanly (no textual conflict), but #431's changes
to `Aimd::builder().build()` and `BulkheadLayer::builder().build_with_handle()`
-- both now return `Result` instead of the previous infallible values --
broke two of #428's *new* tests, which predated that API change.

## Fix

Add the missing `.unwrap()` to both new tests, matching every other call
site in the same files (which #431 already updated).

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --lib --workspace --all-features` (all green)

No other files touched.