### PR TITLE
fix(ratelimiter): validate configuration at construction time (closes #434)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2810,6 +2810,7 @@ version = "0.12.0"
 dependencies = [
  "futures",
  "metrics",
+ "thiserror 2.0.17",
  "tokio",
  "tower",
  "tower-resilience-core",

--- a/benches/comprehensive_benchmarks.rs
+++ b/benches/comprehensive_benchmarks.rs
@@ -310,7 +310,8 @@ fn bench_rate_limiter_exhausted(c: &mut Criterion) {
                 .limit_for_period(1) // Very limited
                 .refresh_period(Duration::from_secs(60)) // Long refresh
                 .timeout_duration(Duration::from_millis(1)) // Short timeout
-                .build();
+                .build()
+                .unwrap();
 
             let mut service = layer.layer(BaselineService);
 
@@ -491,7 +492,8 @@ fn bench_full_stack_composition(c: &mut Criterion) {
             let rl_layer = RateLimiterLayer::builder()
                 .limit_for_period(1000)
                 .refresh_period(Duration::from_secs(1))
-                .build();
+                .build()
+                .unwrap();
 
             let tl_layer = TimeLimiterLayer::builder()
                 .timeout_duration(Duration::from_secs(30))

--- a/benches/happy_path_overhead.rs
+++ b/benches/happy_path_overhead.rs
@@ -183,7 +183,8 @@ fn bench_rate_limiter(c: &mut Criterion) {
             let layer = RateLimiterLayer::builder()
                 .limit_for_period(1000)
                 .refresh_period(Duration::from_secs(1))
-                .build();
+                .build()
+                .unwrap();
             let mut service = layer.layer(BaselineService);
 
             let response = service

--- a/crates/tower-resilience-ratelimiter/Cargo.toml
+++ b/crates/tower-resilience-ratelimiter/Cargo.toml
@@ -16,6 +16,7 @@ tower-resilience-core = { workspace = true }
 tower = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true }
+thiserror = { workspace = true }
 
 # Optional dependencies
 metrics = { workspace = true, optional = true }

--- a/crates/tower-resilience-ratelimiter/examples/ratelimiter_example.rs
+++ b/crates/tower-resilience-ratelimiter/examples/ratelimiter_example.rs
@@ -59,7 +59,8 @@ async fn demo_fixed_window() {
         .on_permit_rejected(move |_| {
             r.fetch_add(1, Ordering::SeqCst);
         })
-        .build();
+        .build()
+        .unwrap();
 
     let service = tower::service_fn(|_req: ()| async { Ok::<_, std::convert::Infallible>("OK") });
     let mut svc = ServiceBuilder::new().layer(layer).service(service);
@@ -101,7 +102,8 @@ async fn demo_sliding_log() {
         .on_permit_rejected(move |_| {
             r.fetch_add(1, Ordering::SeqCst);
         })
-        .build();
+        .build()
+        .unwrap();
 
     let service = tower::service_fn(|_req: ()| async { Ok::<_, std::convert::Infallible>("OK") });
     let mut svc = ServiceBuilder::new().layer(layer).service(service);
@@ -143,7 +145,8 @@ async fn demo_sliding_counter() {
         .on_permit_rejected(move |_| {
             r.fetch_add(1, Ordering::SeqCst);
         })
-        .build();
+        .build()
+        .unwrap();
 
     let service = tower::service_fn(|_req: ()| async { Ok::<_, std::convert::Infallible>("OK") });
     let mut svc = ServiceBuilder::new().layer(layer).service(service);
@@ -178,7 +181,8 @@ async fn demo_boundary_comparison() {
             .refresh_period(Duration::from_millis(200))
             .timeout_duration(Duration::from_millis(10))
             .window_type(WindowType::Fixed)
-            .build();
+            .build()
+            .unwrap();
 
         let service = tower::service_fn(move |_req: ()| {
             c.fetch_add(1, Ordering::SeqCst);
@@ -220,7 +224,8 @@ async fn demo_boundary_comparison() {
             .refresh_period(Duration::from_millis(200))
             .timeout_duration(Duration::from_millis(10))
             .window_type(WindowType::SlidingLog)
-            .build();
+            .build()
+            .unwrap();
 
         let service = tower::service_fn(move |_req: ()| {
             c.fetch_add(1, Ordering::SeqCst);

--- a/crates/tower-resilience-ratelimiter/src/config.rs
+++ b/crates/tower-resilience-ratelimiter/src/config.rs
@@ -167,7 +167,8 @@ impl RateLimiterConfigBuilder {
     ///     .limit_for_period(100)
     ///     .refresh_period(Duration::from_secs(1))
     ///     .backpressure()
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn backpressure(mut self) -> Self {
         self.backpressure = true;
@@ -196,7 +197,8 @@ impl RateLimiterConfigBuilder {
     ///     .limit_for_period(100)
     ///     .refresh_period(Duration::from_secs(1))
     ///     .window_type(WindowType::SlidingLog)
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn window_type(mut self, window_type: WindowType) -> Self {
         self.window_type = window_type;
@@ -243,7 +245,8 @@ impl RateLimiterConfigBuilder {
     ///             println!("Permit immediately available");
     ///         }
     ///     })
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn on_permit_acquired<F>(mut self, f: F) -> Self
     where
@@ -283,7 +286,8 @@ impl RateLimiterConfigBuilder {
     ///         let count = counter.fetch_add(1, Ordering::SeqCst);
     ///         println!("Request rejected after {:?} timeout (total: {})", timeout, count + 1);
     ///     })
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn on_permit_rejected<F>(mut self, f: F) -> Self
     where
@@ -321,7 +325,8 @@ impl RateLimiterConfigBuilder {
     ///     .on_permits_refreshed(|available| {
     ///         println!("Rate limiter refreshed: {} permits now available", available);
     ///     })
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn on_permits_refreshed<F>(mut self, f: F) -> Self
     where
@@ -339,15 +344,28 @@ impl RateLimiterConfigBuilder {
     }
 
     /// Builds the rate limiter layer.
-    pub fn build(self) -> crate::RateLimiterLayer {
-        let config = self.into_config();
-        crate::RateLimiterLayer::new(config)
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RateLimiterConfigError::ZeroLimitForPeriod`] if
+    /// `limit_for_period` is zero, [`RateLimiterConfigError::ZeroRefreshPeriod`]
+    /// if `refresh_period` is zero, or
+    /// [`RateLimiterConfigError::BurstCapacityOverflow`] if
+    /// `limit_for_period + burst_size` overflows `usize`.
+    pub fn build(self) -> Result<crate::RateLimiterLayer, RateLimiterConfigError> {
+        let config = self.into_config()?;
+        Ok(crate::RateLimiterLayer::new(config))
     }
 
     /// Builds the rate limiter layer and returns an observable handle.
     ///
     /// All services produced by the returned layer share the same rate limiter
     /// state, and the handle can observe that state from outside the service.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RateLimiterConfigError`] under the same conditions as
+    /// [`build`](Self::build).
     ///
     /// # Example
     ///
@@ -356,12 +374,15 @@ impl RateLimiterConfigBuilder {
     ///
     /// let (layer, handle) = RateLimiterLayer::builder()
     ///     .limit_for_period(100)
-    ///     .build_with_handle();
+    ///     .build_with_handle()
+    ///     .unwrap();
     ///
     /// assert_eq!(handle.available_permits(), 100);
     /// ```
-    pub fn build_with_handle(self) -> (crate::RateLimiterLayer, crate::RateLimiterHandle) {
-        let config = self.into_config();
+    pub fn build_with_handle(
+        self,
+    ) -> Result<(crate::RateLimiterLayer, crate::RateLimiterHandle), RateLimiterConfigError> {
+        let config = self.into_config()?;
 
         let limiter = crate::limiter::SharedRateLimiter::new(
             config.window_type,
@@ -383,25 +404,26 @@ impl RateLimiterConfigBuilder {
             shared_limiter: Some(limiter),
         };
 
-        (layer, handle)
+        Ok((layer, handle))
     }
 
-    fn into_config(self) -> RateLimiterConfig {
-        assert!(
-            self.limit_for_period > 0,
-            "limit_for_period must be greater than zero"
-        );
-        assert!(
-            !self.refresh_period.is_zero(),
-            "refresh_period must be greater than zero"
-        );
+    fn into_config(self) -> Result<RateLimiterConfig, RateLimiterConfigError> {
+        if self.limit_for_period == 0 {
+            return Err(RateLimiterConfigError::ZeroLimitForPeriod);
+        }
+        if self.refresh_period.is_zero() {
+            return Err(RateLimiterConfigError::ZeroRefreshPeriod);
+        }
         if let Some(burst_size) = self.burst_size {
-            self.limit_for_period
-                .checked_add(burst_size)
-                .expect("limit_for_period + burst_size must not overflow");
+            self.limit_for_period.checked_add(burst_size).ok_or(
+                RateLimiterConfigError::BurstCapacityOverflow {
+                    limit_for_period: self.limit_for_period,
+                    burst_size,
+                },
+            )?;
         }
 
-        RateLimiterConfig {
+        Ok(RateLimiterConfig {
             limit_for_period: self.limit_for_period,
             refresh_period: self.refresh_period,
             timeout_duration: self.timeout_duration,
@@ -410,8 +432,31 @@ impl RateLimiterConfigBuilder {
             backpressure: self.backpressure,
             event_listeners: self.event_listeners,
             name: self.name,
-        }
+        })
     }
+}
+
+/// Errors that can occur when validating a [`RateLimiterConfig`] at
+/// construction time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum RateLimiterConfigError {
+    /// `limit_for_period` is zero, which would create a rate limiter that
+    /// never admits any request.
+    #[error("limit_for_period must be greater than zero")]
+    ZeroLimitForPeriod,
+    /// `refresh_period` is zero, which would create a rate limiter with no
+    /// meaningful refresh interval.
+    #[error("refresh_period must be greater than zero")]
+    ZeroRefreshPeriod,
+    /// `limit_for_period + burst_size` overflows `usize`.
+    #[error("limit_for_period ({limit_for_period}) + burst_size ({burst_size}) overflows usize")]
+    BurstCapacityOverflow {
+        /// The configured `limit_for_period`.
+        limit_for_period: usize,
+        /// The configured `burst_size`.
+        burst_size: usize,
+    },
 }
 
 #[cfg(test)]
@@ -421,7 +466,7 @@ mod tests {
 
     #[test]
     fn test_builder_defaults() {
-        let _layer = RateLimiterLayer::builder().build();
+        let _layer = RateLimiterLayer::builder().build().unwrap();
         // If this compiles and doesn't panic, the builder works
     }
 
@@ -432,7 +477,8 @@ mod tests {
             .refresh_period(Duration::from_secs(2))
             .timeout_duration(Duration::from_millis(500))
             .name("test-limiter")
-            .build();
+            .build()
+            .unwrap();
         // If this compiles and doesn't panic, the builder works
     }
 
@@ -441,23 +487,26 @@ mod tests {
         let _layer = RateLimiterLayer::builder()
             .on_permit_acquired(|_| {})
             .on_permit_rejected(|_| {})
-            .build();
+            .build()
+            .unwrap();
         // If this compiles and doesn't panic, the event listener registration works
     }
 
     #[test]
     fn test_preset_per_second() {
-        let _layer = RateLimiterLayer::per_second(100).build();
+        let _layer = RateLimiterLayer::per_second(100).build().unwrap();
     }
 
     #[test]
     fn test_preset_per_minute() {
-        let _layer = RateLimiterLayer::per_minute(1000).build();
+        let _layer = RateLimiterLayer::per_minute(1000).build().unwrap();
     }
 
     #[test]
     fn test_preset_burst() {
-        let (layer, handle) = RateLimiterLayer::burst(100, 50).build_with_handle();
+        let (layer, handle) = RateLimiterLayer::burst(100, 50)
+            .build_with_handle()
+            .unwrap();
         assert_eq!(layer.config.burst_size, Some(50));
         assert_eq!(handle.limit_for_period(), 100);
         assert_eq!(handle.burst_size(), 50);
@@ -466,23 +515,90 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "limit_for_period must be greater than zero")]
     fn test_zero_limit_is_rejected_at_build() {
-        let _ = RateLimiterLayer::builder().limit_for_period(0).build();
+        let result = RateLimiterLayer::builder().limit_for_period(0).build();
+        assert_eq!(
+            result.err(),
+            Some(RateLimiterConfigError::ZeroLimitForPeriod)
+        );
     }
 
     #[test]
-    #[should_panic(expected = "refresh_period must be greater than zero")]
     fn test_zero_refresh_period_is_rejected_at_build() {
-        let _ = RateLimiterLayer::builder()
+        let result = RateLimiterLayer::builder()
             .refresh_period(Duration::ZERO)
             .build();
+        assert_eq!(
+            result.err(),
+            Some(RateLimiterConfigError::ZeroRefreshPeriod)
+        );
     }
 
     #[test]
-    #[should_panic(expected = "limit_for_period + burst_size must not overflow")]
     fn test_overflowing_burst_capacity_is_rejected_at_build() {
-        let _ = RateLimiterLayer::burst(usize::MAX, 1).build();
+        let result = RateLimiterLayer::burst(usize::MAX, 1).build();
+        assert_eq!(
+            result.err(),
+            Some(RateLimiterConfigError::BurstCapacityOverflow {
+                limit_for_period: usize::MAX,
+                burst_size: 1,
+            })
+        );
+    }
+
+    /// Table-driven: the smallest valid `limit_for_period` and a handful of
+    /// larger values must all be accepted.
+    #[test]
+    fn nonzero_limit_for_period_is_accepted() {
+        for limit in [1, 2, 10, 1000] {
+            let result = RateLimiterLayer::builder().limit_for_period(limit).build();
+            assert!(
+                result.is_ok(),
+                "limit_for_period {limit} should be accepted"
+            );
+        }
+    }
+
+    /// Table-driven: the smallest valid `refresh_period` and a handful of
+    /// larger values must all be accepted.
+    #[test]
+    fn nonzero_refresh_period_is_accepted() {
+        for millis in [1, 10, 1000, 60_000] {
+            let result = RateLimiterLayer::builder()
+                .refresh_period(Duration::from_millis(millis))
+                .build();
+            assert!(
+                result.is_ok(),
+                "refresh_period {millis}ms should be accepted"
+            );
+        }
+    }
+
+    /// Table-driven: burst sizes that keep `limit_for_period + burst_size`
+    /// within `usize` bounds must all be accepted, including zero.
+    #[test]
+    fn non_overflowing_burst_capacity_is_accepted() {
+        for (limit, burst) in [(1, 0), (100, 50), (usize::MAX - 1, 1), (usize::MAX, 0)] {
+            let result = RateLimiterLayer::builder()
+                .limit_for_period(limit)
+                .burst_size(burst)
+                .build();
+            assert!(
+                result.is_ok(),
+                "limit_for_period {limit} + burst_size {burst} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn zero_limit_is_rejected_at_build_with_handle() {
+        let result = RateLimiterLayer::builder()
+            .limit_for_period(0)
+            .build_with_handle();
+        assert_eq!(
+            result.err(),
+            Some(RateLimiterConfigError::ZeroLimitForPeriod)
+        );
     }
 
     #[test]
@@ -491,6 +607,7 @@ mod tests {
         let _layer = RateLimiterLayer::per_second(100)
             .timeout_duration(Duration::from_secs(2))
             .name("custom")
-            .build();
+            .build()
+            .unwrap();
     }
 }

--- a/crates/tower-resilience-ratelimiter/src/handle.rs
+++ b/crates/tower-resilience-ratelimiter/src/handle.rs
@@ -18,7 +18,8 @@ use std::sync::Arc;
 ///
 /// let (layer, handle) = RateLimiterLayer::builder()
 ///     .limit_for_period(100)
-///     .build_with_handle();
+///     .build_with_handle()
+///     .unwrap();
 ///
 /// // Apply the layer to a service...
 ///
@@ -109,7 +110,8 @@ mod tests {
     async fn test_handle_initial_state() {
         let (_layer, handle) = RateLimiterLayer::builder()
             .limit_for_period(10)
-            .build_with_handle();
+            .build_with_handle()
+            .unwrap();
 
         assert_eq!(handle.available_permits(), 10);
         assert!(!handle.is_throttling());
@@ -121,7 +123,8 @@ mod tests {
     async fn test_handle_observes_permit_usage() {
         let (layer, handle) = RateLimiterLayer::builder()
             .limit_for_period(3)
-            .build_with_handle();
+            .build_with_handle()
+            .unwrap();
 
         let mut svc = layer.layer(OkService);
 
@@ -138,7 +141,8 @@ mod tests {
     async fn test_handle_shared_across_services() {
         let (layer, handle) = RateLimiterLayer::builder()
             .limit_for_period(4)
-            .build_with_handle();
+            .build_with_handle()
+            .unwrap();
 
         let mut svc1 = layer.layer(OkService);
         let mut svc2 = layer.layer(OkService);
@@ -154,7 +158,8 @@ mod tests {
     async fn test_handle_clone() {
         let (_layer, handle) = RateLimiterLayer::builder()
             .limit_for_period(10)
-            .build_with_handle();
+            .build_with_handle()
+            .unwrap();
 
         let handle2 = handle.clone();
         assert_eq!(handle.available_permits(), handle2.available_permits());

--- a/crates/tower-resilience-ratelimiter/src/layer.rs
+++ b/crates/tower-resilience-ratelimiter/src/layer.rs
@@ -20,7 +20,8 @@ use tower::Layer;
 ///     .limit_for_period(100)
 ///     .refresh_period(Duration::from_secs(1))
 ///     .timeout_duration(Duration::from_millis(100))
-///     .build();
+///     .build()
+///     .unwrap();
 ///
 /// let service = ServiceBuilder::new()
 ///     .layer(rate_limiter)
@@ -57,7 +58,8 @@ impl RateLimiterLayer {
     /// let layer = RateLimiterLayer::builder()
     ///     .limit_for_period(100)
     ///     .refresh_period(Duration::from_secs(1))
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn builder() -> crate::RateLimiterConfigBuilder {
         crate::RateLimiterConfigBuilder::new()
@@ -79,12 +81,13 @@ impl RateLimiterLayer {
     /// use tower_resilience_ratelimiter::RateLimiterLayer;
     ///
     /// // Allow 100 requests per second
-    /// let layer = RateLimiterLayer::per_second(100).build();
+    /// let layer = RateLimiterLayer::per_second(100).build().unwrap();
     ///
     /// // Customize further
     /// let layer = RateLimiterLayer::per_second(100)
     ///     .timeout_duration(std::time::Duration::from_millis(500))
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn per_second(limit: usize) -> crate::RateLimiterConfigBuilder {
         use std::time::Duration;
@@ -106,7 +109,7 @@ impl RateLimiterLayer {
     /// use tower_resilience_ratelimiter::RateLimiterLayer;
     ///
     /// // Allow 1000 requests per minute
-    /// let layer = RateLimiterLayer::per_minute(1000).build();
+    /// let layer = RateLimiterLayer::per_minute(1000).build().unwrap();
     /// ```
     pub fn per_minute(limit: usize) -> crate::RateLimiterConfigBuilder {
         use std::time::Duration;
@@ -135,7 +138,7 @@ impl RateLimiterLayer {
     /// use tower_resilience_ratelimiter::RateLimiterLayer;
     ///
     /// // Allow 100 requests/sec sustained with burst up to 150
-    /// let layer = RateLimiterLayer::burst(100, 50).build();
+    /// let layer = RateLimiterLayer::burst(100, 50).build().unwrap();
     /// ```
     pub fn burst(rate_per_second: usize, burst_size: usize) -> crate::RateLimiterConfigBuilder {
         use std::time::Duration;

--- a/crates/tower-resilience-ratelimiter/src/lib.rs
+++ b/crates/tower-resilience-ratelimiter/src/lib.rs
@@ -48,7 +48,7 @@
 //!     .on_permit_rejected(|timeout| {
 //!         println!("Rate limited! Timeout: {:?}", timeout);
 //!     })
-//!     .build();
+//!     .build()?;
 //!
 //! // Apply to a service
 //! let service = ServiceBuilder::new()
@@ -77,7 +77,7 @@
 //!     .refresh_period(Duration::from_secs(1))
 //!     .window_type(WindowType::SlidingLog)
 //!     .timeout_duration(Duration::from_millis(500))
-//!     .build();
+//!     .build()?;
 //!
 //! let service = ServiceBuilder::new()
 //!     .layer(rate_limiter)
@@ -104,7 +104,7 @@
 //!     .refresh_period(Duration::from_secs(1))
 //!     .window_type(WindowType::SlidingCounter)
 //!     .timeout_duration(Duration::from_millis(100))
-//!     .build();
+//!     .build()?;
 //!
 //! let service = ServiceBuilder::new()
 //!     .layer(rate_limiter)
@@ -131,7 +131,7 @@
 //!     .limit_for_period(10)
 //!     .refresh_period(Duration::from_secs(1))
 //!     .timeout_duration(Duration::from_millis(100))
-//!     .build();
+//!     .build()?;
 //!
 //! let mut service = ServiceBuilder::new()
 //!     .layer(rate_limiter)
@@ -165,7 +165,7 @@
 //!     .limit_for_period(10)
 //!     .refresh_period(Duration::from_secs(1))
 //!     .timeout_duration(Duration::from_millis(50))
-//!     .build();
+//!     .build()?;
 //!
 //! let mut service = ServiceBuilder::new()
 //!     .layer(rate_limiter)
@@ -198,7 +198,7 @@
 //!     .limit_for_period(100)
 //!     .refresh_period(Duration::from_secs(1))
 //!     .timeout_duration(Duration::from_millis(10)) // Short timeout = fast rejection
-//!     .build();
+//!     .build()?;
 //!
 //! let mut service = ServiceBuilder::new()
 //!     .layer(rate_limiter)
@@ -222,7 +222,7 @@ mod handle;
 mod layer;
 mod limiter;
 
-pub use config::{RateLimiterConfig, RateLimiterConfigBuilder, WindowType};
+pub use config::{RateLimiterConfig, RateLimiterConfigBuilder, RateLimiterConfigError, WindowType};
 pub use error::{RateLimiterError, RateLimiterServiceError};
 pub use events::RateLimiterEvent;
 pub use handle::RateLimiterHandle;
@@ -529,7 +529,8 @@ mod tests {
         let layer = RateLimiterLayer::builder()
             .limit_for_period(10)
             .refresh_period(Duration::from_secs(1))
-            .build();
+            .build()
+            .unwrap();
         let mut limiter = layer.layer(service_fn(|_: String| async {
             Ok::<_, std::io::Error>(())
         }));
@@ -556,7 +557,8 @@ mod tests {
             .limit_for_period(10)
             .refresh_period(Duration::from_secs(1))
             .timeout_duration(Duration::from_millis(100))
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = layer.layer(service);
 
@@ -584,7 +586,8 @@ mod tests {
             .limit_for_period(2)
             .refresh_period(Duration::from_secs(10))
             .timeout_duration(Duration::from_millis(10))
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = layer.layer(service);
 
@@ -630,7 +633,8 @@ mod tests {
             .limit_for_period(2)
             .refresh_period(Duration::from_millis(100))
             .timeout_duration(Duration::from_millis(200))
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = layer.layer(service);
 
@@ -685,7 +689,8 @@ mod tests {
             .on_permit_rejected(move |_| {
                 rc.fetch_add(1, Ordering::SeqCst);
             })
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = layer.layer(service);
 
@@ -707,7 +712,8 @@ mod tests {
             .limit_for_period(1)
             .refresh_period(Duration::from_millis(50))
             .timeout_duration(Duration::from_millis(100)) // Can wait through one refresh
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = layer.layer(service);
 
@@ -748,7 +754,8 @@ mod tests {
             .limit_for_period(10)
             .refresh_period(Duration::from_secs(1))
             .backpressure()
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = layer.layer(service);
 
@@ -774,7 +781,8 @@ mod tests {
             .limit_for_period(1)
             .refresh_period(Duration::from_millis(50))
             .backpressure()
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = layer.layer(service);
 
@@ -805,7 +813,8 @@ mod tests {
             .limit_for_period(1)
             .refresh_period(Duration::from_millis(50))
             .backpressure()
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = layer.layer(service);
 
@@ -837,7 +846,8 @@ mod tests {
             .on_permit_rejected(move |_| {
                 rc.fetch_add(1, Ordering::SeqCst);
             })
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = layer.layer(service);
 
@@ -859,7 +869,8 @@ mod tests {
             .refresh_period(Duration::from_millis(50))
             .window_type(WindowType::SlidingLog)
             .backpressure()
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = layer.layer(service);
 
@@ -879,7 +890,8 @@ mod tests {
             .refresh_period(Duration::from_millis(50))
             .window_type(WindowType::SlidingCounter)
             .backpressure()
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = layer.layer(service);
 
@@ -912,6 +924,7 @@ mod tests {
                 .timeout_duration(Duration::from_secs(5))
                 .window_type(window_type)
                 .build()
+                .unwrap()
                 .layer(inner);
             let barrier = Arc::new(Barrier::new(CALLERS + 1));
             let started_at = tokio::time::Instant::now();

--- a/crates/tower-resilience-ratelimiter/tests/contract.rs
+++ b/crates/tower-resilience-ratelimiter/tests/contract.rs
@@ -13,7 +13,8 @@ async fn ratelimiter_rejection_drives_readied_instance() {
     let layer = RateLimiterLayer::builder()
         .limit_for_period(1000)
         .refresh_period(Duration::from_secs(1))
-        .build();
+        .build()
+        .unwrap();
     let mut svc = tower::ServiceBuilder::new()
         .layer(layer)
         .service(StatefulInner::new());
@@ -29,7 +30,8 @@ async fn ratelimiter_backpressure_drives_readied_instance() {
         .limit_for_period(1000)
         .refresh_period(Duration::from_secs(1))
         .backpressure()
-        .build();
+        .build()
+        .unwrap();
     let mut svc = tower::ServiceBuilder::new()
         .layer(layer)
         .service(StatefulInner::new());
@@ -45,7 +47,8 @@ async fn ratelimiter_rejection_composes_with_concurrency_limit() {
     let layer = RateLimiterLayer::builder()
         .limit_for_period(1000)
         .refresh_period(Duration::from_secs(1))
-        .build();
+        .build()
+        .unwrap();
     let mut svc = tower::ServiceBuilder::new().layer(layer).service(inner);
 
     for _ in 0..3 {
@@ -60,7 +63,8 @@ async fn ratelimiter_backpressure_composes_with_concurrency_limit() {
         .limit_for_period(1000)
         .refresh_period(Duration::from_secs(1))
         .backpressure()
-        .build();
+        .build()
+        .unwrap();
     let mut svc = tower::ServiceBuilder::new().layer(layer).service(inner);
 
     for _ in 0..3 {

--- a/crates/tower-resilience-ratelimiter/tests/upstream_sliding_window_parity.rs
+++ b/crates/tower-resilience-ratelimiter/tests/upstream_sliding_window_parity.rs
@@ -31,6 +31,7 @@ fn immediate_layer(window_type: WindowType, limit: usize, period: Duration) -> R
         .timeout_duration(Duration::ZERO)
         .window_type(window_type)
         .build()
+        .unwrap()
 }
 
 /// tower-rs/tower#842 opens with this exact scenario as the motivating case

--- a/crates/tower-resilience/src/lib.rs
+++ b/crates/tower-resilience/src/lib.rs
@@ -55,7 +55,7 @@
 //! let breaker = CircuitBreakerLayer::standard().build();
 //!
 //! // Rate limiter: 100 requests per second
-//! let limiter = RateLimiterLayer::per_second(100).build();
+//! let limiter = RateLimiterLayer::per_second(100).build().unwrap();
 //!
 //! // Bulkhead: 50 concurrent calls
 //! let bulkhead = BulkheadLayer::medium().build();

--- a/crates/tower-resilience/src/patterns.rs
+++ b/crates/tower-resilience/src/patterns.rs
@@ -1505,7 +1505,8 @@ pub mod rate_limiter {
     //!     .limit_for_period(100)                    // 100 requests
     //!     .refresh_period(Duration::from_secs(1))   // per second
     //!     .timeout_duration(Duration::from_millis(100))  // Wait up to 100ms
-    //!     .build();
+    //!     .build()
+    //!     .unwrap();
     //!
     //! let service = tower::ServiceBuilder::new()
     //!     .layer(rate_limiter)

--- a/examples/observability_metrics.rs
+++ b/examples/observability_metrics.rs
@@ -295,6 +295,7 @@ async fn demo_rate_limiter() {
         .refresh_period(Duration::from_secs(1))
         .timeout_duration(Duration::from_millis(50))
         .build()
+        .unwrap()
         .layer(base_service);
 
     let mut service = service;

--- a/examples/server_api.rs
+++ b/examples/server_api.rs
@@ -141,7 +141,8 @@ async fn scenario_rate_limiting() {
         .on_permit_rejected(|_wait_duration| {
             println!("[Rate Limiter] Request rejected - rate limit exceeded");
         })
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = rate_limiter.layer(base_service);
 

--- a/examples/tonic-resilient-greeter/src/server.rs
+++ b/examples/tonic-resilient-greeter/src/server.rs
@@ -82,7 +82,8 @@ fn build_pipeline() -> GreetPipeline {
                 retry_after
             )
         })
-        .build();
+        .build()
+        .expect("valid ratelimiter config");
 
     let service = ServiceBuilder::new()
         .layer(ratelimiter_layer)

--- a/tests/auto_traits.rs
+++ b/tests/auto_traits.rs
@@ -79,6 +79,7 @@ fn ratelimiter_is_send_sync() {
         .limit_for_period(100)
         .refresh_period(Duration::from_secs(1))
         .build()
+        .unwrap()
         .layer(SyncInner);
     assert_send_sync_static(&svc);
 }
@@ -91,6 +92,7 @@ fn ratelimiter_backpressure_is_send_sync() {
         .refresh_period(Duration::from_secs(1))
         .backpressure()
         .build()
+        .unwrap()
         .layer(SyncInner);
     assert_send_sync_static(&svc);
 }

--- a/tests/clone_in_call_contract.rs
+++ b/tests/clone_in_call_contract.rs
@@ -87,7 +87,8 @@ async fn ratelimiter_rejection_drives_readied_instance() {
     let layer = RateLimiterLayer::builder()
         .limit_for_period(1000)
         .refresh_period(Duration::from_secs(1))
-        .build();
+        .build()
+        .unwrap();
     let mut svc = tower::ServiceBuilder::new()
         .layer(layer)
         .service(StatefulInner::new());
@@ -105,7 +106,8 @@ async fn ratelimiter_backpressure_drives_readied_instance() {
         .limit_for_period(1000)
         .refresh_period(Duration::from_secs(1))
         .backpressure()
-        .build();
+        .build()
+        .unwrap();
     let mut svc = tower::ServiceBuilder::new()
         .layer(layer)
         .service(StatefulInner::new());

--- a/tests/composition_stacks/server_side.rs
+++ b/tests/composition_stacks/server_side.rs
@@ -62,7 +62,8 @@ async fn server_side_stack_compiles() {
     let rate_limiter = RateLimiterLayer::builder()
         .limit_for_period(1000)
         .refresh_period(Duration::from_secs(1))
-        .build();
+        .build()
+        .unwrap();
 
     let handler = mock_handler();
 
@@ -82,7 +83,8 @@ async fn rate_limiter_only_compiles() {
         .limit_for_period(100)
         .refresh_period(Duration::from_secs(1))
         .timeout_duration(Duration::from_millis(100)) // Wait up to 100ms for permit
-        .build();
+        .build()
+        .unwrap();
 
     let handler = mock_handler();
 

--- a/tests/metrics_regression/ratelimiter.rs
+++ b/tests/metrics_regression/ratelimiter.rs
@@ -16,7 +16,8 @@ async fn ratelimiter_metrics_exist() {
         .name("test_ratelimiter")
         .limit_for_period(10)
         .refresh_period(Duration::from_secs(1))
-        .build();
+        .build()
+        .unwrap();
 
     let service = tower::service_fn(|_: u64| async { Ok::<_, &'static str>("success") });
 
@@ -50,7 +51,8 @@ async fn ratelimiter_rejection_metrics() {
         .name("reject_ratelimiter")
         .limit_for_period(2)
         .refresh_period(Duration::from_secs(10))
-        .build();
+        .build()
+        .unwrap();
 
     let service = tower::service_fn(|_: u64| async { Ok::<_, &'static str>("success") });
 

--- a/tests/property/rate_limiter.rs
+++ b/tests/property/rate_limiter.rs
@@ -40,7 +40,8 @@ proptest! {
                 .refresh_period(Duration::from_secs(60)) // Long period so no refresh
                 .timeout_duration(Duration::from_millis(1))
                 .window_type(WindowType::Fixed)
-                .build();
+                .build()
+                .unwrap();
 
             let mut service = layer.layer(svc);
 
@@ -84,7 +85,8 @@ proptest! {
                 .refresh_period(Duration::from_secs(60))
                 .timeout_duration(Duration::from_millis(1))
                 .window_type(WindowType::SlidingLog)
-                .build();
+                .build()
+                .unwrap();
 
             let mut service = layer.layer(svc);
 
@@ -128,7 +130,8 @@ proptest! {
                 .refresh_period(Duration::from_secs(60))
                 .timeout_duration(Duration::from_millis(1))
                 .window_type(WindowType::SlidingCounter)
-                .build();
+                .build()
+                .unwrap();
 
             let mut service = layer.layer(svc);
 
@@ -178,7 +181,8 @@ proptest! {
                 .refresh_period(Duration::from_millis(50))
                 .timeout_duration(Duration::from_millis(1))
                 .window_type(window_type)
-                .build();
+                .build()
+                .unwrap();
 
             let mut service = layer.layer(svc);
 
@@ -233,7 +237,8 @@ proptest! {
                 .limit_for_period(limit)
                 .refresh_period(Duration::from_secs(60))
                 .timeout_duration(Duration::from_millis(10))
-                .build();
+                .build()
+                .unwrap();
 
             let service = layer.layer(svc);
 

--- a/tests/ratelimiter/fixed_window.rs
+++ b/tests/ratelimiter/fixed_window.rs
@@ -21,7 +21,8 @@ async fn fixed_window_allows_requests_within_limit() {
         .refresh_period(Duration::from_secs(1))
         .timeout_duration(Duration::from_millis(50))
         .window_type(WindowType::Fixed)
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -42,7 +43,8 @@ async fn fixed_window_rejects_over_limit() {
         .refresh_period(Duration::from_secs(10))
         .timeout_duration(Duration::from_millis(10))
         .window_type(WindowType::Fixed)
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -72,7 +74,8 @@ async fn fixed_window_refreshes_permits() {
         .refresh_period(Duration::from_millis(100))
         .timeout_duration(Duration::from_millis(50))
         .window_type(WindowType::Fixed)
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -110,7 +113,8 @@ async fn fixed_window_allows_burst_at_boundary() {
         .refresh_period(Duration::from_millis(100))
         .timeout_duration(Duration::from_millis(50))
         .window_type(WindowType::Fixed)
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -153,7 +157,8 @@ async fn fixed_window_event_listeners() {
         .on_permit_rejected(move |_| {
             rej.fetch_add(1, Ordering::SeqCst);
         })
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 

--- a/tests/ratelimiter/sliding_counter.rs
+++ b/tests/ratelimiter/sliding_counter.rs
@@ -21,7 +21,8 @@ async fn sliding_counter_allows_requests_within_limit() {
         .refresh_period(Duration::from_secs(1))
         .timeout_duration(Duration::from_millis(50))
         .window_type(WindowType::SlidingCounter)
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -42,7 +43,8 @@ async fn sliding_counter_rejects_over_limit() {
         .refresh_period(Duration::from_secs(10))
         .timeout_duration(Duration::from_millis(10))
         .window_type(WindowType::SlidingCounter)
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -73,7 +75,8 @@ async fn sliding_counter_weighted_decay() {
         .refresh_period(Duration::from_millis(100))
         .timeout_duration(Duration::from_millis(10))
         .window_type(WindowType::SlidingCounter)
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -114,7 +117,8 @@ async fn sliding_counter_smoother_than_fixed() {
         .refresh_period(Duration::from_millis(200))
         .timeout_duration(Duration::from_millis(10))
         .window_type(WindowType::SlidingCounter)
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -167,7 +171,8 @@ async fn sliding_counter_event_listeners() {
         .on_permit_rejected(move |_| {
             rej.fetch_add(1, Ordering::SeqCst);
         })
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -190,7 +195,8 @@ async fn sliding_counter_memory_efficiency() {
         .refresh_period(Duration::from_millis(100))
         .timeout_duration(Duration::from_millis(200))
         .window_type(WindowType::SlidingCounter)
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -223,7 +229,8 @@ async fn sliding_counter_concurrent_requests() {
         .refresh_period(Duration::from_secs(1))
         .timeout_duration(Duration::from_millis(100))
         .window_type(WindowType::SlidingCounter)
-        .build();
+        .build()
+        .unwrap();
 
     let service = layer.layer(svc);
 

--- a/tests/ratelimiter/sliding_log.rs
+++ b/tests/ratelimiter/sliding_log.rs
@@ -21,7 +21,8 @@ async fn sliding_log_allows_requests_within_limit() {
         .refresh_period(Duration::from_secs(1))
         .timeout_duration(Duration::from_millis(50))
         .window_type(WindowType::SlidingLog)
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -42,7 +43,8 @@ async fn sliding_log_rejects_over_limit() {
         .refresh_period(Duration::from_secs(10))
         .timeout_duration(Duration::from_millis(10))
         .window_type(WindowType::SlidingLog)
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -72,7 +74,8 @@ async fn sliding_log_expires_old_requests() {
         .refresh_period(Duration::from_millis(100))
         .timeout_duration(Duration::from_millis(50))
         .window_type(WindowType::SlidingLog)
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -111,7 +114,8 @@ async fn sliding_log_prevents_boundary_burst() {
         .refresh_period(Duration::from_millis(100))
         .timeout_duration(Duration::from_millis(10))
         .window_type(WindowType::SlidingLog)
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -156,7 +160,8 @@ async fn sliding_log_rolling_window_behavior() {
         .refresh_period(Duration::from_millis(100))
         .timeout_duration(Duration::from_millis(10))
         .window_type(WindowType::SlidingLog)
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -201,7 +206,8 @@ async fn sliding_log_event_listeners() {
         .on_permit_rejected(move |_| {
             rej.fetch_add(1, Ordering::SeqCst);
         })
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -229,7 +235,8 @@ async fn sliding_log_concurrent_requests() {
         .refresh_period(Duration::from_secs(1))
         .timeout_duration(Duration::from_millis(100))
         .window_type(WindowType::SlidingLog)
-        .build();
+        .build()
+        .unwrap();
 
     let service = layer.layer(svc);
 

--- a/tests/ratelimiter/window_comparison.rs
+++ b/tests/ratelimiter/window_comparison.rs
@@ -14,6 +14,7 @@ fn create_limiter(window_type: WindowType, limit: usize, period_ms: u64) -> Rate
         .timeout_duration(Duration::from_millis(10))
         .window_type(window_type)
         .build()
+        .unwrap()
 }
 
 #[tokio::test]
@@ -129,7 +130,8 @@ async fn default_is_fixed_window() {
         .refresh_period(Duration::from_millis(100))
         .timeout_duration(Duration::from_millis(10))
         // No .window_type() call - should default to Fixed
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -165,7 +167,8 @@ async fn window_type_can_be_changed() {
             .refresh_period(Duration::from_secs(1))
             .timeout_duration(Duration::from_millis(10))
             .window_type(window_type)
-            .build();
+            .build()
+            .unwrap();
 
         let mut service = layer.layer(svc);
 

--- a/tests/stress/ratelimiter.rs
+++ b/tests/stress/ratelimiter.rs
@@ -68,7 +68,8 @@ async fn stress_one_million_calls_no_throttling() {
         .limit_for_period(1_000_000) // Very high limit
         .refresh_period(Duration::from_secs(1))
         .timeout_duration(Duration::from_secs(1))
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -111,7 +112,8 @@ async fn stress_rate_limit_enforcement() {
         .limit_for_period(LIMIT)
         .refresh_period(Duration::from_secs(1))
         .timeout_duration(TIMEOUT) // Short timeout
-        .build();
+        .build()
+        .unwrap();
 
     let service = layer.layer(svc);
 
@@ -163,7 +165,8 @@ async fn stress_high_concurrency_rate_limited() {
         .limit_for_period(1000)
         .refresh_period(Duration::from_secs(1))
         .timeout_duration(Duration::from_secs(5))
-        .build();
+        .build()
+        .unwrap();
 
     let service = layer.layer(svc);
 
@@ -218,7 +221,8 @@ async fn stress_burst_traffic() {
         .limit_for_period(LIMIT)
         .refresh_period(REFRESH_PERIOD)
         .timeout_duration(Duration::from_millis(5))
-        .build();
+        .build()
+        .unwrap();
 
     let service = layer.layer(svc);
 
@@ -280,7 +284,8 @@ async fn stress_permit_refresh_timing() {
         .refresh_period(REFRESH_PERIOD)
         // Wide enough that no caller times out while waiting out refreshes.
         .timeout_duration(Duration::from_secs(2))
-        .build();
+        .build()
+        .unwrap();
 
     let service = layer.layer(svc);
 
@@ -320,7 +325,8 @@ async fn stress_memory_stability() {
         .limit_for_period(1000)
         .refresh_period(Duration::from_millis(100))
         .timeout_duration(Duration::from_millis(50))
-        .build();
+        .build()
+        .unwrap();
 
     let mut service = layer.layer(svc);
 
@@ -381,7 +387,8 @@ async fn stress_timeout_behavior() {
         .limit_for_period(LIMIT)
         .refresh_period(Duration::from_secs(1))
         .timeout_duration(TIMEOUT) // Very short timeout
-        .build();
+        .build()
+        .unwrap();
 
     let service = layer.layer(svc);
 
@@ -423,7 +430,8 @@ async fn stress_multiple_rate_limiters() {
             .limit_for_period(limit)
             .refresh_period(Duration::from_millis(100))
             .timeout_duration(Duration::from_millis(50))
-            .build();
+            .build()
+            .unwrap();
 
         layer.layer(svc)
     };

--- a/tests/unified_errors.rs
+++ b/tests/unified_errors.rs
@@ -148,7 +148,8 @@ async fn test_three_layers_stacked() {
         RateLimiterLayer::builder()
             .limit_for_period(1000)
             .refresh_period(Duration::from_secs(1))
-            .build(),
+            .build()
+            .unwrap(),
     );
     let bulkhead = ResilienceErrorLayer::<_, AppError>::new(
         BulkheadLayer::builder()


### PR DESCRIPTION
Closes #434.

## Summary

Follow-up to #422 (PR #431), covering the deferred `tower-resilience-ratelimiter`
crate. Converts `RateLimiterConfigBuilder::into_config`'s `assert!`/`.expect()`
panics into a typed, non-exhaustive `thiserror::Error` enum, following the
`CircuitBreakerConfigError` / `BulkheadConfigError` pattern from PR #417 / #431.

### `RateLimiterConfigError`

```rust
#[non_exhaustive]
pub enum RateLimiterConfigError {
    ZeroLimitForPeriod,
    ZeroRefreshPeriod,
    BurstCapacityOverflow { limit_for_period: usize, burst_size: usize },
}
```

`RateLimiterConfigBuilder::build()` and `build_with_handle()` now return
`Result<_, RateLimiterConfigError>` instead of the bare layer/handle. This is
a breaking API change, consistent with the precedent set by the circuit
breaker, bulkhead, Vegas, and outlier-detection builders.

## Plan

1. Add `RateLimiterConfigError` alongside `into_config()` in
   `crates/tower-resilience-ratelimiter/src/config.rs`, with table-driven
   boundary tests colocated with the enum.
2. Change `build()` / `build_with_handle()` signatures to return `Result`.
3. Sweep every workspace call site (crate-internal tests/doctests, top-level
   integration tests including `tests/upstream_sliding_window_parity.rs`,
   `examples/`, `benches/`, and the `tower-resilience` facade crate) to handle
   the new `Result`, guided by `cargo check`/`cargo test --doc`, not regex.
4. Verify with `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`,
   and `cargo test --workspace`.

## Out of scope

`tower-resilience-retry`'s backoff multiplier validation is explicitly excluded
per #434 (tracked separately).
