### PR TITLE
refactor(outlier)!: de-box Service::Future as a proof for #426

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2792,9 +2792,9 @@ dependencies = [
 name = "tower-resilience-outlier"
 version = "0.12.0"
 dependencies = [
- "futures",
  "metrics",
  "metrics-util",
+ "pin-project-lite",
  "thiserror 2.0.17",
  "tokio",
  "tower",

--- a/crates/tower-resilience-outlier/CHANGELOG.md
+++ b/crates/tower-resilience-outlier/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** `OutlierDetectionService::Future` is now a named,
+  `pin_project!`-based `OutlierDetectionFuture<F, C>` instead of
+  `BoxFuture<'static, Result<...>>`. This removes one `Box::pin` heap
+  allocation per call and, as a direct consequence, drops the `S: Send +
+  'static`, `S::Future: Send + 'static`, `Req: Send + 'static`, and `C:
+  Send + 'static` bounds from the `Service` impl -- only `S: Service<Req>
+  + Clone` and `C: FailureClassifier<S::Response, S::Error> + Clone` are
+  required now. Code that names the concrete future type (rare; most
+  callers only `.await` it) needs to update to the new type. See
+  `docs/tower-api-surface-audit.md` for the allocation-count evidence and
+  the crate-by-crate follow-up plan (#426).
+
 ### Added
 
 - `OutlierDetectionService::get_ref()`, `get_mut()`, and `into_inner()`
@@ -23,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Drop an unused non-dev `tokio` dependency; nothing in the crate's
   library code used it (the only `tokio::` references were in test code,
   already covered by the dev-dependency).
+- Drop the `futures` dependency; no longer needed now that
+  `Service::Future` is not `BoxFuture`-based.
 
 ## [0.12.0](https://github.com/joshrotenberg/tower-resilience/compare/tower-resilience-outlier-v0.11.0...tower-resilience-outlier-v0.12.0) - 2026-08-17
 

--- a/crates/tower-resilience-outlier/Cargo.toml
+++ b/crates/tower-resilience-outlier/Cargo.toml
@@ -16,7 +16,7 @@ tower-resilience-core = { workspace = true }
 tower = { workspace = true }
 tower-layer = { workspace = true }
 tower-service = { workspace = true }
-futures = { workspace = true }
+pin-project-lite = { workspace = true }
 thiserror = { workspace = true }
 
 # Optional dependencies

--- a/crates/tower-resilience-outlier/src/lib.rs
+++ b/crates/tower-resilience-outlier/src/lib.rs
@@ -85,6 +85,6 @@ pub use detector::OutlierDetector;
 pub use error::{OutlierDetectionError, OutlierDetectionServiceError};
 pub use events::OutlierDetectionEvent;
 pub use layer::OutlierDetectionLayer;
-pub use service::OutlierDetectionService;
+pub use service::{OutlierDetectionFuture, OutlierDetectionService};
 pub use strategy::{ConsecutiveErrors, EjectionStrategy};
 pub use tower_resilience_core::classifier::{DefaultClassifier, FailureClassifier, FnClassifier};

--- a/crates/tower-resilience-outlier/src/service.rs
+++ b/crates/tower-resilience-outlier/src/service.rs
@@ -1,8 +1,11 @@
 //! Tower Service implementation for outlier detection.
 
 use crate::config::OutlierDetectionConfig;
+use crate::detector::OutlierDetector;
 use crate::error::{OutlierDetectionError, OutlierDetectionServiceError};
-use futures::future::BoxFuture;
+use pin_project_lite::pin_project;
+use std::future::Future;
+use std::pin::Pin;
 use std::task::{Context, Poll};
 use tower::Service;
 use tower_resilience_core::classifier::FailureClassifier;
@@ -66,16 +69,12 @@ impl<S: Clone, C: Clone> Clone for OutlierDetectionService<S, C> {
 
 impl<S, C, Request> Service<Request> for OutlierDetectionService<S, C>
 where
-    S: Service<Request> + Clone + Send + 'static,
-    S::Future: Send + 'static,
-    S::Response: Send + 'static,
-    S::Error: Send + 'static,
-    C: FailureClassifier<S::Response, S::Error> + Clone + Send + 'static,
-    Request: Send + 'static,
+    S: Service<Request> + Clone,
+    C: FailureClassifier<S::Response, S::Error> + Clone,
 {
     type Response = S::Response;
     type Error = OutlierDetectionServiceError<S::Error>;
-    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+    type Future = OutlierDetectionFuture<S::Future, C>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         // In backpressure mode, return Pending when ejected
@@ -103,32 +102,85 @@ where
 
         // In error mode, check ejection in call()
         if !backpressure && detector.is_ejected(&instance_name) {
-            return Box::pin(async move {
-                Err(OutlierDetectionServiceError::OutlierDetection(
-                    OutlierDetectionError::Ejected {
-                        name: instance_name,
-                    },
-                ))
-            });
+            return OutlierDetectionFuture::Rejected {
+                name: Some(instance_name),
+            };
         }
 
         let clone = self.inner.clone();
         let mut inner = std::mem::replace(&mut self.inner, clone);
 
-        Box::pin(async move {
-            let result = inner.call(request).await;
+        OutlierDetectionFuture::Called {
+            future: inner.call(request),
+            instance_name,
+            detector,
+            classifier,
+        }
+    }
+}
 
-            // Classify the result
-            let is_failure = classifier.classify(&result);
+pin_project! {
+    #[project = OutlierDetectionFutureProj]
+    /// Future returned by [`OutlierDetectionService::call`].
+    ///
+    /// Wraps the inner service's future directly (no heap allocation) with
+    /// one exception: error mode's pre-ejected path, which is a plain
+    /// already-computed result and needs no inner future at all.
+    pub enum OutlierDetectionFuture<F, C> {
+        /// Error mode already determined the instance is ejected in `call()`;
+        /// there is no inner future to drive.
+        Rejected {
+            name: Option<String>,
+        },
+        /// The inner future is being driven; its result is classified and
+        /// recorded against the shared detector when it completes.
+        Called {
+            #[pin]
+            future: F,
+            instance_name: String,
+            detector: OutlierDetector,
+            classifier: C,
+        },
+    }
+}
 
-            if is_failure {
-                detector.record_failure(&instance_name);
-            } else {
-                detector.record_success(&instance_name);
+impl<F, C, Res, E> Future for OutlierDetectionFuture<F, C>
+where
+    F: Future<Output = Result<Res, E>>,
+    C: FailureClassifier<Res, E>,
+{
+    type Output = Result<Res, OutlierDetectionServiceError<E>>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.project() {
+            OutlierDetectionFutureProj::Rejected { name } => {
+                let name = name
+                    .take()
+                    .expect("OutlierDetectionFuture polled after completion");
+                Poll::Ready(Err(OutlierDetectionServiceError::OutlierDetection(
+                    OutlierDetectionError::Ejected { name },
+                )))
             }
+            OutlierDetectionFutureProj::Called {
+                future,
+                instance_name,
+                detector,
+                classifier,
+            } => match future.poll(cx) {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(result) => {
+                    let is_failure = classifier.classify(&result);
 
-            result.map_err(OutlierDetectionServiceError::Inner)
-        })
+                    if is_failure {
+                        detector.record_failure(instance_name);
+                    } else {
+                        detector.record_success(instance_name);
+                    }
+
+                    Poll::Ready(result.map_err(OutlierDetectionServiceError::Inner))
+                }
+            },
+        }
     }
 }
 

--- a/crates/tower-resilience-outlier/src/service.rs
+++ b/crates/tower-resilience-outlier/src/service.rs
@@ -13,8 +13,7 @@ use tower_resilience_core::classifier::FailureClassifier;
 /// A Tower Service that applies outlier detection to an inner service.
 ///
 /// This wraps a single backend instance. The shared
-/// [`OutlierDetector`](crate::OutlierDetector) coordinates ejection state
-/// across all instances.
+/// [`OutlierDetector`] coordinates ejection state across all instances.
 ///
 /// # Backpressure vs Error Mode
 ///

--- a/docs/tower-api-surface-audit.md
+++ b/docs/tower-api-surface-audit.md
@@ -31,7 +31,7 @@ workspace depends on).
 | executor | Named (`ExecutorFuture`) | Yes | Pre-existing (only crate that already had the full triad before this PR) | `tokio::runtime::Handle` (pluggable `Executor` trait, not hardwired) |
 | fallback | `BoxFuture` (both `Fallback` and `ServiceFallback`) | Yes | Added in this PR (`ServiceFallback` exposes the primary only -- see [below](#the-servicefallback-primary-only-accessor)) | none beyond `#[tokio::test]`; `ServiceFallback`'s shared backup uses `futures::lock::Mutex`, not Tokio's |
 | hedge | `BoxFuture` | Yes | Added in this PR | `tokio::time::sleep` (hedge delay) |
-| outlier | `BoxFuture` | Yes | Added in this PR | None -- had an unused non-dev `tokio` dependency, removed in this PR (see [below](#three-crates-had-an-unused-non-dev-tokio-dependency)) |
+| outlier | Named (`OutlierDetectionFuture`) -- de-boxed in #426 | No -- see [below](#de-boxing-prototype-outlier-426) | Added in the #376 PR | None -- had an unused non-dev `tokio` dependency, removed in the #376 PR (see [below](#three-crates-had-an-unused-non-dev-tokio-dependency)) |
 | ratelimiter | `BoxFuture` | Yes | Added in this PR | `tokio::time::Sleep` (backpressure mode) |
 | reconnect | Named (`ReconnectFuture`) | No -- see [below](#reconnect-and-router-no-single-inner-service) | Not applicable -- see [below](#reconnect-and-router-no-single-inner-service) | `tokio::time::Sleep` (reconnect backoff) |
 | retry | `BoxFuture` | Yes | Added in this PR | `tokio::time::sleep` (backoff delay) |
@@ -43,13 +43,13 @@ not a `tower::Service`), matching the contract matrix.
 
 ## Boxing and trait bounds
 
-10 of the 15 `Service`-implementing crates (`bulkhead`, `cache`, `chaos`,
-`circuitbreaker` x2, `fallback` x2, `hedge`, `outlier`, `ratelimiter`,
-`retry`, `timelimiter`) set `type Future = BoxFuture<'static, Result<...>>`
+9 of the 15 `Service`-implementing crates (`bulkhead`, `cache`, `chaos`,
+`circuitbreaker` x2, `fallback` x2, `hedge`, `ratelimiter`, `retry`,
+`timelimiter`) set `type Future = BoxFuture<'static, Result<...>>`
 (`futures::future::BoxFuture`, i.e. `Pin<Box<dyn Future<Output = ...> +
 Send>>`). Boxing a trait object requires the boxed future to be `Send +
 'static`, and Rust's type system propagates that requirement outward to
-every type that future is built from -- which is why every one of those ten
+every type that future is built from -- which is why every one of those nine
 crates' `Service` impl also requires `S: Send + 'static`, `S::Future: Send +
 'static`, `Req: Send + 'static`, and usually `S::Response`/`S::Error: Send +
 'static` too. For example (`crates/tower-resilience-ratelimiter/src/lib.rs`):
@@ -91,28 +91,34 @@ S, Request>` state machine with three states (`Called`/`Waiting`/`Retrying`)
 -- compare to this crate's `tower-resilience-retry::Retry`, whose bound set
 above is a direct consequence of `BoxFuture`.
 
-Four crates already avoid this: `adaptive` (`AdaptiveFuture`), `coalesce`
-(`CoalesceFuture`), `executor` (`ExecutorFuture`), and `reconnect`
+Five crates already avoid this: `adaptive` (`AdaptiveFuture`), `coalesce`
+(`CoalesceFuture`), `executor` (`ExecutorFuture`), `outlier`
+(`OutlierDetectionFuture`, de-boxed in #426 -- see
+[below](#de-boxing-prototype-outlier-426)), and `reconnect`
 (`ReconnectFuture`) each hand-write a named future type via `pin_project!`
 or manual `Future` impls, matching Tower's own approach. `router` goes
 further and doesn't wrap the future at all (`type Future = S::Future`),
 identical in shape to `tower::limit::rate::RateLimit`.
 
-### Is de-boxing the other ten crates an "avoidable restriction"?
+### Is de-boxing the other nine crates an "avoidable restriction"?
 
-Given the above, `Send + 'static` on `S`/`Req` in the ten `BoxFuture` crates
-is a direct, mechanical consequence of the boxing choice, not an
-independently-chosen restriction -- so it is not something that can be
-"removed" in isolation; removing it requires removing the boxing itself.
-Doing that properly (a hand-written `pin_project!` state machine per crate,
-each with its own poll-loop shape -- rejection vs backpressure branching,
-sliding-window/circuit-state interaction, cache-store locking, and so on) is
-a substantial, per-crate redesign with real correctness risk (the four
-crates that already do this run a meaningfully larger state machine than a
-`Box::pin(async move { ... })` body). That is a bigger, riskier change than
-belongs in this PR, which is scoped to auditing plus the genuinely
-zero-risk fixes (accessors, below). #426 tracks de-boxing as future work,
-crate by crate, starting with whichever crate's call-path is simplest.
+Given the above, `Send + 'static` on `S`/`Req` in the nine remaining
+`BoxFuture` crates is a direct, mechanical consequence of the boxing
+choice, not an independently-chosen restriction -- so it is not something
+that can be "removed" in isolation; removing it requires removing the
+boxing itself. Doing that properly (a hand-written `pin_project!` state
+machine per crate, each with its own poll-loop shape -- rejection vs
+backpressure branching, sliding-window/circuit-state interaction,
+cache-store locking, and so on) is a substantial, per-crate redesign with
+real correctness risk for some of the nine (see the
+[difficulty assessment](#remaining-crates-difficulty-and-recommendation)
+below) -- which is why the original #376 PR scoped itself to auditing plus
+the genuinely zero-risk fixes (accessors, below) and left this as follow-up
+work. #426 explored that follow-up: it de-boxed `outlier` as a proof of the
+pattern (the crate whose `call()` had the fewest branches and no internal
+timer/lock state) and assessed the rest -- some are worth doing next, two
+are probably not worth it on their own. See
+[below](#de-boxing-prototype-outlier-426) for both.
 
 ### Bounds driven by spawning, not boxing
 
@@ -273,3 +279,72 @@ implement, so none are flagged as restrictions to remove.
 future types) crate by crate, as a follow-up to this audit -- mirroring how
 #372's construction-time-validation audit scoped its first fix to
 `circuitbreaker` (#417) and tracked the rest in #422.
+
+### De-boxing prototype: `outlier` (#426)
+
+`outlier` was chosen as the first de-boxing candidate: its `call()` has
+exactly one branch point (error mode's pre-ejected immediate-error path
+versus the normal wrapped-inner-future path) and no internal timer, lock, or
+multi-attempt state, so it needed only a two-variant `pin_project!` enum
+(`OutlierDetectionFuture<F, C>` in
+`crates/tower-resilience-outlier/src/service.rs`) rather than a bespoke
+poll-loop. The `Service` impl's bound list dropped from `S: Send + 'static,
+S::Future: Send + 'static, S::Response: Send + 'static, S::Error: Send +
+'static, C: ... + Send + 'static, Request: Send + 'static` down to just `S:
+Service<Request> + Clone, C: FailureClassifier<S::Response, S::Error> +
+Clone` -- the same bound set `tower::limit::rate::RateLimit` and this
+workspace's other named-future crates carry.
+
+**Allocation evidence.** `tests/outlier_deboxing_allocation_evidence.rs`
+installs a counting `#[global_allocator]` in its own test binary (so it
+cannot affect any other test's allocator) and measures one `call()` on the
+de-boxed implementation against a byte-for-byte reconstruction of the
+pre-#426 `BoxFuture`-based implementation (same clone/classify/record work,
+differing only in `Box::pin` vs the named enum). Result, stable across five
+repeated runs: **1 allocation per call de-boxed, versus 2 boxed** -- exactly
+the `Box::pin` heap frame eliminated, with the remaining allocation being the
+`instance_name: String` clone both implementations pay identically. This is
+a small, real, per-call win, not a measurement artifact; the takeaway for
+the crates below is that the boxing removal itself is worth roughly one
+allocation per call, and the harder or riskier state-machine rewrites (which
+some of the remaining nine are) should be weighed against that -- not
+against some larger allocation-elimination number.
+
+### Remaining crates: difficulty and recommendation
+
+Assessed by reading each crate's `call()` body and existing state (not just
+the summary table above). Ordered roughly easiest to hardest:
+
+| Crate | Shape | Difficulty | Notes |
+| --- | --- | --- | --- |
+| `cache` | Two branches: cache hit (immediate `Ok(response)`, no inner future) vs. cache miss (wrap inner future, insert on completion). | Low | Structurally identical to `outlier`'s prototype -- a two-variant enum, no timers or locks held across `.await`. Good second candidate. |
+| `bulkhead` | Backpressure/non-backpressure entry, one wrapped inner future with a semaphore permit released on completion, plus a "not ready" immediate-error branch. | Low-medium | Same overall shape as `outlier` (permit bookkeeping is synchronous, not something the future itself has to drive across polls). |
+| `ratelimiter` | Backpressure mode wraps the inner future with permit/window bookkeeping; the harder admission decisions (token bucket, sliding window) already happen in `poll_ready`, not in the future. | Medium | Similar to `bulkhead` in shape; the existing `RateLimiterHandle` plumbing needs checking for anything that assumes a `'static` future. |
+| `timelimiter` | Two independent modes: `cancel_running_future` (default) can reuse `tokio::time::timeout()`'s own named `Timeout<F>` type directly with no new code; `detached` mode spawns and races a `oneshot::Receiver` against a `Sleep`, the same shape `executor`'s `ExecutorFuture` already has plus one extra field. | Medium | Two variants, both with local precedent already in this workspace (`tokio::time::Timeout`, `ExecutorFuture`). Not hard, just two future types instead of one. |
+| `chaos` | Sequential: optional injected latency (`tokio::time::sleep`) before calling inner, or immediate fault-injection error, or a direct pass-through. | Medium | A 2-3 variant enum with a `Sleep` field for the latency-injection case; no loops or shared locks. |
+| `retry` | Multi-attempt loop: call, evaluate policy, optionally sleep for backoff, call again, up to `max_attempts`. | Medium | Core Tower's own `tower::retry::Retry` (`tower-0.5.3/src/retry/mod.rs`) already solves this exact shape with a 3-state `pin_project!` enum (`Called`/`Waiting`/`Retrying`) that this crate's version could mirror closely -- a proven template lowers the risk relative to its apparent complexity. |
+| `fallback` (`Fallback` and `ServiceFallback`) | Two-phase sequential: await primary, and on a fallback-triggering result, await backup. `ServiceFallback`'s backup is behind `Arc<Mutex<B>>` (`futures::lock::Mutex`, itself poll-based), so the backup phase is its own nested lock-then-call sub-state-machine. | Medium-high | `Fallback`'s value/closure backup path is simpler (no second service future to project, no lock). `ServiceFallback` is harder because the async-mutex-guarded backup call needs its own state (acquire lock, then poll the locked service's future) layered inside the outer Primary/Backup enum. |
+| `circuitbreaker` (`CircuitBreaker` and `CircuitBreakerWithFallback`) | Already the most complex `call()` in the workspace even in its current boxed form: a `tokio::sync::Mutex` for circuit state, a `tokio::sync::Semaphore` for half-open admission, and an `Option<Pin<Box<tokio::time::Sleep>>>` for backpressure mode, combined per-call. | High | The crate already hand-manages a boxed `Sleep` internally, which is a signal of real state-machine complexity, not just future-wrapping. `CircuitBreakerWithFallback` adds a second service future on top. This is the crate the original #376 audit explicitly called out as carrying the most correctness risk, and that assessment holds. |
+| `hedge` | Races up to `max_hedged_attempts` inner-service calls concurrently via `FuturesUnordered` + `tokio::select!` against per-attempt delays, cancelling losers when a winner completes. | High | A hand-rolled equivalent needs to reimplement `FuturesUnordered`'s poll-many-and-remove-completed behavior manually, or restrict itself to a small `SmallVec`/array of `Option<Pin<&mut F>>` slots polled in a fixed-size loop (which pin-projects awkwardly for a runtime-determined `max_hedged_attempts`). Racing an unbounded set of heterogeneous futures without a heap-allocated collection is the least precedented shape in this workspace. |
+
+**Recommendation:** `cache` and `bulkhead` are the next two candidates --
+same low-risk shape as this PR's `outlier` prototype, each worth its own PR
+per the per-crate-PR discipline above. `chaos`, `timelimiter`, and
+`ratelimiter` are reasonable medium-difficulty follow-ups once the pattern
+is well-worn. `retry` is medium risk but has a direct upstream template to
+mirror (`tower::retry::Retry`), which is worth leaning on rather than
+inventing a new shape.
+
+`circuitbreaker` and `hedge` are the two crates most likely **not** worth
+de-boxing on their own merits: both already carry meaningfully more
+per-call state-machine complexity than a `Box::pin` removal saves (roughly
+one allocation, per the measurement above), and `circuitbreaker` in
+particular is under active, carefully-scoped work already (#372, #417,
+#422) where introducing a hand-written poll loop is a correctness risk this
+audit is not positioned to take on. If either is revisited, it should be
+its own dedicated design effort weighing the one-allocation-per-call win
+against the state-machine rewrite risk explicitly, not bundled into the
+mechanical "de-box the next crate" pattern this table otherwise describes.
+`fallback`'s `ServiceFallback` sits in between -- worth attempting after the
+low-risk crates are done, but should budget for the nested lock-then-call
+sub-state-machine, not just a plain enum.

--- a/tests/outlier_deboxing_allocation_evidence.rs
+++ b/tests/outlier_deboxing_allocation_evidence.rs
@@ -1,0 +1,150 @@
+//! Allocation-count evidence for #426.
+//!
+//! `tower-resilience-outlier` was de-boxed from `Service::Future =
+//! BoxFuture<'static, Result<...>>` to a hand-written, `pin_project!`-based
+//! `OutlierDetectionFuture<F, C>` enum (see `crates/tower-resilience-outlier/
+//! src/service.rs`). This binary is a standalone integration test (its own
+//! process, so installing a custom `#[global_allocator]` here cannot affect
+//! any other test binary) that counts heap allocations for one `call()` on
+//! the de-boxed implementation versus a byte-for-byte reconstruction of the
+//! pre-#426 `BoxFuture`-based implementation, to give a real number for the
+//! tradeoff documented in `docs/tower-api-surface-audit.md`.
+//!
+//! Both implementations do the identical amount of "real" work per call
+//! (clone the instance name, clone the shared detector handle, drive the
+//! inner future, classify and record the result), so the measured
+//! allocation delta isolates the cost of the `Box::pin` heap allocation
+//! itself.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::task::{Context, Poll};
+
+use tower::{Layer, Service, ServiceExt};
+use tower_resilience_outlier::{
+    DefaultClassifier, FailureClassifier, OutlierDetectionLayer, OutlierDetectionServiceError,
+    OutlierDetector,
+};
+
+static ALLOC_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+struct CountingAllocator;
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+/// A reconstruction of `OutlierDetectionService`'s pre-#426 `Service` impl:
+/// the same clone/classify/record logic, but with `Self::Future` boxed via
+/// `Box::pin` the way every one of #426's other nine candidate crates still
+/// does. Kept local to this test since the real crate no longer contains it.
+#[derive(Clone)]
+struct BoxedOutlierLike<S, C> {
+    inner: S,
+    detector: OutlierDetector,
+    instance_name: String,
+    classifier: C,
+}
+
+impl<S, C, Request> Service<Request> for BoxedOutlierLike<S, C>
+where
+    S: Service<Request> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Response: Send + 'static,
+    S::Error: Send + 'static,
+    C: FailureClassifier<S::Response, S::Error> + Clone + Send + 'static,
+    Request: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = OutlierDetectionServiceError<S::Error>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner
+            .poll_ready(cx)
+            .map_err(OutlierDetectionServiceError::Inner)
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let instance_name = self.instance_name.clone();
+        let detector = self.detector.clone();
+        let classifier = self.classifier.clone();
+
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+
+        Box::pin(async move {
+            let result = inner.call(request).await;
+
+            let is_failure = classifier.classify(&result);
+            if is_failure {
+                detector.record_failure(&instance_name);
+            } else {
+                detector.record_success(&instance_name);
+            }
+
+            result.map_err(OutlierDetectionServiceError::Inner)
+        })
+    }
+}
+
+#[tokio::test]
+async fn deboxing_reduces_per_call_heap_allocations() {
+    // De-boxed (current) implementation.
+    let detector = OutlierDetector::new();
+    detector.register("backend", 5);
+    let mut deboxed = OutlierDetectionLayer::builder()
+        .detector(detector)
+        .instance_name("backend")
+        .build()
+        .unwrap()
+        .layer(tower::service_fn(|req: u32| async move {
+            Ok::<u32, std::io::Error>(req)
+        }));
+
+    // Warm up so any one-time allocator/executor setup doesn't pollute the
+    // measured count.
+    let _ = deboxed.ready().await.unwrap().call(0).await;
+
+    let before = ALLOC_COUNT.load(Ordering::Relaxed);
+    let _ = deboxed.ready().await.unwrap().call(1).await;
+    let deboxed_allocs = ALLOC_COUNT.load(Ordering::Relaxed) - before;
+
+    // Pre-#426 BoxFuture-based equivalent.
+    let boxed_detector = OutlierDetector::new();
+    boxed_detector.register("backend", 5);
+    let mut boxed = BoxedOutlierLike {
+        inner: tower::service_fn(|req: u32| async move { Ok::<u32, std::io::Error>(req) }),
+        detector: boxed_detector,
+        instance_name: "backend".to_string(),
+        classifier: DefaultClassifier,
+    };
+
+    let _ = boxed.ready().await.unwrap().call(0).await;
+
+    let before = ALLOC_COUNT.load(Ordering::Relaxed);
+    let _ = boxed.ready().await.unwrap().call(1).await;
+    let boxed_allocs = ALLOC_COUNT.load(Ordering::Relaxed) - before;
+
+    println!("de-boxed per-call allocations:        {deboxed_allocs}");
+    println!("boxed-equivalent per-call allocations: {boxed_allocs}");
+
+    assert!(
+        deboxed_allocs < boxed_allocs,
+        "expected the de-boxed implementation to allocate fewer times per \
+         call than the BoxFuture-based equivalent; de-boxed={deboxed_allocs}, \
+         boxed={boxed_allocs}"
+    );
+}


### PR DESCRIPTION
## Summary

#426 asks for an exploration of de-boxing `Service::Future` (`BoxFuture` ->
a named, `pin_project!`-based future type) for the 10 crates flagged in
`docs/tower-api-surface-audit.md` (added in #376's PR, #424), starting with
whichever crate's call-path is simplest.

This PR:

1. De-boxes `tower-resilience-outlier` as the prototype -- its `call()` has
   the fewest branches (one: error-mode pre-ejection) and no internal
   timer/lock/multi-attempt state, so it needed only a two-variant
   `pin_project!` enum (`OutlierDetectionFuture<F, C>`) rather than a
   bespoke poll loop.
2. Adds an allocation-counting integration test
   (`tests/outlier_deboxing_allocation_evidence.rs`) that installs a
   counting `#[global_allocator]` in its own test binary and measures the
   win directly against a byte-for-byte reconstruction of the pre-#426
   `BoxFuture`-based implementation: **1 allocation per call de-boxed vs 2
   boxed**, stable across repeated runs.
3. Updates `docs/tower-api-surface-audit.md` with the prototype's evidence
   and a per-crate difficulty assessment for the remaining nine
   `BoxFuture` crates, with a recommendation: `cache` and `bulkhead` are
   good next candidates (same low-risk shape); `chaos`, `timelimiter`,
   `ratelimiter`, and `retry` are reasonable medium-difficulty follow-ups
   (`retry` has a direct upstream template to mirror,
   `tower::retry::Retry`); `circuitbreaker` and `hedge` are probably **not**
   worth de-boxing on their own merits -- both carry meaningfully more
   state-machine complexity than the roughly-one-allocation-per-call win
   justifies, and `circuitbreaker` is under separate active work already
   (#372, #417, #422).

## Semver

**Breaking, but narrow.** `OutlierDetectionService<S, C>::Future`'s
concrete type changes from `BoxFuture<'static, Result<...>>` to
`OutlierDetectionFuture<S::Future, C>`. Code that only calls `.await` on
the future (the overwhelming majority of usage) is unaffected. Code that
names the concrete future type in a signature needs to update. As a direct
consequence of removing the boxing, the `Service` impl's bounds loosen:
`S: Send + 'static`, `S::Future: Send + 'static`, `Req: Send + 'static`,
and `C: ... + Send + 'static` are no longer required -- only `S:
Service<Request> + Clone` and `C: FailureClassifier<S::Response,
S::Error> + Clone`. This is documented in the crate's CHANGELOG under a
`Breaking` bullet.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features` (full workspace, all crates green)
- [x] New allocation-evidence test run 5x for stability (`1` vs `2`
      allocations every time)

Closes #426