### PR TITLE
ci: add workspace publish preflight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,26 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  # This packages every publishable crate in dependency order without
+  # publishing it. Running on every PR necessarily gates release-plz PRs while
+  # also catching package-surface regressions when they are introduced.
+  publish-preflight:
+    name: Publish Preflight
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Test preflight validation
+        run: python3 -m unittest scripts.tests.test_publish_preflight
+
+      - name: Inspect publishable package archives
+        run: python3 scripts/publish_preflight.py
+
   test:
     name: Test
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /target
 **/*.rs.bk
 *.pdb
+__pycache__/
+*.pyc
 .DS_Store
 CLAUDE.md
 .claude/AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -288,6 +288,16 @@ same location. If a crate is added, confirm its changelog lands at that
 default path (or add an explicit `[[package]]` entry if it needs a
 different one).
 
+Before merging a release PR, run the complete non-publishing package check:
+
+```bash
+python3 scripts/publish_preflight.py
+```
+
+See the [release preflight and recovery runbook](docs/release-process.md) for
+what the command validates, the publication order, the known release-plz dry
+run limitation, monitored-publish steps, and partial-failure recovery.
+
 ### Runbook: checking for stale release branches/PRs
 
 Run this check whenever the release automation looks off (e.g. a release PR

--- a/crates/tower-resilience-fallback/Cargo.toml
+++ b/crates/tower-resilience-fallback/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 rust-version.workspace = true
+readme = "../../README.md"
 description = "Fallback middleware for Tower services"
 keywords = ["tower", "resilience", "fallback", "fault-tolerance", "middleware"]
 categories = ["asynchronous", "network-programming"]

--- a/crates/tower-resilience-healthcheck/Cargo.toml
+++ b/crates/tower-resilience-healthcheck/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 description = "Proactive health checking for resources with intelligent selection strategies"
 repository.workspace = true
 rust-version.workspace = true
+readme = "../../README.md"
 
 [dependencies]
 tokio = { workspace = true, features = ["rt"] }

--- a/crates/tower-resilience-hedge/Cargo.toml
+++ b/crates/tower-resilience-hedge/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 rust-version.workspace = true
+readme = "../../README.md"
 description = "Hedging middleware for Tower services - reduces tail latency via parallel requests"
 keywords = ["tower", "resilience", "hedge", "latency", "middleware"]
 categories = ["asynchronous", "network-programming"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ must do the same, or it does not belong here.
 | [tower-api-surface-audit.md](tower-api-surface-audit.md) | Contributors, maintainer | Durable record of the API-surface audit against core Tower's own conventions (boxing, trait bounds, allocations, Tokio coupling, accessors). Reference baseline for future public-API changes. |
 | [circuitbreaker-tower-comparison.md](circuitbreaker-tower-comparison.md) | Contributors, maintainer | Pinned comparison against the upstream `tower-rs/tower#855` circuit-breaker proposal, including the RMQTT/GovCraft-Acton integration review. Updated when upstream behavior actually ships, not on every proposal revision. |
 | [upstream-watchlist.md](upstream-watchlist.md) | Maintainer | Durable list of upstream `tower`/`tower-http` issues that could erase a local differentiator, supply a parity test, or hand over a reusable primitive. Reviewed at least once per release. |
+| [release-process.md](release-process.md) | Maintainer | Reproducible publish preflight, ordered release monitoring, and partial-failure recovery runbook. Reviewed for every release PR. |
 
 ## Maintaining this index
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,105 @@
+# Release preflight and recovery
+
+Audience: maintainers preparing, monitoring, or recovering a workspace release.
+
+Review this runbook for every release PR. Update it whenever the publishable
+workspace shape, release-plz workflow, or crates.io recovery procedure changes.
+
+## Non-publishing preflight
+
+From the repository root, run:
+
+```bash
+python3 scripts/publish_preflight.py
+```
+
+The command reads Cargo metadata, excludes every package with
+`publish = false`, calculates a topological order for the remaining workspace
+packages, validates their metadata and internal dependency versions, checks
+each `cargo package --list`, and produces all `.crate` archives in one
+non-publishing `cargo package --no-verify` invocation. It then verifies that:
+
+- README, license metadata, changelog, targets, and required package files are
+  present;
+- path dependencies carry the synchronized internal version and git
+  dependencies are absent;
+- each archive exactly matches Cargo's file list and contains a normalized
+  manifest without path or git sources; and
+- packaging did not modify a source manifest or the workspace lockfile.
+
+The preflight uses `--allow-dirty` so it can be run while preparing a PR, but
+it snapshots manifests and lockfiles and fails if Cargo changes them. It does
+not publish, upload, tag, or create a GitHub release.
+
+CI runs this same command on every pull request, which necessarily includes
+release-plz release PRs. Its deliberately malformed path-only dependency
+fixture is covered by `python3 -m unittest scripts.tests.test_publish_preflight`.
+
+## Why this is not `release-plz release --dry-run`
+
+The workspace crates share a synchronized version. Before a release starts,
+that version of `tower-resilience-core` does not exist on crates.io. A
+release-plz dry run does not actually publish core, so later packages can fail
+resolution even though the real ordered release would succeed.
+
+The preflight instead selects every publishable package in one Cargo packaging
+operation. Cargo can then prepare interdependent packages under the assumption
+that the selected versions will be published together. `--no-verify` avoids
+trying to rebuild an extracted dependent archive against a version that is not
+yet in the registry; normal workspace CI still builds and tests all source,
+and the preflight inspects the exact archives and normalized manifests.
+
+Do not use `cargo package --workspace` here. It selects the repository test
+harness and integration examples, which intentionally have `publish = false`
+and path-only dependencies.
+
+## Publication order
+
+Treat the order printed by the preflight as authoritative. The dependency
+stages are:
+
+1. `tower-resilience-core`.
+2. Pattern crates whose internal dependencies are now available. Independent
+   pattern crates may publish in the same stage; `tower-resilience-reconnect`
+   waits for both core and retry.
+3. `tower-resilience`, after every optional pattern crate is available.
+
+Release-plz performs the actual publish. The preflight calculates the order
+from Cargo metadata instead of maintaining a second hard-coded crate list.
+
+## Monitored publish checklist
+
+1. Confirm the release PR's publish preflight and normal CI are green, it has
+   no conflicts, and its generated changelog matches the intended release.
+2. Merge the release PR and immediately locate the `Release` workflow run for
+   that merge commit with `gh run list --workflow Release`.
+3. Watch it through completion with `gh run watch <run-id> --exit-status`.
+4. Check the workflow log for the order and outcome of every crate. Do not
+   treat a Git tag or GitHub release alone as proof that all crates reached
+   crates.io.
+5. Verify the expected version of core, each pattern crate, and the facade on
+   crates.io. Allow for registry-index propagation before diagnosing a missing
+   dependency as a permanent failure.
+6. Confirm the expected tags and GitHub releases only after the registry set is
+   complete.
+
+## Partial-failure recovery
+
+1. Stop and record the failed workflow run, failing crate, and last confirmed
+   published crate. Do not delete tags, yank successful publications, or try
+   to overwrite a published version.
+2. Inventory every expected crate/version on crates.io and split the list into
+   already published and still missing. Recheck after index propagation.
+3. For a transient registry or index error, rerun the failed Release workflow
+   job. [`release-plz release` publishes unpublished
+   packages](https://release-plz.dev/docs/github/quickstart); confirm in the
+   rerun log that already-published versions are skipped and only the missing
+   set continues. Monitor the rerun as closely as the original.
+4. For a source, manifest, or archive defect, fix it on `main`. Published
+   archives are immutable: prepare a new patch version for any changed crate
+   and its dependents rather than attempting to reuse an already-published
+   version.
+5. Run the preflight on the recovery branch, require green CI, and document the
+   exact published/missing boundary in the recovery PR.
+6. After recovery, verify the complete crates.io set, tags, GitHub releases,
+   and the next release-plz PR. Record any new failure mode in this runbook.

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository maintenance tooling."""

--- a/scripts/publish_preflight.py
+++ b/scripts/publish_preflight.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Build and inspect every publishable workspace crate without publishing it."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import subprocess
+import sys
+import tarfile
+import tomllib
+from typing import Any, Iterable
+
+
+class PreflightError(RuntimeError):
+    """A release preflight check failed."""
+
+
+def run(command: list[str], root: Path) -> subprocess.CompletedProcess[str]:
+    environment = os.environ.copy()
+    environment["CARGO_TERM_COLOR"] = "never"
+    result = subprocess.run(
+        command,
+        cwd=root,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        output = "\n".join(part for part in (result.stdout, result.stderr) if part)
+        raise PreflightError(f"command failed: {' '.join(command)}\n{output}".rstrip())
+    return result
+
+
+def load_metadata(root: Path) -> dict[str, Any]:
+    result = run(["cargo", "metadata", "--locked", "--no-deps", "--format-version", "1"], root)
+    return json.loads(result.stdout)
+
+
+def workspace_packages(metadata: dict[str, Any]) -> list[dict[str, Any]]:
+    member_ids = set(metadata["workspace_members"])
+    return [package for package in metadata["packages"] if package["id"] in member_ids]
+
+
+def publishable_packages(metadata: dict[str, Any]) -> list[dict[str, Any]]:
+    # Cargo represents `publish = false` as an empty registry allow-list.
+    return [package for package in workspace_packages(metadata) if package.get("publish") != []]
+
+
+def skipped_packages(metadata: dict[str, Any]) -> list[dict[str, Any]]:
+    return [package for package in workspace_packages(metadata) if package.get("publish") == []]
+
+
+def _path_from_manifest(package: dict[str, Any], value: str) -> Path:
+    return (Path(package["manifest_path"]).parent / value).resolve()
+
+
+def validate_package_metadata(packages: list[dict[str, Any]]) -> list[str]:
+    errors: list[str] = []
+    for package in packages:
+        name = package["name"]
+        manifest_directory = Path(package["manifest_path"]).parent
+
+        readme = package.get("readme")
+        if not readme:
+            errors.append(f"{name}: package.readme is missing")
+        else:
+            readme_path = _path_from_manifest(package, readme)
+            if not readme_path.is_file() or readme_path.stat().st_size == 0:
+                errors.append(f"{name}: README is missing or empty: {readme_path}")
+
+        license_expression = package.get("license")
+        license_file = package.get("license_file")
+        if not license_expression and not license_file:
+            errors.append(f"{name}: package license metadata is missing")
+        elif license_file:
+            license_path = _path_from_manifest(package, license_file)
+            if not license_path.is_file() or license_path.stat().st_size == 0:
+                errors.append(f"{name}: license file is missing or empty: {license_path}")
+
+        changelog = manifest_directory / "CHANGELOG.md"
+        if not changelog.is_file() or changelog.stat().st_size == 0:
+            errors.append(f"{name}: CHANGELOG.md is missing or empty")
+
+        targets = package.get("targets", [])
+        if not targets:
+            errors.append(f"{name}: package has no Cargo targets")
+        for target in targets:
+            source = Path(target["src_path"])
+            if not source.is_file():
+                errors.append(f"{name}: target source is missing: {source}")
+    return errors
+
+
+def _is_exact_internal_requirement(requirement: str, version: str) -> bool:
+    return requirement.strip() in {version, f"^{version}", f"={version}"}
+
+
+def validate_dependencies(packages: list[dict[str, Any]]) -> list[str]:
+    errors: list[str] = []
+    internal_versions = {package["name"]: package["version"] for package in packages}
+
+    for package in packages:
+        for dependency in package.get("dependencies", []):
+            dependency_name = dependency["name"]
+            source = dependency.get("source") or ""
+            path = dependency.get("path")
+            requirement = dependency.get("req") or ""
+            kind = dependency.get("kind") or "normal"
+            label = f"{package['name']}: {kind} dependency {dependency_name}"
+
+            if source.startswith("git+"):
+                errors.append(f"{label} uses a forbidden git source")
+
+            if path and (not requirement or requirement.strip() == "*"):
+                errors.append(f"{label} is a forbidden path-only dependency")
+
+            if dependency_name in internal_versions:
+                expected = internal_versions[dependency_name]
+                if not path:
+                    errors.append(f"{label} must retain its workspace path for local validation")
+                if not _is_exact_internal_requirement(requirement, expected):
+                    errors.append(
+                        f"{label} requires {requirement!r}; expected the "
+                        f"synchronized version {expected}"
+                    )
+    return errors
+
+
+def publication_order(packages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_name = {package["name"]: package for package in packages}
+    dependencies: dict[str, set[str]] = {name: set() for name in by_name}
+
+    for package in packages:
+        for dependency in package.get("dependencies", []):
+            if (dependency.get("kind") or "normal") == "dev":
+                continue
+            if dependency["name"] in by_name:
+                dependencies[package["name"]].add(dependency["name"])
+
+    order: list[dict[str, Any]] = []
+    remaining = {name: set(required) for name, required in dependencies.items()}
+    while remaining:
+        ready = sorted(name for name, required in remaining.items() if not required)
+        if not ready:
+            cycle = ", ".join(sorted(remaining))
+            raise PreflightError(f"publishable workspace dependency cycle: {cycle}")
+        for name in ready:
+            order.append(by_name[name])
+            del remaining[name]
+        for required in remaining.values():
+            required.difference_update(ready)
+
+    facade = next((package for package in order if package["name"] == "tower-resilience"), None)
+    if facade and order[-1] is not facade:
+        raise PreflightError("tower-resilience facade is not last in publication order")
+    return order
+
+
+def package_file_lists(root: Path, packages: list[dict[str, Any]]) -> dict[str, set[str]]:
+    required_files = {"Cargo.toml", "Cargo.toml.orig", "Cargo.lock", "CHANGELOG.md", "README.md"}
+    file_lists: dict[str, set[str]] = {}
+
+    for package in packages:
+        result = run(
+            [
+                "cargo",
+                "package",
+                "--locked",
+                "--allow-dirty",
+                "--list",
+                "-p",
+                package["name"],
+            ],
+            root,
+        )
+        files = {line.strip() for line in result.stdout.splitlines() if line.strip()}
+        missing = sorted(required_files - files)
+        if missing:
+            raise PreflightError(
+                f"{package['name']}: package file list is missing {', '.join(missing)}"
+            )
+        if not any(path.startswith("src/") for path in files):
+            raise PreflightError(f"{package['name']}: package file list has no src/ content")
+        file_lists[package["name"]] = files
+    return file_lists
+
+
+def _file_hash(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def snapshot_manifests(root: Path, packages: list[dict[str, Any]]) -> dict[Path, str]:
+    paths = {root / "Cargo.toml", root / "Cargo.lock"}
+    paths.update(Path(package["manifest_path"]) for package in packages)
+    return {path: _file_hash(path) for path in sorted(paths)}
+
+
+def verify_snapshot(snapshot: dict[Path, str]) -> None:
+    changed = [
+        str(path)
+        for path, digest in snapshot.items()
+        if not path.is_file() or _file_hash(path) != digest
+    ]
+    if changed:
+        raise PreflightError(
+            "packaging changed source manifests or lockfiles: " + ", ".join(changed)
+        )
+
+
+def _dependency_specs(document: dict[str, Any]) -> Iterable[tuple[str, dict[str, Any]]]:
+    dependency_sections = {"dependencies", "dev-dependencies", "build-dependencies"}
+    for key, value in document.items():
+        if key in dependency_sections and isinstance(value, dict):
+            for name, specification in value.items():
+                if isinstance(specification, dict):
+                    yield name, specification
+        elif isinstance(value, dict):
+            yield from _dependency_specs(value)
+
+
+def inspect_archives(
+    metadata: dict[str, Any],
+    packages: list[dict[str, Any]],
+    expected_files: dict[str, set[str]],
+) -> None:
+    target_directory = Path(metadata["target_directory"])
+    for package in packages:
+        name = package["name"]
+        version = package["version"]
+        archive = target_directory / "package" / f"{name}-{version}.crate"
+        if not archive.is_file() or archive.stat().st_size == 0:
+            raise PreflightError(f"{name}: expected archive was not produced: {archive}")
+
+        prefix = PurePosixPath(f"{name}-{version}")
+        with tarfile.open(archive, mode="r:gz") as crate:
+            archive_files: set[str] = set()
+            normalized_manifest: bytes | None = None
+            for member in crate.getmembers():
+                path = PurePosixPath(member.name)
+                if not member.isfile() or not path.is_relative_to(prefix):
+                    continue
+                relative = str(path.relative_to(prefix))
+                archive_files.add(relative)
+                if relative == "Cargo.toml":
+                    extracted = crate.extractfile(member)
+                    normalized_manifest = extracted.read() if extracted else None
+
+        if archive_files != expected_files[name]:
+            missing = sorted(expected_files[name] - archive_files)
+            extra = sorted(archive_files - expected_files[name])
+            raise PreflightError(
+                f"{name}: archive differs from cargo package --list; "
+                f"missing={missing}, extra={extra}"
+            )
+        if normalized_manifest is None:
+            raise PreflightError(f"{name}: archive has no normalized Cargo.toml")
+
+        document = tomllib.loads(normalized_manifest.decode("utf-8"))
+        if document.get("package", {}).get("name") != name:
+            raise PreflightError(f"{name}: normalized manifest has the wrong package name")
+        if document.get("package", {}).get("version") != version:
+            raise PreflightError(f"{name}: normalized manifest has the wrong package version")
+        for dependency_name, specification in _dependency_specs(document):
+            if "path" in specification or "git" in specification:
+                raise PreflightError(
+                    f"{name}: normalized dependency {dependency_name} retained a path or git source"
+                )
+
+
+def package_archives(root: Path, packages: list[dict[str, Any]]) -> None:
+    command = ["cargo", "package", "--locked", "--allow-dirty", "--no-verify"]
+    for package in packages:
+        command.extend(["-p", package["name"]])
+    result = run(command, root)
+    if result.stderr:
+        print(result.stderr.rstrip())
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    try:
+        metadata = load_metadata(root)
+        packages = publishable_packages(metadata)
+        skipped = skipped_packages(metadata)
+        if not packages:
+            raise PreflightError("workspace has no publishable packages")
+
+        errors = validate_package_metadata(packages) + validate_dependencies(packages)
+        if errors:
+            raise PreflightError("metadata validation failed:\n- " + "\n- ".join(errors))
+
+        order = publication_order(packages)
+        print(f"Publishable packages ({len(order)}), in dependency order:")
+        for position, package in enumerate(order, start=1):
+            print(f"  {position:2}. {package['name']} {package['version']}")
+        skipped_names = sorted(package["name"] for package in skipped)
+        print("Skipped publish = false packages: " + ", ".join(skipped_names))
+
+        snapshot = snapshot_manifests(root, packages)
+        file_lists = package_file_lists(root, order)
+        package_archives(root, order)
+        inspect_archives(metadata, order, file_lists)
+        verify_snapshot(snapshot)
+    except (OSError, json.JSONDecodeError, tomllib.TOMLDecodeError, PreflightError) as error:
+        print(f"publish preflight failed: {error}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Publish preflight passed: inspected {len(order)} package file lists "
+        "and archives; nothing was published."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/__init__.py
+++ b/scripts/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for repository maintenance tooling."""

--- a/scripts/tests/fixtures/invalid_dependency_metadata.json
+++ b/scripts/tests/fixtures/invalid_dependency_metadata.json
@@ -1,0 +1,38 @@
+{
+  "workspace_members": [
+    "path+file:///fixture#internal@1.0.0",
+    "path+file:///fixture#broken@1.0.0",
+    "path+file:///fixture#example@0.1.0"
+  ],
+  "packages": [
+    {
+      "id": "path+file:///fixture#internal@1.0.0",
+      "name": "internal",
+      "version": "1.0.0",
+      "publish": null,
+      "dependencies": []
+    },
+    {
+      "id": "path+file:///fixture#broken@1.0.0",
+      "name": "broken",
+      "version": "1.0.0",
+      "publish": null,
+      "dependencies": [
+        {
+          "name": "internal",
+          "kind": null,
+          "path": "/fixture/internal",
+          "req": "*",
+          "source": null
+        }
+      ]
+    },
+    {
+      "id": "path+file:///fixture#example@0.1.0",
+      "name": "example",
+      "version": "0.1.0",
+      "publish": [],
+      "dependencies": []
+    }
+  ]
+}

--- a/scripts/tests/test_publish_preflight.py
+++ b/scripts/tests/test_publish_preflight.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import unittest
+
+from scripts import publish_preflight
+
+
+class PublishPreflightTests(unittest.TestCase):
+    def setUp(self) -> None:
+        fixture = Path(__file__).parent / "fixtures" / "invalid_dependency_metadata.json"
+        self.metadata = json.loads(fixture.read_text(encoding="utf-8"))
+
+    def test_publish_false_package_is_skipped(self) -> None:
+        packages = publish_preflight.publishable_packages(self.metadata)
+        names = {package["name"] for package in packages}
+        self.assertEqual(names, {"internal", "broken"})
+
+    def test_path_only_dependency_fixture_fails_validation(self) -> None:
+        packages = publish_preflight.publishable_packages(self.metadata)
+        errors = publish_preflight.validate_dependencies(packages)
+        self.assertTrue(any("forbidden path-only dependency" in error for error in errors), errors)
+        self.assertTrue(
+            any("expected the synchronized version 1.0.0" in error for error in errors),
+            errors,
+        )
+
+    def test_dependency_order_places_dependency_first(self) -> None:
+        packages = publish_preflight.publishable_packages(self.metadata)
+        names = [package["name"] for package in publish_preflight.publication_order(packages)]
+        self.assertEqual(names, ["internal", "broken"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add one non-publishing command that discovers, orders, packages, and inspects all 18 publishable workspace crates
- reject missing metadata/files, path-only or git dependencies, mismatched internal versions, malformed archives, and packaging-induced manifest/lockfile changes
- gate pull requests with the preflight and a deliberately malformed dependency fixture
- include the README in the three package archives that omitted it and document publication monitoring and partial-failure recovery

## Validation

- `python3 scripts/publish_preflight.py`
- `python3 -m unittest scripts.tests.test_publish_preflight`
- `cargo test --locked --workspace --all-features`
- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps --format-version 1`

Closes #447
