### PR TITLE
docs: add complete 0.13 migration guide

### DIFF
--- a/crates/tower-resilience-adaptive/CHANGELOG.md
+++ b/crates/tower-resilience-adaptive/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   limit changes. Metrics are not yet labeled by instance name -- `adaptive`
   has no per-instance naming concept ([#428](https://github.com/joshrotenberg/tower-resilience/issues/428)).
 
+### Changed
+
+- **Breaking:** `Aimd::new`, `AimdBuilder::build`, and
+  `VegasBuilder::build` now return typed `Result` values and reject invalid
+  limits, zero additive increase, and invalid decrease factors during
+  construction.
+
 ## [0.12.0](https://github.com/joshrotenberg/tower-resilience/compare/tower-resilience-adaptive-v0.11.0...tower-resilience-adaptive-v0.12.0) - 2026-08-17
 
 ### Fixed

--- a/crates/tower-resilience-bulkhead/CHANGELOG.md
+++ b/crates/tower-resilience-bulkhead/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** `BulkheadConfigBuilder::build` and `build_with_handle` now
+  return `Result<_, BulkheadConfigError>` and reject
+  `max_concurrent_calls == 0` during construction.
+- **Breaking:** `BulkheadError` adds the `Closed` and `NotReady` variants.
+  Exhaustive matches must handle both new readiness failures.
 - Backpressure readiness now polls and reserves semaphore permits directly,
   without spawning one Tokio task per waiter.
 

--- a/crates/tower-resilience-circuitbreaker/CHANGELOG.md
+++ b/crates/tower-resilience-circuitbreaker/CHANGELOG.md
@@ -36,6 +36,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   service on both `CircuitBreaker` and `CircuitBreakerWithFallback`,
   matching Tower's own middleware convention.
 
+### Changed
+
+- **Breaking:** `CircuitBreakerConfigBuilder::build` and
+  `build_with_handle` now return `Result<_, CircuitBreakerConfigError>` and
+  reject invalid thresholds, windows, consecutive-failure counts, and
+  incomplete time-based window configuration during construction.
+
 ### Fixed
 
 - Reserve half-open probe admission atomically with a per-cycle semaphore

--- a/crates/tower-resilience-core/CHANGELOG.md
+++ b/crates/tower-resilience-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** `AimdController::new` now returns
+  `Result<_, AimdConfigError>` and rejects invalid limit bounds, zero
+  additive increase, and invalid decrease factors during construction.
+
 ## [0.12.0](https://github.com/joshrotenberg/tower-resilience/compare/tower-resilience-core-v0.11.0...tower-resilience-core-v0.12.0) - 2026-08-17
 
 ### Fixed

--- a/crates/tower-resilience-outlier/CHANGELOG.md
+++ b/crates/tower-resilience-outlier/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** `OutlierDetectionConfigBuilder::build` now returns
+  `Result<_, OutlierDetectionConfigError>` and rejects a missing detector at
+  construction time.
 - **Breaking:** `OutlierDetectionService::Future` is now a named,
   `pin_project!`-based `OutlierDetectionFuture<F, C>` instead of
   `BoxFuture<'static, Result<...>>`. This removes one `Box::pin` heap

--- a/crates/tower-resilience-ratelimiter/CHANGELOG.md
+++ b/crates/tower-resilience-ratelimiter/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `RateLimiter::get_ref()`, `get_mut()`, and `into_inner()` accessors for
   the wrapped service, matching Tower's own middleware convention.
 
+### Changed
+
+- **Breaking:** `RateLimiterConfigBuilder::build` and `build_with_handle`
+  now return `Result<_, RateLimiterConfigError>` and reject zero limits,
+  zero refresh periods, and overflowing burst capacities during
+  construction.
+
 ## [0.12.0](https://github.com/joshrotenberg/tower-resilience/compare/tower-resilience-ratelimiter-v0.11.0...tower-resilience-ratelimiter-v0.12.0) - 2026-08-17
 
 ### Fixed

--- a/crates/tower-resilience-retry/CHANGELOG.md
+++ b/crates/tower-resilience-retry/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ExponentialRandomBackoff::new`, and
   `ExponentialRandomBackoff::multiplier` now return `Result` with a typed
   `BackoffConfigError` instead of accepting invalid floating-point settings.
+- **Breaking:** `TokenBucketBuilder::build`, `AimdBudgetBuilder::build`,
+  `TokenBucketBudget::new`, and `AimdBudget::new` now return `Result` with a
+  typed `RetryBudgetConfigError` instead of accepting invalid rates, bounds,
+  or zero deposit/withdraw amounts.
+- **Breaking:** `TokenBucketBudget` no longer automatically implements
+  `UnwindSafe` or `RefUnwindSafe` after moving to clock-backed synchronized
+  accounting.
 
 ### Fixed
 

--- a/crates/tower-resilience-timelimiter/CHANGELOG.md
+++ b/crates/tower-resilience-timelimiter/CHANGELOG.md
@@ -17,8 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Define TimeLimiter's deadline as covering only the `Service::call` future,
   excluding readiness and response-body frames; document and test composition
   with tower-http 0.7 idle and absolute body timeouts.
-- Rename the misleading `streaming()` preset to `detached()`; the old name is
-  retained as a deprecated alias.
+- Deprecate the misleading `streaming()` preset in favor of `detached()`.
+  The old name remains as an alias for this release.
 
 ## [0.12.0](https://github.com/joshrotenberg/tower-resilience/compare/tower-resilience-timelimiter-v0.11.0...tower-resilience-timelimiter-v0.12.0) - 2026-08-17
 

--- a/crates/tower-resilience/CHANGELOG.md
+++ b/crates/tower-resilience/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** 0.13 validates configuration at construction time. Builders
+  and constructors in core AIMD, adaptive, bulkhead, circuit breaker, rate
+  limiter, outlier detection, retry budgets/backoff, and reconnect now return
+  typed `Result` values where invalid configuration was previously accepted.
+- **Breaking:** outlier detection uses a named, allocation-free
+  `Service::Future`; exhaustive `BulkheadError` matches must handle `Closed`
+  and `NotReady`; and `TokenBucketBudget` no longer automatically implements
+  `UnwindSafe`/`RefUnwindSafe`.
+- Generic middleware errors now compose directly with Tower `BoxError`.
+  Application/inner errors remain available through typed variants and
+  accessors but are no longer exposed through `std::error::Error::source`.
+- `TimeLimiterLayer::streaming()` is deprecated in favor of the more accurate
+  `detached()` name.
+
+### Migrating from 0.12
+
+See the [0.12 to 0.13 migration guide](MIGRATION.md) for the complete API list
+and compiling upgrade examples. Release tooling may call this pre-1.0 minor
+bump API compatible because the version increment permits breaking changes;
+0.13 is not source-compatible with 0.12.
+
 ## [0.12.0](https://github.com/joshrotenberg/tower-resilience/compare/tower-resilience-v0.11.0...tower-resilience-v0.12.0) - 2026-08-17
 
 ### Fixed

--- a/crates/tower-resilience/MIGRATION.md
+++ b/crates/tower-resilience/MIGRATION.md
@@ -1,0 +1,223 @@
+# Migrating from 0.12 to 0.13
+
+Version 0.13 is a pre-1.0 minor release with intentional source-breaking
+changes. Release tooling may describe a `0.12 -> 0.13` bump as API compatible
+because that version increment is allowed to contain breaking changes; it does
+not mean existing 0.12 source code will compile unchanged.
+
+The central migration rule is: configuration that could previously create an
+invalid runtime value is now validated at construction time. Handle the new
+typed `Result` where the layer, algorithm, budget, or backoff is built.
+
+## Fallible construction
+
+The following APIs now return `Result`:
+
+| Crate | APIs | Error type |
+| --- | --- | --- |
+| `core` | `AimdController::new` | `AimdConfigError` |
+| `adaptive` | `Aimd::new`, `AimdBuilder::build` | `AimdConfigError` |
+| `adaptive` | `VegasBuilder::build` | `VegasConfigError` |
+| `bulkhead` | `BulkheadConfigBuilder::{build, build_with_handle}` | `BulkheadConfigError` |
+| `circuitbreaker` | `CircuitBreakerConfigBuilder::{build, build_with_handle}` | `CircuitBreakerConfigError` |
+| `ratelimiter` | `RateLimiterConfigBuilder::{build, build_with_handle}` | `RateLimiterConfigError` |
+| `outlier` | `OutlierDetectionConfigBuilder::build` | `OutlierDetectionConfigError` |
+| `retry` | `ExponentialBackoff::multiplier`, `ExponentialRandomBackoff::{new, multiplier}` | `BackoffConfigError` |
+| `retry` | `TokenBucketBuilder::build`, `AimdBudgetBuilder::build`, `TokenBucketBudget::new`, `AimdBudget::new` | `RetryBudgetConfigError` |
+| `reconnect` | `ReconnectPolicy::exponential_random` | `BackoffConfigError` |
+
+### Propagate configuration errors
+
+For configuration loaded at runtime, prefer returning the typed error or using
+`?` to compose it into an application configuration error:
+
+```rust
+# #[cfg(all(feature = "bulkhead", feature = "circuitbreaker", feature = "ratelimiter"))]
+# {
+use std::error::Error;
+use tower_resilience::bulkhead::BulkheadLayer;
+use tower_resilience::circuitbreaker::CircuitBreakerLayer;
+use tower_resilience::core::aimd::{AimdConfig, AimdController};
+use tower_resilience::ratelimiter::RateLimiterLayer;
+
+fn build_layers() -> Result<(), Box<dyn Error>> {
+    let _controller = AimdController::new(AimdConfig::default())?;
+    let _bulkhead = BulkheadLayer::builder()
+        .max_concurrent_calls(32)
+        .build()?;
+
+    let _circuit_breaker = CircuitBreakerLayer::builder()
+        .failure_rate_threshold(0.5)
+        .build()?;
+
+    let _rate_limiter = RateLimiterLayer::per_second(100).build()?;
+    Ok(())
+}
+# build_layers().unwrap();
+# }
+```
+
+For a hard-coded preset or static configuration, `expect` is reasonable when
+the message explains the invariant:
+
+```rust
+# #[cfg(feature = "adaptive")]
+# {
+use tower_resilience::adaptive::Aimd;
+
+let algorithm = Aimd::builder()
+    .build()
+    .expect("the default AIMD configuration is valid");
+# let _ = algorithm;
+# }
+```
+
+### Shared handles
+
+In 0.12, callers could access the layer directly from the returned tuple:
+
+```rust,ignore
+let circuit_layer = CircuitBreakerLayer::builder().build_with_handle().0;
+```
+
+In 0.13, tuple access must happen after handling the result:
+
+```rust
+# #[cfg(all(feature = "bulkhead", feature = "circuitbreaker"))]
+# {
+use std::error::Error;
+use tower_resilience::bulkhead::BulkheadLayer;
+use tower_resilience::circuitbreaker::CircuitBreakerLayer;
+
+fn shared_layers() -> Result<(), Box<dyn Error>> {
+    let (_circuit_layer, circuit_handle) = CircuitBreakerLayer::builder()
+        .build_with_handle()?;
+    let (_bulkhead_layer, bulkhead_handle) = BulkheadLayer::builder()
+        .max_concurrent_calls(100)
+        .build_with_handle()?;
+
+    // Retain the handles when state must be shared or inspected externally.
+    let _ = (circuit_handle, bulkhead_handle);
+    Ok(())
+}
+# shared_layers().unwrap();
+# }
+```
+
+This is the migration shape for integrations such as GovCraft/Acton that
+previously called `build_with_handle().0`: change the surrounding helper to
+return `Result<Option<Layer>, ConfigError>` (or an application error), then use
+`build_with_handle()?.0`.
+
+Integrations such as RMQTT that previously returned `builder.build()` directly
+must likewise update their helper's return type:
+
+```rust,ignore
+// 0.12
+fn circuit_breaker_layer() -> CircuitBreakerLayer {
+    CircuitBreakerLayer::builder().build()
+}
+```
+
+```rust
+# #[cfg(feature = "circuitbreaker")]
+# {
+use tower_resilience::circuitbreaker::{
+    CircuitBreakerConfigError, CircuitBreakerLayer,
+};
+
+// 0.13
+fn circuit_breaker_layer(
+) -> Result<CircuitBreakerLayer, CircuitBreakerConfigError> {
+    CircuitBreakerLayer::builder().build()
+}
+# circuit_breaker_layer().unwrap();
+# }
+```
+
+Alternatively, use `expect` only when an earlier validation step makes invalid
+configuration impossible.
+
+### Backoff and retry budgets
+
+Backoff modifiers now validate floating-point inputs immediately:
+
+```rust
+# #[cfg(all(feature = "retry", feature = "reconnect"))]
+# {
+use std::error::Error;
+use std::time::Duration;
+use tower_resilience::reconnect::ReconnectPolicy;
+use tower_resilience::retry::{ExponentialBackoff, RetryBudgetBuilder};
+
+fn retry_configuration() -> Result<(), Box<dyn Error>> {
+    let _backoff = ExponentialBackoff::new(Duration::from_millis(100))
+        .multiplier(2.0)?;
+    let _reconnect = ReconnectPolicy::exponential_random(
+        Duration::from_millis(100),
+        Duration::from_secs(10),
+        0.25,
+    )?;
+    let _budget = RetryBudgetBuilder::new()
+        .token_bucket()
+        .tokens_per_second(10.0)
+        .max_tokens(100)
+        .build()?;
+    Ok(())
+}
+# retry_configuration().unwrap();
+# }
+```
+
+## Outlier future type
+
+`OutlierDetectionService::Future` is now the named
+`OutlierDetectionFuture<F, C>` instead of a boxed future. Normal `.await`
+callers do not need to change. Code that names the associated future type or
+requires a boxed future must update the type or box it at that boundary. The
+new future removes one heap allocation per call and removes the previous
+`Send + 'static` bounds from the service implementation.
+
+`OutlierDetectionConfigBuilder::build` also returns
+`Result<_, OutlierDetectionConfigError>` and rejects a missing detector during
+construction.
+
+## Bulkhead errors
+
+`BulkheadError` adds `Closed` and `NotReady`. Code that exhaustively matches
+the enum must handle both variants. They distinguish a permanently closed
+semaphore from calling a backpressure service without first obtaining a
+readiness reservation.
+
+## Generic error wrappers and `Error::source`
+
+Generic middleware errors now implement `std::error::Error` for any inner type
+that implements `Debug + Display`. This allows Tower's
+`Box<dyn Error + Send + Sync>` (`BoxError`) to compose directly through the
+middleware stack.
+
+As part of that change, generic application/inner errors are no longer returned
+from `std::error::Error::source`. Typed access is unchanged: match the wrapper
+variant or use its `inner`, `into_inner`, `application_error`, `primary_error`,
+or `fallback_error` accessor as appropriate. Code that walked `source()` to
+recover an application error should migrate to those typed APIs.
+
+The new generic Tower backup-service fallback is additive, and the second error
+parameter on `FallbackError<PrimaryError, BackupError = PrimaryError>` is
+defaulted. See the fallback crate's migration module for its readiness,
+request-cloning, and error-selection behavior.
+
+## Time limiter preset rename
+
+`TimeLimiterLayer::streaming()` is deprecated. Use
+`TimeLimiterLayer::detached()` for the same preset. The new name makes the
+actual boundary explicit: the timeout covers the `Service::call` future, not
+readiness or later response-body frames.
+
+## Retry-budget unwind safety
+
+`TokenBucketBudget` no longer automatically implements `UnwindSafe` or
+`RefUnwindSafe` after its accounting moved to a clock-backed synchronized
+state. Most async applications are unaffected. Code with explicit unwind-safety
+bounds must remove that bound, introduce an application-owned wrapper, or use
+`AssertUnwindSafe` only after reviewing its own panic invariants.

--- a/crates/tower-resilience/src/lib.rs
+++ b/crates/tower-resilience/src/lib.rs
@@ -150,6 +150,7 @@
 //! - **[Pattern Guides](patterns)** - Detailed guides for each pattern with examples and anti-patterns
 //! - **[Composition Guide](composition)** - How to combine patterns effectively
 //! - **[Use Cases](use_cases)** - Real-world scenarios and recommendations
+//! - **[0.12 to 0.13 Migration](migration)** - Required source changes for the 0.13 release
 //!
 //! ## Observability
 //!
@@ -310,6 +311,8 @@
 
 // Documentation modules
 pub mod composition;
+#[doc = include_str!("../MIGRATION.md")]
+pub mod migration {}
 pub mod observability;
 pub mod patterns;
 pub mod tower_primer;


### PR DESCRIPTION
## Summary

- add a facade-level 0.12 → 0.13 migration guide with compiling upgrade examples
- explicitly label every known source-breaking change in the affected crate changelogs
- qualify the pre-1.0 “API compatible” release-tooling result and document the RMQTT- and Acton-shaped migrations

## Validation

- `cargo test --locked --workspace --all-features`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- `cargo package --list -p tower-resilience --allow-dirty`

Closes #446
