### PR TITLE
chore: clean unused workspace dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,26 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  # After the dependency audit in #448, cargo-machete is a fast, deterministic
+  # gate. Generated-code/build-script false positives are documented narrowly
+  # in the owning manifest rather than hidden by a workspace-wide allowlist.
+  dependency-hygiene:
+    name: Dependency Hygiene
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-machete
+        run: cargo install cargo-machete --locked --version 0.9.2
+
+      - name: Check unused dependencies
+        run: cargo machete --with-metadata
+
   # This packages every publishable crate in dependency order without
   # publishing it. Running on every PR necessarily gates release-plz PRs while
   # also catching package-surface regressions when they are introduced.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,12 +33,22 @@ cargo test --locked --workspace --all-features
 cargo build --locked --workspace --examples --all-features
 RUSTDOCFLAGS="-D warnings" cargo doc --locked --workspace --all-features --no-deps
 rustup run 1.85.0 cargo check --locked -p tower-resilience --all-features
+cargo machete --with-metadata
 cargo audit
 ```
 
 `Cargo.lock` is committed for reproducible workspace, example, and security
 checks. Include intentional compatible dependency updates in your pull request
 and verify the resulting lockfile with the commands above.
+
+Install the dependency-hygiene tool with `cargo install cargo-machete --locked
+--version 0.9.2`. CI treats findings as errors. Before removing a reported
+dependency, check generated code, build scripts, doctests, optional feature
+forwarding, and minimal-feature builds. Document a confirmed false positive in
+the owning manifest's `[package.metadata.cargo-machete]` table with a nearby
+reason; do not add workspace-wide exceptions. The current audit and its
+classifications are recorded in
+[`docs/dependency-hygiene.md`](docs/dependency-hygiene.md).
 
 Nightly stress tests are opt-in locally but gating in their GitHub Actions
 workflow:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,28 +106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.108",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,7 +113,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn",
 ]
 
 [[package]]
@@ -234,7 +212,7 @@ checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn",
 ]
 
 [[package]]
@@ -537,7 +515,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn",
 ]
 
 [[package]]
@@ -560,12 +538,6 @@ checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "equivalent"
@@ -690,7 +662,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn",
 ]
 
 [[package]]
@@ -1239,15 +1211,12 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe8db7a05415d0f919ffb905afa37784f71901c9a773188876984b4f769ab986"
 dependencies = [
- "aho-corasick",
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.15.5",
  "indexmap",
  "metrics",
  "ordered-float",
- "quanta",
- "radix_trie",
  "rand 0.9.2",
  "rand_xoshiro",
  "sketches-ddsketch",
@@ -1275,15 +1244,6 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
-
-[[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
-]
 
 [[package]]
 name = "nu-ansi-term"
@@ -1406,7 +1366,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn",
 ]
 
 [[package]]
@@ -1486,7 +1446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.108",
+ "syn",
 ]
 
 [[package]]
@@ -1545,7 +1505,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.108",
+ "syn",
  "tempfile",
 ]
 
@@ -1559,7 +1519,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn",
 ]
 
 [[package]]
@@ -1589,21 +1549,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5b6a0769a491a08b31ea5c62494a8f144ee0987d86d670a8af4df1e1b7cde75"
 dependencies = [
  "pulldown-cmark",
-]
-
-[[package]]
-name = "quanta"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
-dependencies = [
- "crossbeam-utils",
- "libc",
- "once_cell",
- "raw-cpuid",
- "wasi",
- "web-sys",
- "winapi",
 ]
 
 [[package]]
@@ -1691,16 +1636,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
-]
-
-[[package]]
 name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1771,15 +1706,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
  "rand_core 0.9.3",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "11.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -2099,7 +2025,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn",
 ]
 
 [[package]]
@@ -2149,21 +2075,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "scc",
- "serial_test_derive 3.2.0",
-]
-
-[[package]]
-name = "serial_test"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6df5ed973ad8d834e09f824f9e9f449af6b9a3745f78dec7cc752770bd3bf11"
-dependencies = [
- "futures-executor",
- "futures-util",
- "log",
- "once_cell",
- "parking_lot",
- "serial_test_derive 4.0.1",
+ "serial_test_derive",
 ]
 
 [[package]]
@@ -2174,18 +2086,7 @@ checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.3",
+ "syn",
 ]
 
 [[package]]
@@ -2264,17 +2165,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2291,7 +2181,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn",
 ]
 
 [[package]]
@@ -2354,7 +2244,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn",
 ]
 
 [[package]]
@@ -2365,7 +2255,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn",
 ]
 
 [[package]]
@@ -2437,7 +2327,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn",
 ]
 
 [[package]]
@@ -2459,19 +2349,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "tokio-test"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
-dependencies = [
- "async-stream",
- "bytes",
- "futures-core",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -2525,7 +2402,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn",
 ]
 
 [[package]]
@@ -2550,7 +2427,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.108",
+ "syn",
  "tempfile",
  "tonic-build",
 ]
@@ -2560,7 +2437,6 @@ name = "tonic-resilient-greeter"
 version = "0.1.0"
 dependencies = [
  "prost",
- "rand 0.9.2",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -2667,7 +2543,6 @@ version = "0.12.0"
 dependencies = [
  "metrics",
  "metrics-util",
- "pin-project-lite",
  "thiserror 2.0.17",
  "tokio",
  "tokio-util",
@@ -2688,9 +2563,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tower",
- "tower-layer",
  "tower-resilience-core",
- "tower-service",
  "tracing",
 ]
 
@@ -2728,7 +2601,6 @@ version = "0.12.0"
 dependencies = [
  "futures",
  "metrics",
- "metrics-util",
  "serde",
  "thiserror 2.0.17",
  "tokio",
@@ -2760,12 +2632,10 @@ dependencies = [
  "metrics",
  "metrics-util",
  "pin-project-lite",
- "serial_test 4.0.1",
  "thiserror 2.0.17",
  "tokio",
  "tower",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -2791,9 +2661,7 @@ dependencies = [
  "metrics",
  "tokio",
  "tower",
- "tower-layer",
  "tower-resilience-core",
- "tower-service",
  "tracing",
 ]
 
@@ -2805,7 +2673,6 @@ dependencies = [
  "reqwest",
  "tokio",
  "tower",
- "tower-layer",
  "tower-resilience-chaos",
  "tower-resilience-core",
  "wiremock",
@@ -2818,12 +2685,10 @@ dependencies = [
  "futures",
  "metrics",
  "metrics-util",
- "pin-project-lite",
  "tokio",
  "tower",
  "tower-layer",
  "tower-resilience-core",
- "tower-service",
  "tracing",
 ]
 
@@ -2837,9 +2702,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tower",
- "tower-layer",
  "tower-resilience-core",
- "tower-service",
  "tracing",
 ]
 
@@ -2863,11 +2726,8 @@ dependencies = [
  "futures",
  "metrics",
  "metrics-util",
- "thiserror 2.0.17",
  "tokio",
- "tokio-test",
  "tower",
- "tower-resilience-core",
  "tower-resilience-retry",
  "tracing",
 ]
@@ -2908,7 +2768,7 @@ dependencies = [
  "metrics-util",
  "proptest",
  "rand 0.9.2",
- "serial_test 3.2.0",
+ "serial_test",
  "tokio",
  "tower",
  "tower-resilience-adaptive",
@@ -2975,7 +2835,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn",
 ]
 
 [[package]]
@@ -3165,7 +3025,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -3555,7 +3415,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn",
  "synstructure",
 ]
 
@@ -3576,7 +3436,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn",
 ]
 
 [[package]]
@@ -3596,7 +3456,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn",
  "synstructure",
 ]
 
@@ -3636,5 +3496,5 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn",
 ]

--- a/crates/tower-resilience-adaptive/Cargo.toml
+++ b/crates/tower-resilience-adaptive/Cargo.toml
@@ -18,7 +18,6 @@ tower-layer = { workspace = true }
 tower-service = { workspace = true }
 tokio = { workspace = true, features = ["sync", "time"] }
 tokio-util.workspace = true
-pin-project-lite = { workspace = true }
 thiserror = { workspace = true }
 
 # Optional dependencies

--- a/crates/tower-resilience-bulkhead/Cargo.toml
+++ b/crates/tower-resilience-bulkhead/Cargo.toml
@@ -14,8 +14,6 @@ keywords = ["tower", "bulkhead", "resilience", "middleware", "concurrency"]
 [dependencies]
 tower-resilience-core = { workspace = true }
 tower = { workspace = true }
-tower-layer = { workspace = true }
-tower-service = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
 tokio-util.workspace = true
 futures = { workspace = true }

--- a/crates/tower-resilience-circuitbreaker/Cargo.toml
+++ b/crates/tower-resilience-circuitbreaker/Cargo.toml
@@ -20,13 +20,12 @@ tower-resilience-core.workspace = true
 
 tracing = { workspace = true, optional = true }
 metrics = { workspace = true, optional = true }
-metrics-util = { version = "0.20", optional = true }
 serde = { workspace = true, optional = true }
 
 [features]
 default = []
 # Enable Prometheus metrics (state transitions, call counts, latency histograms)
-metrics = ["dep:metrics", "dep:metrics-util"]
+metrics = ["dep:metrics"]
 # Enable distributed tracing via the tracing crate
 tracing = ["dep:tracing"]
 # Enable serde serialization for circuit breaker state

--- a/crates/tower-resilience-core/Cargo.toml
+++ b/crates/tower-resilience-core/Cargo.toml
@@ -35,5 +35,3 @@ testing = ["dep:tower"]
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
 metrics-util = { version = "0.20", default-features = false, features = ["debugging"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "registry"] }
-serial_test = "4.0"

--- a/crates/tower-resilience-fallback/Cargo.toml
+++ b/crates/tower-resilience-fallback/Cargo.toml
@@ -21,8 +21,6 @@ tracing = ["dep:tracing"]
 [dependencies]
 tower-resilience-core = { workspace = true }
 tower = { workspace = true }
-tower-layer = { workspace = true }
-tower-service = { workspace = true }
 futures = { workspace = true }
 metrics = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }

--- a/crates/tower-resilience-healthcheck/Cargo.toml
+++ b/crates/tower-resilience-healthcheck/Cargo.toml
@@ -19,7 +19,6 @@ wiremock = "0.6"
 tower-resilience-chaos = { version = "0.12.0", path = "../tower-resilience-chaos" }
 reqwest = "0.13"
 tower = "0.5"
-tower-layer = "0.3"
 
 [features]
 default = []

--- a/crates/tower-resilience-hedge/Cargo.toml
+++ b/crates/tower-resilience-hedge/Cargo.toml
@@ -22,10 +22,8 @@ tracing = ["dep:tracing"]
 tower-resilience-core = { workspace = true }
 tower = { workspace = true }
 tower-layer = { workspace = true }
-tower-service = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true, features = ["time", "sync", "rt", "macros"] }
-pin-project-lite = { workspace = true }
 metrics = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 

--- a/crates/tower-resilience-outlier/Cargo.toml
+++ b/crates/tower-resilience-outlier/Cargo.toml
@@ -14,8 +14,6 @@ keywords = ["tower", "outlier", "resilience", "middleware", "ejection"]
 [dependencies]
 tower-resilience-core = { workspace = true }
 tower = { workspace = true }
-tower-layer = { workspace = true }
-tower-service = { workspace = true }
 pin-project-lite = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/tower-resilience-reconnect/Cargo.toml
+++ b/crates/tower-resilience-reconnect/Cargo.toml
@@ -12,12 +12,10 @@ categories = ["asynchronous", "network-programming"]
 keywords = ["tower", "reconnect", "resilience", "middleware", "connection"]
 
 [dependencies]
-tower-resilience-core = { workspace = true }
 tower-resilience-retry = { version = "0.12.0", path = "../tower-resilience-retry" }
 tower = { workspace = true, features = ["make"] }
 futures = { workspace = true }
 tokio = { workspace = true }
-thiserror = { workspace = true }
 
 # Optional dependencies
 metrics = { workspace = true, optional = true }
@@ -25,14 +23,12 @@ tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
-tokio-test = "0.4"
-tower-resilience-core = { workspace = true, features = ["testing"] }
 tower = { workspace = true, features = ["util", "limit"] }
 metrics-util = { version = "0.20", default-features = false, features = ["debugging"] }
 
 [features]
 default = []
 # Enable Prometheus metrics (reconnection attempts, state transitions)
-metrics = ["dep:metrics", "tower-resilience-core/metrics"]
+metrics = ["dep:metrics"]
 # Enable distributed tracing via the tracing crate
-tracing = ["dep:tracing", "tower-resilience-core/tracing"]
+tracing = ["dep:tracing"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ must do the same, or it does not belong here.
 | [circuitbreaker-tower-comparison.md](circuitbreaker-tower-comparison.md) | Contributors, maintainer | Pinned comparison against the upstream `tower-rs/tower#855` circuit-breaker proposal, including the RMQTT/GovCraft-Acton integration review. Updated when upstream behavior actually ships, not on every proposal revision. |
 | [upstream-watchlist.md](upstream-watchlist.md) | Maintainer | Durable list of upstream `tower`/`tower-http` issues that could erase a local differentiator, supply a parity test, or hand over a reusable primitive. Reviewed at least once per release. |
 | [release-process.md](release-process.md) | Maintainer | Reproducible publish preflight, ordered release monitoring, and partial-failure recovery runbook. Reviewed for every release PR. |
+| [dependency-hygiene.md](dependency-hygiene.md) | Contributors, maintainer | Classification record for dependency-audit findings and the process for keeping direct dependencies intentional. Updated whenever a `cargo machete` exception is added or removed. |
 
 ## Maintaining this index
 

--- a/docs/dependency-hygiene.md
+++ b/docs/dependency-hygiene.md
@@ -1,0 +1,40 @@
+# Dependency hygiene
+
+Audience: contributors and maintainers.
+
+Run the same dependency audit as CI from the workspace root:
+
+```bash
+cargo machete --with-metadata
+```
+
+The check is required on pull requests. A finding may be removed only after
+checking normal source, tests, examples, doctests, build scripts, generated
+code, feature definitions, and a minimal-feature build. If a dependency is an
+intentional false positive, add the narrowest possible
+`package.metadata.cargo-machete.ignored` entry to its owning manifest and
+explain the reason next to it.
+
+## 2026-08-21 audit (#448)
+
+The audit classified every finding emitted by cargo-machete 0.9.2:
+
+| Package | Dependency | Classification |
+| --- | --- | --- |
+| `tower-resilience-fallback` | `tower-layer`, `tower-service` | Removed: the crate imports both traits through `tower`. |
+| `tower-resilience-reconnect` | `thiserror`, `tokio-test` | Removed: neither appears in source or tests. |
+| `tower-resilience-reconnect` | `tower-resilience-core` | Removed: source does not use the crate; its feature forwarding did not enable the corresponding `tower-resilience-retry` features and was therefore ineffective. |
+| `tower-resilience-core` | `serial_test`, `tracing-subscriber` | Removed: neither appears in source or tests. |
+| `tower-resilience-bulkhead` | `tower-layer`, `tower-service` | Removed: the crate imports both traits through `tower`. |
+| `tower-resilience-outlier` | `tower-layer`, `tower-service` | Removed: the crate imports both traits through `tower`. |
+| `tower-resilience-circuitbreaker` | `metrics-util` | Removed: metrics instrumentation uses `metrics`; no recorder from `metrics-util` is created by the library. |
+| `tower-resilience-adaptive` | `pin-project-lite` | Removed: no pin-projection macro or type is used. |
+| `tower-resilience-hedge` | `pin-project-lite`, `tower-service` | Removed: no pin-projection macro is used, and `Service` is imported through `tower`. |
+| `tower-resilience-healthcheck` | `tower-layer` | Removed: the integration test imports `Layer` through its `tower` dev-dependency. |
+| `tonic-resilient-greeter` | `rand` | Removed: neither binary nor its build script uses randomness. |
+| `tonic-resilient-greeter` | `prost`, `tonic-prost` | Kept and ignored: generated protobuf/message and codec code refers to these crates. |
+| `tonic-resilient-greeter` | `tonic-prost-build` | Kept and ignored: `build.rs` calls it directly, but cargo-machete does not scan the build script. |
+
+This left no unexplained findings. Because the remaining exceptions are local,
+documented, and exercised by the workspace build, the audit was promoted
+directly to a required CI gate rather than introduced as an advisory check.

--- a/examples/tonic-resilient-greeter/Cargo.toml
+++ b/examples/tonic-resilient-greeter/Cargo.toml
@@ -32,7 +32,12 @@ tower-resilience-chaos = { path = "../../crates/tower-resilience-chaos" }
 # Utilities
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-rand = "0.9"
 
 [build-dependencies]
 tonic-prost-build = "0.14"
+
+# `prost` and `tonic-prost` are referenced by the Rust generated from the
+# protobuf schema. `tonic-prost-build` is called by build.rs, which
+# cargo-machete does not scan. All three are required despite appearing unused.
+[package.metadata.cargo-machete]
+ignored = ["prost", "tonic-prost", "tonic-prost-build"]


### PR DESCRIPTION
## Summary

- classify every current cargo-machete finding and remove confirmed-unused dependencies
- preserve and document the three tonic generated-code/build-script false positives in package metadata
- add a required Dependency Hygiene PR check and contributor guidance
- prune the resulting unreachable lockfile dependency trees

## Validation

- cargo machete --with-metadata
- cargo check --locked --workspace
- cargo check --locked --workspace --all-features
- cargo check --locked --no-default-features for every affected crate and the tonic example
- cargo test --locked --workspace --all-features
- cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc --locked --workspace --all-features --no-deps
- cargo fmt --all -- --check
- python3 scripts/publish_preflight.py

Closes #448