### PR TITLE
fix: compose generic errors with Tower BoxError

### DIFF
--- a/crates/tower-resilience-adaptive/src/service.rs
+++ b/crates/tower-resilience-adaptive/src/service.rs
@@ -312,6 +312,11 @@ where
 }
 
 /// Error type for adaptive limiter.
+///
+/// The inner service error remains available through [`AdaptiveError::Service`].
+/// It is intentionally not exposed through [`std::error::Error::source`] so
+/// boxed Tower errors can be wrapped without requiring the boxed trait object
+/// itself to implement [`std::error::Error`].
 #[derive(Debug)]
 pub enum AdaptiveError<E> {
     /// The service returned an error.
@@ -329,14 +334,7 @@ impl<E: std::fmt::Display> std::fmt::Display for AdaptiveError<E> {
     }
 }
 
-impl<E: std::error::Error + 'static> std::error::Error for AdaptiveError<E> {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::Service(e) => Some(e),
-            Self::LimitReached => None,
-        }
-    }
-}
+impl<E> std::error::Error for AdaptiveError<E> where E: std::fmt::Debug + std::fmt::Display {}
 
 /// Future returned by [`AdaptiveService`].
 pub struct AdaptiveFuture<T, E> {

--- a/crates/tower-resilience-bulkhead/src/error.rs
+++ b/crates/tower-resilience-bulkhead/src/error.rs
@@ -31,6 +31,12 @@ pub type Result<T> = std::result::Result<T, BulkheadError>;
 /// allows services with any error type to be wrapped without requiring
 /// `From<BulkheadError>` implementations.
 ///
+/// The inner service error remains available through
+/// [`BulkheadServiceError::Inner`] and [`BulkheadServiceError::into_inner`]. It
+/// is intentionally not exposed through [`std::error::Error::source`] so boxed
+/// Tower errors can be wrapped directly. Bulkhead-specific errors remain
+/// available as an error source.
+///
 /// # Examples
 ///
 /// ```rust
@@ -93,11 +99,14 @@ impl<E: std::fmt::Display> std::fmt::Display for BulkheadServiceError<E> {
     }
 }
 
-impl<E: std::error::Error + 'static> std::error::Error for BulkheadServiceError<E> {
+impl<E> std::error::Error for BulkheadServiceError<E>
+where
+    E: std::fmt::Debug + std::fmt::Display,
+{
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             BulkheadServiceError::Bulkhead(e) => Some(e),
-            BulkheadServiceError::Inner(e) => Some(e),
+            BulkheadServiceError::Inner(_) => None,
         }
     }
 }

--- a/crates/tower-resilience-cache/src/error.rs
+++ b/crates/tower-resilience-cache/src/error.rs
@@ -3,6 +3,10 @@
 use std::fmt;
 
 /// Errors that can occur in the cache.
+///
+/// The inner service error remains available through [`CacheError::Inner`] and
+/// [`CacheError::into_inner`]. It is intentionally not exposed through
+/// [`std::error::Error::source`] so boxed Tower errors can be wrapped directly.
 #[derive(Debug)]
 pub enum CacheError<E> {
     /// The inner service returned an error.
@@ -17,13 +21,7 @@ impl<E: fmt::Display> fmt::Display for CacheError<E> {
     }
 }
 
-impl<E: std::error::Error + 'static> std::error::Error for CacheError<E> {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            CacheError::Inner(e) => Some(e),
-        }
-    }
-}
+impl<E> std::error::Error for CacheError<E> where E: fmt::Debug + fmt::Display {}
 
 impl<E> CacheError<E> {
     /// Converts this error into the inner error.

--- a/crates/tower-resilience-coalesce/src/service.rs
+++ b/crates/tower-resilience-coalesce/src/service.rs
@@ -19,6 +19,10 @@ use metrics::{counter, describe_counter};
 use tracing::debug;
 
 /// Error type for coalesced requests.
+///
+/// The inner service error remains available through [`CoalesceError::Service`].
+/// It is intentionally not exposed through [`std::error::Error::source`] so
+/// boxed Tower errors can be wrapped directly.
 #[derive(Debug)]
 pub enum CoalesceError<E> {
     /// The underlying service returned an error.
@@ -39,14 +43,7 @@ impl<E: std::fmt::Display> std::fmt::Display for CoalesceError<E> {
     }
 }
 
-impl<E: std::error::Error + 'static> std::error::Error for CoalesceError<E> {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            CoalesceError::Service(e) => Some(e),
-            _ => None,
-        }
-    }
-}
+impl<E> std::error::Error for CoalesceError<E> where E: std::fmt::Debug + std::fmt::Display {}
 
 impl<E: Clone> Clone for CoalesceError<E> {
     fn clone(&self) -> Self {

--- a/crates/tower-resilience-core/src/error.rs
+++ b/crates/tower-resilience-core/src/error.rs
@@ -150,6 +150,11 @@ use std::time::Duration;
 ///
 /// - `E`: The application-specific error type from the wrapped service
 ///
+/// The application error remains available through
+/// [`ResilienceError::Application`] and the typed accessor methods. It is not
+/// exposed through [`std::error::Error::source`] so conventional boxed Tower
+/// errors can be used as `E` directly.
+///
 /// # Examples
 ///
 /// ```
@@ -258,7 +263,7 @@ where
     }
 }
 
-impl<E> std::error::Error for ResilienceError<E> where E: std::error::Error {}
+impl<E> std::error::Error for ResilienceError<E> where E: fmt::Debug + fmt::Display {}
 
 // Note: From implementations for each resilience layer error are provided
 // by the individual crates (bulkhead, circuitbreaker, etc.) to avoid

--- a/crates/tower-resilience-executor/src/service.rs
+++ b/crates/tower-resilience-executor/src/service.rs
@@ -112,6 +112,10 @@ where
 }
 
 /// Error type for executor service operations.
+///
+/// The inner service error remains available through [`ExecutorError::Service`].
+/// It is intentionally not exposed through [`std::error::Error::source`] so
+/// boxed Tower errors can be wrapped directly.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExecutorError<E> {
     /// The spawned task was cancelled or panicked.
@@ -129,14 +133,7 @@ impl<E: std::fmt::Display> std::fmt::Display for ExecutorError<E> {
     }
 }
 
-impl<E: std::error::Error + 'static> std::error::Error for ExecutorError<E> {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::Service(e) => Some(e),
-            _ => None,
-        }
-    }
-}
+impl<E> std::error::Error for ExecutorError<E> where E: std::fmt::Debug + std::fmt::Display {}
 
 pin_project! {
     /// Future returned by [`ExecutorService`].

--- a/crates/tower-resilience-fallback/src/error.rs
+++ b/crates/tower-resilience-fallback/src/error.rs
@@ -7,6 +7,10 @@ use std::fmt;
 /// `E` is the primary service error. `FallbackE` is the backup service error
 /// and defaults to `E` so existing value, function, and closure-backed fallback
 /// APIs retain their original `FallbackError<E>` type.
+///
+/// Both typed errors remain available through the variants and accessor methods.
+/// They are intentionally not exposed through [`std::error::Error::source`] so
+/// boxed Tower errors can be wrapped directly.
 #[derive(Debug)]
 pub enum FallbackError<E, FallbackE = E> {
     /// The inner service failed and no fallback was applied (predicate didn't match),
@@ -114,13 +118,7 @@ impl<E: fmt::Display, FallbackE: fmt::Display> fmt::Display for FallbackError<E,
 
 impl<E, FallbackE> std::error::Error for FallbackError<E, FallbackE>
 where
-    E: std::error::Error + 'static,
-    FallbackE: std::error::Error + 'static,
+    E: fmt::Debug + fmt::Display,
+    FallbackE: fmt::Debug + fmt::Display,
 {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::Inner(error) => Some(error),
-            Self::FallbackFailed(error) => Some(error),
-        }
-    }
 }

--- a/crates/tower-resilience-hedge/src/error.rs
+++ b/crates/tower-resilience-hedge/src/error.rs
@@ -3,6 +3,10 @@
 use std::fmt;
 
 /// Error type for the hedging service.
+///
+/// The typed inner error remains available through [`HedgeError::inner`] and
+/// [`HedgeError::into_inner`]. It is intentionally not exposed through
+/// [`std::error::Error::source`] so boxed Tower errors can be wrapped directly.
 #[derive(Debug, Clone)]
 pub enum HedgeError<E> {
     /// All hedged attempts failed.
@@ -25,14 +29,7 @@ impl<E: fmt::Display> fmt::Display for HedgeError<E> {
     }
 }
 
-impl<E: std::error::Error + 'static> std::error::Error for HedgeError<E> {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            HedgeError::AllAttemptsFailed(e) => Some(e),
-            HedgeError::Inner(e) => Some(e),
-        }
-    }
-}
+impl<E> std::error::Error for HedgeError<E> where E: fmt::Debug + fmt::Display {}
 
 impl<E> HedgeError<E> {
     /// Returns `true` if all hedged attempts failed.

--- a/crates/tower-resilience-outlier/src/error.rs
+++ b/crates/tower-resilience-outlier/src/error.rs
@@ -14,6 +14,13 @@ pub enum OutlierDetectionError {
 }
 
 /// Service-level error that wraps both outlier detection and inner service errors.
+///
+/// The inner service error remains available through
+/// [`OutlierDetectionServiceError::Inner`] and
+/// [`OutlierDetectionServiceError::into_inner`]. It is intentionally not
+/// exposed through [`std::error::Error::source`] so boxed Tower errors can be
+/// wrapped directly. Outlier-detection errors remain available as an error
+/// source.
 #[derive(Debug)]
 pub enum OutlierDetectionServiceError<E> {
     /// An outlier detection error (e.g., instance ejected).
@@ -59,11 +66,14 @@ impl<E: std::fmt::Display> std::fmt::Display for OutlierDetectionServiceError<E>
     }
 }
 
-impl<E: std::error::Error + 'static> std::error::Error for OutlierDetectionServiceError<E> {
+impl<E> std::error::Error for OutlierDetectionServiceError<E>
+where
+    E: std::fmt::Debug + std::fmt::Display,
+{
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             OutlierDetectionServiceError::OutlierDetection(e) => Some(e),
-            OutlierDetectionServiceError::Inner(e) => Some(e),
+            OutlierDetectionServiceError::Inner(_) => None,
         }
     }
 }

--- a/crates/tower-resilience-ratelimiter/src/error.rs
+++ b/crates/tower-resilience-ratelimiter/src/error.rs
@@ -23,6 +23,12 @@ impl std::error::Error for RateLimiterError {}
 /// This error type is returned by the [`RateLimiter`](crate::RateLimiter) service and
 /// allows services with any error type to be wrapped without losing inner service errors.
 ///
+/// The inner service error remains available through
+/// [`RateLimiterServiceError::Inner`] and
+/// [`RateLimiterServiceError::into_inner`]. It is intentionally not exposed
+/// through [`std::error::Error::source`] so boxed Tower errors can be wrapped
+/// directly.
+///
 /// # Examples
 ///
 /// ```rust
@@ -77,14 +83,7 @@ impl<E: fmt::Display> fmt::Display for RateLimiterServiceError<E> {
     }
 }
 
-impl<E: std::error::Error + 'static> std::error::Error for RateLimiterServiceError<E> {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            RateLimiterServiceError::RateLimited => None,
-            RateLimiterServiceError::Inner(e) => Some(e),
-        }
-    }
-}
+impl<E> std::error::Error for RateLimiterServiceError<E> where E: fmt::Debug + fmt::Display {}
 
 impl<E> From<RateLimiterError> for RateLimiterServiceError<E> {
     fn from(_err: RateLimiterError) -> Self {

--- a/crates/tower-resilience-reconnect/src/service.rs
+++ b/crates/tower-resilience-reconnect/src/service.rs
@@ -607,6 +607,11 @@ fn notify_state_change(
 }
 
 /// Errors that can occur during reconnection.
+///
+/// Factory and service errors remain available through their typed variants.
+/// They are intentionally not exposed through [`std::error::Error::source`] so
+/// boxed Tower errors can be wrapped directly. The boxed terminal cause in
+/// [`ReconnectError::MaxAttemptsExceeded`] remains available as a source.
 #[derive(Debug)]
 pub enum ReconnectError<MakeError, ServiceError> {
     /// The maximum number of reconnection attempts was exceeded.
@@ -651,16 +656,16 @@ where
 
 impl<M, S> std::error::Error for ReconnectError<M, S>
 where
-    M: std::error::Error + 'static,
-    S: std::error::Error + 'static,
+    M: std::fmt::Debug + std::fmt::Display,
+    S: std::fmt::Debug + std::fmt::Display,
 {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::MaxAttemptsExceeded { error, .. } => Some(error.as_ref()),
-            Self::FactoryError(error) => Some(error),
-            Self::ConnectionFailed(error)
-            | Self::ConnectionFailedNoRetry(error)
-            | Self::ServiceError(error) => Some(error),
+            Self::FactoryError(_)
+            | Self::ConnectionFailed(_)
+            | Self::ConnectionFailedNoRetry(_)
+            | Self::ServiceError(_) => None,
         }
     }
 }

--- a/crates/tower-resilience-router/src/error.rs
+++ b/crates/tower-resilience-router/src/error.rs
@@ -8,6 +8,11 @@ use tower_resilience_core::ResilienceError;
 /// The weighted router itself does not produce errors -- it delegates
 /// to the selected backend. This error type wraps the inner service
 /// error for consistency with other tower-resilience patterns.
+///
+/// The inner service error remains available through [`WeightedRouterError::Inner`]
+/// and [`WeightedRouterError::into_inner`]. It is intentionally not exposed
+/// through [`std::error::Error::source`] so boxed Tower errors can be wrapped
+/// directly.
 #[derive(Debug)]
 pub enum WeightedRouterError<E> {
     /// An error from the selected backend service.
@@ -36,13 +41,7 @@ impl<E: fmt::Display> fmt::Display for WeightedRouterError<E> {
     }
 }
 
-impl<E: std::error::Error + 'static> std::error::Error for WeightedRouterError<E> {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            WeightedRouterError::Inner(e) => Some(e),
-        }
-    }
-}
+impl<E> std::error::Error for WeightedRouterError<E> where E: fmt::Debug + fmt::Display {}
 
 impl<E> From<WeightedRouterError<E>> for ResilienceError<E> {
     fn from(err: WeightedRouterError<E>) -> Self {

--- a/crates/tower-resilience-timelimiter/src/error.rs
+++ b/crates/tower-resilience-timelimiter/src/error.rs
@@ -4,6 +4,11 @@ use std::fmt;
 use tower_resilience_core::ResilienceError;
 
 /// Errors that can occur in the time limiter.
+///
+/// The inner service error remains available through [`TimeLimiterError::Inner`]
+/// and [`TimeLimiterError::into_inner`]. It is intentionally not exposed
+/// through [`std::error::Error::source`] so boxed Tower errors can be wrapped
+/// directly.
 #[derive(Debug)]
 pub enum TimeLimiterError<E> {
     /// The request timed out.
@@ -21,14 +26,7 @@ impl<E: fmt::Display> fmt::Display for TimeLimiterError<E> {
     }
 }
 
-impl<E: std::error::Error + 'static> std::error::Error for TimeLimiterError<E> {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            TimeLimiterError::Timeout => None,
-            TimeLimiterError::Inner(e) => Some(e),
-        }
-    }
-}
+impl<E> std::error::Error for TimeLimiterError<E> where E: fmt::Debug + fmt::Display {}
 
 impl<E> TimeLimiterError<E> {
     /// Returns true if this is a timeout error.

--- a/examples/apalis-resilient-worker/README.md
+++ b/examples/apalis-resilient-worker/README.md
@@ -22,12 +22,9 @@ Apalis already accepts Tower layers, so the integration point is its
 `WorkerBuilder::layer` method. The layer sees Apalis's full `Task` request even
 though the handler continues to receive the ergonomic job arguments.
 
-Apalis task functions use a boxed dynamic service error. Bulkhead and adaptive
-currently need the outer `map_err` adapter shown in the example because their
-generic wrapper errors cannot convert back into that boxed type. This is
-tracked in [#443](https://github.com/joshrotenberg/tower-resilience/issues/443);
-the adapter intentionally makes the current integration executable, but loses
-the original typed error and source chain.
+Apalis task functions use a boxed dynamic service error. The resilience
+wrappers compose with that error directly, so the layers preserve their typed
+variants without an outer error-mapping adapter.
 
 For queue-backed work, backpressure is usually a better default than
 fail-fast rejection. When a circuit is open or a bulkhead is full,

--- a/examples/apalis-resilient-worker/src/lib.rs
+++ b/examples/apalis-resilient-worker/src/lib.rs
@@ -133,7 +133,6 @@ async fn bulkhead_isolation() -> Result<(), BoxDynError> {
     let handler_max_seen = Arc::clone(&max_seen);
     let worker = WorkerBuilder::new("bulkhead-worker")
         .backend(storage)
-        .map_err(box_layer_error)
         .layer(bulkhead)
         .parallelize(tokio::spawn)
         .build(move |job: Job, worker: WorkerContext| {
@@ -194,7 +193,6 @@ async fn adaptive_concurrency() -> Result<(), BoxDynError> {
 
     let worker = WorkerBuilder::new("adaptive-worker")
         .backend(storage)
-        .map_err(box_layer_error)
         .layer(layer)
         .build(|job: Job, worker: WorkerContext| async move {
             if job.id == 3 {
@@ -222,13 +220,6 @@ async fn run_with_timeout(
         .await
         .map_err(|_| io::Error::other("worker demo timed out"))??;
     Ok(())
-}
-
-// Apalis task functions expose BoxDynError as their service error. Until #443
-// is fixed, generic tower-resilience wrappers around that error need an outer
-// adapter to satisfy Apalis's Into<BoxDynError> worker bound.
-fn box_layer_error(error: impl std::fmt::Display) -> BoxDynError {
-    io::Error::other(error.to_string()).into()
 }
 
 #[derive(Clone)]

--- a/tests/box_error_compat.rs
+++ b/tests/box_error_compat.rs
@@ -1,0 +1,81 @@
+//! Compile-time regression coverage for wrapping conventional Tower errors.
+
+use tower::BoxError;
+use tower::{Layer, Service, service_fn};
+
+fn assert_into_box_error<T>()
+where
+    T: Into<BoxError>,
+{
+}
+
+fn assert_service_error_into_box_error<S>(_: &S)
+where
+    S: Service<()>,
+    S::Error: Into<BoxError>,
+{
+}
+
+#[test]
+fn affected_layers_wrap_a_box_error_service() {
+    let bulkhead = tower_resilience_bulkhead::BulkheadLayer::builder()
+        .max_concurrent_calls(1)
+        .build()
+        .expect("valid bulkhead");
+    let bulkhead_service = bulkhead.layer(service_fn(|()| async {
+        Err::<(), BoxError>(std::io::Error::other("inner failure").into())
+    }));
+    assert_service_error_into_box_error(&bulkhead_service);
+
+    let aimd = tower_resilience_adaptive::Aimd::builder()
+        .initial_limit(1)
+        .build()
+        .expect("valid AIMD configuration");
+    let adaptive = tower_resilience_adaptive::AdaptiveLimiterLayer::new(aimd);
+    let adaptive_service = adaptive.layer(service_fn(|()| async {
+        Err::<(), BoxError>(std::io::Error::other("inner failure").into())
+    }));
+    assert_service_error_into_box_error(&adaptive_service);
+}
+
+#[test]
+fn generic_error_wrappers_convert_into_tower_box_error() {
+    assert_into_box_error::<tower_resilience_adaptive::AdaptiveError<BoxError>>();
+    assert_into_box_error::<tower_resilience_bulkhead::BulkheadServiceError<BoxError>>();
+    assert_into_box_error::<tower_resilience_cache::CacheError<BoxError>>();
+    assert_into_box_error::<tower_resilience_circuitbreaker::CircuitBreakerError<BoxError>>();
+    assert_into_box_error::<tower_resilience_coalesce::CoalesceError<BoxError>>();
+    assert_into_box_error::<tower_resilience_core::ResilienceError<BoxError>>();
+    assert_into_box_error::<tower_resilience_executor::ExecutorError<BoxError>>();
+    assert_into_box_error::<tower_resilience_fallback::FallbackError<BoxError>>();
+    assert_into_box_error::<tower_resilience_hedge::HedgeError<BoxError>>();
+    assert_into_box_error::<tower_resilience_outlier::OutlierDetectionServiceError<BoxError>>();
+    assert_into_box_error::<tower_resilience_ratelimiter::RateLimiterServiceError<BoxError>>();
+    assert_into_box_error::<tower_resilience_reconnect::ReconnectError<BoxError, BoxError>>();
+    assert_into_box_error::<tower_resilience_router::WeightedRouterError<BoxError>>();
+    assert_into_box_error::<tower_resilience_timelimiter::TimeLimiterError<BoxError>>();
+}
+
+#[test]
+fn typed_inner_error_remains_recoverable() {
+    let inner: BoxError = std::io::Error::other("inner failure").into();
+    let error = tower_resilience_bulkhead::BulkheadServiceError::Inner(inner);
+
+    assert_eq!(
+        error.into_inner().expect("inner error").to_string(),
+        "inner failure"
+    );
+}
+
+#[test]
+fn library_owned_error_remains_a_source() {
+    use std::error::Error;
+
+    let error: tower_resilience_bulkhead::BulkheadServiceError<BoxError> =
+        tower_resilience_bulkhead::BulkheadError::Timeout.into();
+
+    assert_eq!(
+        error.source().expect("bulkhead source").to_string(),
+        "timeout waiting for bulkhead permit"
+    );
+}


### PR DESCRIPTION
## Summary
- relax generic resilience wrapper Error bounds so conventional tower::BoxError services compose directly
- preserve typed variants and accessors, while documenting the stable-Rust source-chain tradeoff
- add cross-crate wrapper and real layer compatibility coverage
- remove the lossy Apalis map_err adapter

## Verification
- cargo fmt --all -- --check
- cargo test --locked --lib --workspace --all-features
- cargo test --locked --test '*' --workspace --all-features
- cargo test --locked --doc --workspace --all-features
- cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS='-D warnings' cargo doc --locked --workspace --all-features --no-deps
- cargo check --locked -p tower-resilience --all-features

Closes #443