### PR TITLE
docs(examples): validate Apalis worker integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "apalis"
+version = "1.0.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7780d1e7082500a4fdb463b0a6fc1c00e4012cd9b2af101c26fcabbb2f390f2c"
+dependencies = [
+ "apalis-core",
+ "pin-project",
+ "thiserror 2.0.17",
+ "tower",
+]
+
+[[package]]
+name = "apalis-core"
+version = "1.0.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "797af42a40f6bc297365f2fed187b74d089c63641f57ce2a5e0f629db560cb47"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "pin-project",
+ "thiserror 2.0.17",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "apalis-resilient-worker"
+version = "0.1.0"
+dependencies = [
+ "apalis",
+ "tokio",
+ "tower-resilience-adaptive",
+ "tower-resilience-bulkhead",
+ "tower-resilience-circuitbreaker",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,7 +580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1627,7 +1666,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1869,7 +1908,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1926,7 +1965,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2286,7 +2325,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3190,7 +3229,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ members = [
     "crates/tower-resilience-outlier",
     "crates/tower-resilience-router",
     "crates/tower-resilience",
+    "examples/apalis-resilient-worker",
     "examples/axum-resilient-kv-store",
     "examples/tonic-resilient-greeter",
 ]

--- a/examples/apalis-resilient-worker/Cargo.toml
+++ b/examples/apalis-resilient-worker/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "apalis-resilient-worker"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+apalis = { version = "=1.0.0-rc.9", default-features = false }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tower-resilience-adaptive = { path = "../../crates/tower-resilience-adaptive" }
+tower-resilience-bulkhead = { path = "../../crates/tower-resilience-bulkhead" }
+tower-resilience-circuitbreaker = { path = "../../crates/tower-resilience-circuitbreaker" }

--- a/examples/apalis-resilient-worker/README.md
+++ b/examples/apalis-resilient-worker/README.md
@@ -1,0 +1,72 @@
+# Resilient Apalis workers
+
+This example verifies that `tower-resilience` layers compose directly with an
+[Apalis](https://apalis.dev/) 1.0 release-candidate worker. It runs three
+finite, asserted scenarios against Apalis's in-memory backend:
+
+- circuit-breaker backpressure pauses job intake while the circuit is open,
+  then permits a half-open recovery call;
+- a bulkhead caps concurrently spawned jobs without rejecting queued work;
+- an AIMD adaptive limiter raises and lowers its concurrency limit from real
+  job outcomes.
+
+Run it with:
+
+```console
+cargo run -p apalis-resilient-worker
+```
+
+## Why the layers are attached to `WorkerBuilder`
+
+Apalis already accepts Tower layers, so the integration point is its
+`WorkerBuilder::layer` method. The layer sees Apalis's full `Task` request even
+though the handler continues to receive the ergonomic job arguments.
+
+Apalis task functions use a boxed dynamic service error. Bulkhead and adaptive
+currently need the outer `map_err` adapter shown in the example because their
+generic wrapper errors cannot convert back into that boxed type. This is
+tracked in [#443](https://github.com/joshrotenberg/tower-resilience/issues/443);
+the adapter intentionally makes the current integration executable, but loses
+the original typed error and source chain.
+
+For queue-backed work, backpressure is usually a better default than
+fail-fast rejection. When a circuit is open or a bulkhead is full,
+backpressure leaves pending jobs in the worker pipeline until capacity or the
+dependency recovers. Fail-fast mode instead turns admission control into a job
+error, which may consume retry attempts or trigger backend-specific failure
+handling.
+
+## Apalis overlap and tower-resilience additions
+
+Apalis has built-in concurrency and circuit-breaker middleware. Its current
+circuit breaker offers a consecutive-failure threshold, recovery timeout, and
+half-open calls. `tower-resilience` is useful when an application also needs
+features such as:
+
+- selectable count-based or time-based failure-rate windows;
+- response and custom failure classification;
+- slow-call detection;
+- named event listeners, tracing, metrics, and handles;
+- explicit Tower readiness backpressure;
+- the same policy types across workers, HTTP/gRPC clients, and other Tower
+  services.
+
+This example pins Apalis 1.0.0-rc.9. In that release, the built-in breaker's
+[execution path uses literal default thresholds and open readiness returns
+`Pending` without arranging a recovery wake](https://github.com/apalis-dev/apalis/blob/v1.0.0-rc.9/apalis-core/src/worker/ext/circuit_breaker/service.rs#L201-L266).
+The circuit-breaker scenario here therefore also verifies configured thresholds
+and timer-driven readiness recovery.
+
+The two concurrency controls also operate at different levels. Apalis decides
+how a worker spawns work; a bulkhead isolates a particular service or job type,
+and an adaptive limiter changes its admission limit based on observed latency
+and errors.
+
+## Choose the protected boundary deliberately
+
+Wrapping the whole worker classifies whole-job results. That is appropriate
+when the job is the fault-isolation boundary. If a handler calls several
+downstream systems, wrap each downstream Tower client instead so, for example,
+a Stripe outage does not open the breaker for unrelated database work. A
+handler that catches a downstream error and returns `Ok` also hides that error
+from worker-level resilience middleware.

--- a/examples/apalis-resilient-worker/src/lib.rs
+++ b/examples/apalis-resilient-worker/src/lib.rs
@@ -1,0 +1,273 @@
+use std::{
+    io,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use apalis::prelude::*;
+use tower_resilience_adaptive::{AdaptiveLimiterLayer, Aimd, ConcurrencyAlgorithm};
+use tower_resilience_bulkhead::BulkheadLayer;
+use tower_resilience_circuitbreaker::{CircuitBreakerLayer, CircuitState};
+
+const DEMO_TIMEOUT: Duration = Duration::from_secs(3);
+
+#[derive(Clone, Debug)]
+struct Job {
+    id: usize,
+    should_fail: bool,
+}
+
+/// Run the finite circuit-breaker, bulkhead, and adaptive-limit scenarios.
+pub async fn run_all() -> Result<(), BoxDynError> {
+    circuit_breaker_backpressure().await?;
+    bulkhead_isolation().await?;
+    adaptive_concurrency().await?;
+    Ok(())
+}
+
+async fn circuit_breaker_backpressure() -> Result<(), BoxDynError> {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let opened = Arc::new(AtomicUsize::new(0));
+    let half_opened = Arc::new(AtomicUsize::new(0));
+    let closed = Arc::new(AtomicUsize::new(0));
+
+    let opened_listener = Arc::clone(&opened);
+    let half_opened_listener = Arc::clone(&half_opened);
+    let closed_listener = Arc::clone(&closed);
+    let breaker = CircuitBreakerLayer::builder()
+        .name("apalis-downstream")
+        .consecutive_failures(2)
+        .wait_duration_in_open(Duration::from_millis(50))
+        .backpressure()
+        .on_state_transition(move |from, to| {
+            println!("circuit breaker: {from:?} -> {to:?}");
+            match to {
+                CircuitState::Open => opened_listener.fetch_add(1, Ordering::SeqCst),
+                CircuitState::HalfOpen => half_opened_listener.fetch_add(1, Ordering::SeqCst),
+                CircuitState::Closed => closed_listener.fetch_add(1, Ordering::SeqCst),
+            };
+        })
+        .build()?;
+
+    let mut storage = MemoryStorage::new();
+    storage
+        .push(Job {
+            id: 1,
+            should_fail: true,
+        })
+        .await?;
+    storage
+        .push(Job {
+            id: 2,
+            should_fail: true,
+        })
+        .await?;
+    storage
+        .push(Job {
+            id: 3,
+            should_fail: false,
+        })
+        .await?;
+    storage
+        .push(Job {
+            id: 4,
+            should_fail: false,
+        })
+        .await?;
+
+    let handler_calls = Arc::clone(&calls);
+    let worker = WorkerBuilder::new("circuit-breaker-worker")
+        .backend(storage)
+        .layer(breaker)
+        .build(move |job: Job, worker: WorkerContext| {
+            let calls = Arc::clone(&handler_calls);
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                if job.id == 4 {
+                    worker.stop()?;
+                }
+                if job.should_fail {
+                    Err::<(), BoxDynError>(io::Error::other("planned downstream failure").into())
+                } else {
+                    Ok(())
+                }
+            }
+        });
+
+    run_with_timeout(worker.run()).await?;
+
+    assert_eq!(calls.load(Ordering::SeqCst), 4);
+    assert_eq!(opened.load(Ordering::SeqCst), 1);
+    assert_eq!(half_opened.load(Ordering::SeqCst), 1);
+    assert_eq!(closed.load(Ordering::SeqCst), 1);
+    println!("circuit breaker preserved queued work while open");
+    Ok(())
+}
+
+async fn bulkhead_isolation() -> Result<(), BoxDynError> {
+    const MAX_CONCURRENT: usize = 2;
+    const JOBS: usize = 8;
+
+    let in_flight = Arc::new(AtomicUsize::new(0));
+    let max_seen = Arc::new(AtomicUsize::new(0));
+    let bulkhead = BulkheadLayer::builder()
+        .name("apalis-job-type")
+        .max_concurrent_calls(MAX_CONCURRENT)
+        .backpressure()
+        .build()?;
+
+    let mut storage = MemoryStorage::new();
+    for id in 0..JOBS {
+        storage
+            .push(Job {
+                id,
+                should_fail: false,
+            })
+            .await?;
+    }
+
+    let handler_in_flight = Arc::clone(&in_flight);
+    let handler_max_seen = Arc::clone(&max_seen);
+    let worker = WorkerBuilder::new("bulkhead-worker")
+        .backend(storage)
+        .map_err(box_layer_error)
+        .layer(bulkhead)
+        .parallelize(tokio::spawn)
+        .build(move |job: Job, worker: WorkerContext| {
+            let in_flight = Arc::clone(&handler_in_flight);
+            let max_seen = Arc::clone(&handler_max_seen);
+            async move {
+                let current = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                max_seen.fetch_max(current, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                in_flight.fetch_sub(1, Ordering::SeqCst);
+                if job.id == JOBS - 1 {
+                    worker.stop()?;
+                }
+                Ok::<(), BoxDynError>(())
+            }
+        });
+
+    run_with_timeout(worker.run()).await?;
+
+    let observed = max_seen.load(Ordering::SeqCst);
+    assert_eq!(observed, MAX_CONCURRENT);
+    println!("bulkhead capped Apalis at {observed} concurrent jobs");
+    Ok(())
+}
+
+async fn adaptive_concurrency() -> Result<(), BoxDynError> {
+    let algorithm = Arc::new(
+        Aimd::builder()
+            .initial_limit(2)
+            .min_limit(1)
+            .max_limit(10)
+            .increase_by(1)
+            .decrease_factor(0.5)
+            .latency_threshold(Duration::from_secs(1))
+            .build()?,
+    );
+    let layer = AdaptiveLimiterLayer::new(SharedAimd(Arc::clone(&algorithm)));
+
+    let mut storage = MemoryStorage::new();
+    storage
+        .push(Job {
+            id: 1,
+            should_fail: false,
+        })
+        .await?;
+    storage
+        .push(Job {
+            id: 2,
+            should_fail: false,
+        })
+        .await?;
+    storage
+        .push(Job {
+            id: 3,
+            should_fail: true,
+        })
+        .await?;
+
+    let worker = WorkerBuilder::new("adaptive-worker")
+        .backend(storage)
+        .map_err(box_layer_error)
+        .layer(layer)
+        .build(|job: Job, worker: WorkerContext| async move {
+            if job.id == 3 {
+                worker.stop()?;
+            }
+            if job.should_fail {
+                Err::<(), BoxDynError>(io::Error::other("planned congestion signal").into())
+            } else {
+                Ok(())
+            }
+        });
+
+    run_with_timeout(worker.run()).await?;
+
+    // Two fast successes raise the limit from 2 to 4; the failure halves it.
+    assert_eq!(algorithm.limit(), 2);
+    println!("adaptive limit reacted to Apalis job outcomes: 2 -> 4 -> 2");
+    Ok(())
+}
+
+async fn run_with_timeout(
+    worker: impl Future<Output = Result<(), WorkerError>>,
+) -> Result<(), BoxDynError> {
+    tokio::time::timeout(DEMO_TIMEOUT, worker)
+        .await
+        .map_err(|_| io::Error::other("worker demo timed out"))??;
+    Ok(())
+}
+
+// Apalis task functions expose BoxDynError as their service error. Until #443
+// is fixed, generic tower-resilience wrappers around that error need an outer
+// adapter to satisfy Apalis's Into<BoxDynError> worker bound.
+fn box_layer_error(error: impl std::fmt::Display) -> BoxDynError {
+    io::Error::other(error.to_string()).into()
+}
+
+#[derive(Clone)]
+struct SharedAimd(Arc<Aimd>);
+
+impl ConcurrencyAlgorithm for SharedAimd {
+    fn record_success(&self, latency: Duration) {
+        self.0.record_success(latency);
+    }
+
+    fn record_failure(&self) {
+        self.0.record_failure();
+    }
+
+    fn record_dropped(&self) {
+        self.0.record_dropped();
+    }
+
+    fn limit(&self) -> usize {
+        self.0.limit()
+    }
+
+    fn min_limit(&self) -> usize {
+        self.0.min_limit()
+    }
+
+    fn max_limit(&self) -> usize {
+        self.0.max_limit()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn layers_compose_with_apalis_workers() {
+        circuit_breaker_backpressure().await.unwrap();
+        bulkhead_isolation().await.unwrap();
+        adaptive_concurrency().await.unwrap();
+    }
+}

--- a/examples/apalis-resilient-worker/src/main.rs
+++ b/examples/apalis-resilient-worker/src/main.rs
@@ -1,0 +1,6 @@
+use apalis::prelude::BoxDynError;
+
+#[tokio::main]
+async fn main() -> Result<(), BoxDynError> {
+    apalis_resilient_worker::run_all().await
+}


### PR DESCRIPTION
## Summary

- add a finite Apalis 1.0.0-rc.9 worker example for circuit-breaker backpressure, bulkhead isolation, and AIMD adaptive concurrency
- assert runtime behavior so the example is covered by the workspace library-test gate
- document queue-specific backpressure guidance, middleware ordering, Apalis overlap, and protected-boundary choices
- retain a documented `map_err` adapter for the boxed-error incompatibility tracked in #443

## Verified behavior

- circuit breaker: `Closed -> Open -> HalfOpen -> Closed`, with queued work preserved during the open interval
- bulkhead: 8 parallelized jobs reached exactly 2 concurrent handlers
- adaptive limiter: `2 -> 4 -> 2` after two fast successes and one failure

## Validation

- `cargo run --locked -p apalis-resilient-worker`
- `cargo test --locked --lib --workspace --all-features`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #442
